### PR TITLE
hybris: install missing ui_compatibility_layer.h header file

### DIFF
--- a/hybris/include/Makefile.am
+++ b/hybris/include/Makefile.am
@@ -55,3 +55,7 @@ hardwareinclude_HEADERS = \
 	android/hardware/hardware.h \
 	android/hardware/sensors.h \
 	android/hardware/lights.h
+
+hybrisincludedir = $(includedir)/hybris
+hybrisinclude_HEADERS = \
+	hybris/ui_compatibility_layer.h


### PR DESCRIPTION
Signed-off-by: Simon Busch morphis@gravedo.de
