### PR TITLE
fix config.status dependency tracking

### DIFF
--- a/hybris/common/Makefile.am
+++ b/hybris/common/Makefile.am
@@ -1,47 +1,29 @@
 lib_LTLIBRARIES = \
 	libhybris-common.la
 
-if WANT_ARCH_ARM
-ARCHFLAGS = -DHAVE_ARM_TLS_REGISTER -DANDROID_ARM_LINKER
-endif
-
-if  WANT_ARCH_X86
-ARCHFLAGS = -DANDROID_X86_LINKER
-endif
-
 if  WANT_GB
-LNKR = gingerbread
+SUBDIRS = gingerbread
+libhybris_common_la_LIBADD= gingerbread/libandroid-linker.la
 endif
 
 if  WANT_ICS
-LNKR = ics
+SUBDIRS = ics
+libhybris_common_la_LIBADD= ics/libandroid-linker.la
 endif
 
 if  WANT_JB
-LNKR = jb
+SUBDIRS = jb
+libhybris_common_la_LIBADD= jb/libandroid-linker.la
 endif
-
-
 
 
 libhybris_common_la_SOURCES = \
 	hooks.c \
 	properties.c \
 	strlcpy.c
-libhybris_common_la_SOURCES += \
-	$(LNKR)/dlfcn.c \
-	$(LNKR)/linker.c \
-	$(LNKR)/linker_environ.c \
-	$(LNKR)/linker_format.c \
-	$(LNKR)/rt.c
 libhybris_common_la_CFLAGS = \
 	-I$(top_srcdir)/include \
-	-I$(top_srcdir)/common \
-	-I$(top_srcdir)/common/$(LNKR) \
-	-DLINKER_DEBUG=1 \
-	-DLINKER_TEXT_BASE=0xB0000100 \
-	-DLINKER_AREA_SIZE=0x01000000 \
-	$(ARCHFLAGS)
+	-I$(top_srcdir)/common
 if WANT_DEBUG
 libhybris_common_la_CFLAGS += -ggdb -O0 -DDEBUG
 endif
@@ -49,4 +31,3 @@ libhybris_common_la_LDFLAGS = \
 	-ldl \
 	-pthread \
 	-version-info "$(LT_CURRENT)":"$(LT_REVISION)":"$(LT_AGE)"
-

--- a/hybris/common/gingerbread/Makefile.am
+++ b/hybris/common/gingerbread/Makefile.am
@@ -1,0 +1,24 @@
+if WANT_ARCH_ARM
+ARCHFLAGS = -DHAVE_ARM_TLS_REGISTER -DANDROID_ARM_LINKER
+endif
+
+if  WANT_ARCH_X86
+ARCHFLAGS = -DANDROID_X86_LINKER
+endif
+
+noinst_LTLIBRARIES = \
+	libandroid-linker.la
+libandroid_linker_la_SOURCES = \
+	dlfcn.c \
+	linker.c \
+	linker_environ.c \
+	linker_format.c \
+	rt.c
+libandroid_linker_la_CFLAGS = \
+	-I$(top_srcdir)/include \
+	-I$(top_srcdir)/common \
+	-DLINKER_DEBUG=1 \
+	-DLINKER_TEXT_BASE=0xB0000100 \
+	-DLINKER_AREA_SIZE=0x01000000 \
+	$(ARCHFLAGS)
+

--- a/hybris/common/ics/Makefile.am
+++ b/hybris/common/ics/Makefile.am
@@ -1,0 +1,24 @@
+if WANT_ARCH_ARM
+ARCHFLAGS = -DHAVE_ARM_TLS_REGISTER -DANDROID_ARM_LINKER
+endif
+
+if  WANT_ARCH_X86
+ARCHFLAGS = -DANDROID_X86_LINKER
+endif
+
+noinst_LTLIBRARIES = \
+	libandroid-linker.la
+libandroid_linker_la_SOURCES = \
+	dlfcn.c \
+	linker.c \
+	linker_environ.c \
+	linker_format.c \
+	rt.c
+libandroid_linker_la_CFLAGS = \
+	-I$(top_srcdir)/include \
+	-I$(top_srcdir)/common \
+	-DLINKER_DEBUG=1 \
+	-DLINKER_TEXT_BASE=0xB0000100 \
+	-DLINKER_AREA_SIZE=0x01000000 \
+	$(ARCHFLAGS)
+

--- a/hybris/common/jb/Makefile.am
+++ b/hybris/common/jb/Makefile.am
@@ -1,0 +1,24 @@
+if WANT_ARCH_ARM
+ARCHFLAGS = -DHAVE_ARM_TLS_REGISTER -DANDROID_ARM_LINKER
+endif
+
+if  WANT_ARCH_X86
+ARCHFLAGS = -DANDROID_X86_LINKER
+endif
+
+noinst_LTLIBRARIES = \
+	libandroid-linker.la
+libandroid_linker_la_SOURCES = \
+	dlfcn.c \
+	linker.c \
+	linker_environ.c \
+	linker_format.c \
+	rt.c
+libandroid_linker_la_CFLAGS = \
+	-I$(top_srcdir)/include \
+	-I$(top_srcdir)/common \
+	-DLINKER_DEBUG=1 \
+	-DLINKER_TEXT_BASE=0xB0000100 \
+	-DLINKER_AREA_SIZE=0x01000000 \
+	$(ARCHFLAGS)
+

--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -95,6 +95,9 @@ AM_CONDITIONAL([WANT_JB], [test x$alinker = xjb])
 AC_CONFIG_FILES([
 	Makefile
 	common/Makefile
+	common/gingerbread/Makefile
+	common/ics/Makefile
+	common/jb/Makefile
 	egl/Makefile
 	glesv2/Makefile
 	hardware/Makefile


### PR DESCRIPTION
variable expansion doesn't work in automake _SOURCES variables,
so config.status would create a "$(LNKR)" directory rather than
expand the variable.

Signed-off-by: Adrian Negreanu adrian.m.negreanu@intel.com
