### PR TITLE
linker,jb: use stdout if kernel lacks android-log

### DIFF
--- a/hybris/common/jb/linker_format.c
+++ b/hybris/common/jb/linker_format.c
@@ -273,8 +273,10 @@ static int log_vprint(int prio, const char *tag, const char *fmt, va_list  args)
 
     if (log_fd < 0) {
         log_fd = open("/dev/log/main", O_WRONLY);
-        if (log_fd < 0)
+        if (log_fd < 0) {
+            log_fd = fileno(stdout); // kernel doesn't have android log
             return result;
+        }
     }
 
     {


### PR DESCRIPTION
I used a vanilla kernel that lacks android logging.
In that case, any log output is helpful
to know what goes wrong.

Signed-off-by: Adrian Negreanu adrian.m.negreanu@intel.com
