### PR TITLE
fbdev_window: cleanups

### DIFF
--- a/hybris/egl/platforms/fbdev/fbdev_window.cpp
+++ b/hybris/egl/platforms/fbdev/fbdev_window.cpp
@@ -1,140 +1,272 @@
+/*
+ * Copyright (C) 2013 libhybris
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//#define DEBUG
+
 #include "fbdev_window.h"
-#include <sys/ioctl.h>
-#include <fcntl.h>
-#include <linux/matroxfb.h> // for FBIO_WAITFORVSYNC
-#include <sys/mman.h> //mmap, munmap
+
+
 #include <errno.h>
 #include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
 
-#define TRACE(fmt, ...) 
+#define FRAMEBUFFER_PARTITIONS 2
 
-FbDevNativeWindow::FbDevNativeWindow(gralloc_module_t* gralloc, alloc_device_t* alloc, framebuffer_device_t* fbDev)
+static pthread_cond_t _cond = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t _mutex = PTHREAD_MUTEX_INITIALIZER;
+
+
+FbDevNativeWindowBuffer::FbDevNativeWindowBuffer(unsigned int width,
+                            unsigned int height,
+                            unsigned int format,
+                            unsigned int usage)
+{
+    ANativeWindowBuffer::width  = width;
+    ANativeWindowBuffer::height = height;
+    ANativeWindowBuffer::format = format;
+    ANativeWindowBuffer::usage  = usage;
+}
+
+
+
+FbDevNativeWindowBuffer::~FbDevNativeWindowBuffer()
+{
+    TRACE("%s: %p\n", __PRETTY_FUNCTION__, this);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+FbDevNativeWindow::FbDevNativeWindow(gralloc_module_t* gralloc,
+                            alloc_device_t* alloc,
+                            framebuffer_device_t* fbDev)
 {
     m_gralloc = alloc;
     m_fbDev = fbDev;
-
-    for(unsigned int i = 0; i < FRAMEBUFFER_PARTITIONS; i++) {
-        m_buffers[i] = new FbDevNativeWindowBuffer(width(), height(), m_fbDev->format, GRALLOC_USAGE_HW_FB);
-
-        int err = m_gralloc->alloc(m_gralloc,
-                        width(), height(), m_fbDev->format,
-                        GRALLOC_USAGE_HW_FB,
-                        &m_buffers[i]->handle,
-                        &m_buffers[i]->stride);
-        TRACE("buffer %i is at %p (native %p) err=%s handle=%i stride=%i\n", 
-                i, m_buffers[i], (ANativeWindowBuffer*) m_buffers[i],
-                strerror(-err), m_buffers[i]->handle, m_buffers[i]->stride);
+    m_freeBufs = 0;
+    setBufferCount(FRAMEBUFFER_PARTITIONS);
+}
 
 
+
+FbDevNativeWindow::~FbDevNativeWindow()
+{
+    TRACE("%s\n",__PRETTY_FUNCTION__);
+
+    std::list<FbDevNativeWindowBuffer*>::iterator it = m_bufList.begin();
+    for (;it!=m_bufList.end()
+         ;++it)
+    {
+        FbDevNativeWindowBuffer* fbnb = *it;
+        m_gralloc->free(m_gralloc, fbnb);
+        delete fbnb;
     }
-    m_frontbuffer = 0;
-    m_tailbuffer = 1;
 }
 
-FbDevNativeWindow::~FbDevNativeWindow() {
-    TRACE("%s\n",__PRETTY_FUNCTION__);
-}
 
-// overloads from BaseNativeWindow
-int FbDevNativeWindow::setSwapInterval(int interval) {
-    TRACE("%s\n",__PRETTY_FUNCTION__);
+
+int FbDevNativeWindow::setSwapInterval(int interval)
+{
+    TRACE("%s: interval=%i\n", __PRETTY_FUNCTION__, interval);
+    m_fbDev->setSwapInterval(m_fbDev, interval);
     return 0;
 }
 
-int FbDevNativeWindow::dequeueBuffer(BaseNativeWindowBuffer **buffer, int *fenceFd)
+
+
+int FbDevNativeWindow::dequeueBuffer(BaseNativeWindowBuffer** buffer, int *fenceFd)
 {
     TRACE("%s\n",__PRETTY_FUNCTION__);
-    *buffer = m_buffers[m_tailbuffer];
-    TRACE("dequeueing buffer %i %p",m_tailbuffer, m_buffers[m_tailbuffer]);
-    m_tailbuffer++;
-    if(m_tailbuffer == FRAMEBUFFER_PARTITIONS)
-        m_tailbuffer = 0;
+    FbDevNativeWindowBuffer* backBuf=NULL;
+
+    pthread_mutex_lock(&_mutex);
+
+    while (m_freeBufs==0)
+        pthread_cond_wait(&_cond, &_mutex);
+
+    std::list<FbDevNativeWindowBuffer*>::iterator it = m_bufList.begin();
+    for (; it != m_bufList.end(); it++) if ((*it)->busy == 0) break;
+    if (it != m_bufList.end())
+    {
+        backBuf = *it;
+        backBuf->busy = 1;
+        *buffer = backBuf;
+        *fenceFd = -1;
+        m_freeBufs--;
+        pthread_mutex_unlock(&_mutex);
+    }
+
+    pthread_mutex_unlock(&_mutex);
+
     return NO_ERROR;
 }
 
-int FbDevNativeWindow::lockBuffer(BaseNativeWindowBuffer* buffer)
-{
-    TRACE("%s\n",__PRETTY_FUNCTION__);
-    return NO_ERROR;
-}
+
 
 int FbDevNativeWindow::queueBuffer(BaseNativeWindowBuffer* buffer, int fenceFd)
 {
-    FbDevNativeWindowBuffer* buf = static_cast<FbDevNativeWindowBuffer*>(buffer);
-    m_frontbuffer++;
-    if(m_frontbuffer == FRAMEBUFFER_PARTITIONS)
-        m_frontbuffer = 0;
-    int res = m_fbDev->post(m_fbDev, buffer->handle);
-    TRACE("%s %s\n",__PRETTY_FUNCTION__,strerror(res));
-    return NO_ERROR;
+    TRACE("%s\n",__PRETTY_FUNCTION__);
+    FbDevNativeWindowBuffer* backBuf = (FbDevNativeWindowBuffer*) buffer;
+
+    backBuf->common.incRef(&backBuf->common);
+
+    pthread_mutex_lock(&_mutex);
+    backBuf->busy = 2;
+    pthread_mutex_unlock(&_mutex);
+
+    int rv = m_fbDev->post(m_fbDev, buffer->handle);
+
+    pthread_mutex_lock(&_mutex);
+    backBuf->busy = 0;
+    m_freeBufs++;
+    pthread_cond_signal(&_cond);
+    pthread_mutex_unlock(&_mutex);
+
+    return rv;
 }
+
+
 
 int FbDevNativeWindow::cancelBuffer(BaseNativeWindowBuffer* buffer, int fenceFd)
 {
-    TRACE("%s\n",__PRETTY_FUNCTION__);
+    TRACE("%s: WARN: stub\n", __PRETTY_FUNCTION__);
     return 0;
 }
 
-unsigned int FbDevNativeWindow::width() const {
-    unsigned int val = m_fbDev->width;
-    TRACE("%s value: %i\n",__PRETTY_FUNCTION__, val);
-    return val;
+
+
+int FbDevNativeWindow::lockBuffer(BaseNativeWindowBuffer* buffer)
+{
+    TRACE("%s: WARN: stub\n", __PRETTY_FUNCTION__);
+    return NO_ERROR;
 }
 
-unsigned int FbDevNativeWindow::height() const {
-    unsigned int val = m_fbDev->height;
-    TRACE("%s value: %i\n",__PRETTY_FUNCTION__, val);
-    return val;
+
+
+unsigned int FbDevNativeWindow::width() const
+{
+    unsigned int rv = m_fbDev->width;
+    TRACE("%s: width=%i\n", __PRETTY_FUNCTION__, rv);
+    return rv;
 }
 
-unsigned int FbDevNativeWindow::format() const {
-    unsigned int val = m_fbDev->format;
-    TRACE("%s value: %i\n",__PRETTY_FUNCTION__, val);
-    return val;
+
+
+unsigned int FbDevNativeWindow::height() const
+{
+    unsigned int rv = m_fbDev->height;
+    TRACE("%s: height=%i\n", __PRETTY_FUNCTION__, rv);
+    return rv;
 }
 
-unsigned int FbDevNativeWindow::defaultWidth() const {
-    TRACE("%s\n",__PRETTY_FUNCTION__);
-    return m_fbDev->width;
+
+
+unsigned int FbDevNativeWindow::format() const
+{
+    unsigned int rv = m_fbDev->format;
+    TRACE("%s: format=%x\n", __PRETTY_FUNCTION__, rv);
+    return rv;
 }
 
-unsigned int FbDevNativeWindow::defaultHeight() const {
-    TRACE("%s\n",__PRETTY_FUNCTION__);
-    return m_fbDev->height;
+
+
+unsigned int FbDevNativeWindow::defaultWidth() const
+{
+    unsigned int rv = m_fbDev->width;
+    TRACE("%s: width=%i\n", __PRETTY_FUNCTION__, rv);
+    return rv;
 }
 
-unsigned int FbDevNativeWindow::queueLength() const {
-    TRACE("%s\n",__PRETTY_FUNCTION__);
+
+
+unsigned int FbDevNativeWindow::defaultHeight() const
+{
+    unsigned int rv = m_fbDev->height;
+    TRACE("%s: height=%i\n", __PRETTY_FUNCTION__, rv);
+    return rv;
+}
+
+
+
+unsigned int FbDevNativeWindow::queueLength() const
+{
+    TRACE("%s: WARN: stub\n", __PRETTY_FUNCTION__);
     return 0;
 }
 
-unsigned int FbDevNativeWindow::type() const {
+
+
+unsigned int FbDevNativeWindow::type() const
+{
     TRACE("%s\n",__PRETTY_FUNCTION__);
     return NATIVE_WINDOW_FRAMEBUFFER;
 }
 
-unsigned int FbDevNativeWindow::transformHint() const {
-    TRACE("%s\n",__PRETTY_FUNCTION__);
+
+
+unsigned int FbDevNativeWindow::transformHint() const
+{
+    TRACE("%s: WARN: stub\n", __PRETTY_FUNCTION__);
     return 0;
 }
 
-int FbDevNativeWindow::setUsage(int usage) {
-    TRACE("%s usage %i\n",__PRETTY_FUNCTION__, usage);
-    return NO_ERROR;
-}
 
-int FbDevNativeWindow::setBuffersFormat(int format) {
-    TRACE("%s format %i\n",__PRETTY_FUNCTION__, format);
-    return NO_ERROR;
-}
 
-int FbDevNativeWindow::setBufferCount(int cnt) {
-    TRACE("%s buffercount %i\n",__PRETTY_FUNCTION__, cnt);
+int FbDevNativeWindow::setUsage(int usage)
+{
+    TRACE("%s: usage=x%x\n", __PRETTY_FUNCTION__, usage);
+    m_usage = usage;
     return NO_ERROR;
 }
 
 
-int FbDevNativeWindow::setBuffersDimensions(int width, int height) {
-    TRACE("%s size %ix%i\n",__PRETTY_FUNCTION__, width, height);
+
+int FbDevNativeWindow::setBuffersFormat(int format)
+{
+    TRACE("%s: format=x%x\n", __PRETTY_FUNCTION__, format);
+    m_bufFormat = format;
     return NO_ERROR;
 }
+
+
+
+int FbDevNativeWindow::setBufferCount(int cnt)
+{
+    for(unsigned int i = 0; i < cnt; i++)
+    {
+        FbDevNativeWindowBuffer *fbnb = new FbDevNativeWindowBuffer(width(),
+                            height(), m_fbDev->format, GRALLOC_USAGE_HW_FB);
+
+        int err = m_gralloc->alloc(m_gralloc, width(), height(), m_fbDev->format,
+                            GRALLOC_USAGE_HW_FB, &fbnb->handle, &fbnb->stride);
+        TRACE("buffer %i is at %p (native %p) err=%s handle=%i stride=%i\n",
+                i, fbnb, (ANativeWindowBuffer*)fbnb,
+                strerror(-err), fbnb->handle, fbnb->stride);
+
+        assert(err==0);
+        m_bufList.push_back(fbnb);
+    }
+    return NO_ERROR;
+}
+
+
+
+int FbDevNativeWindow::setBuffersDimensions(int width, int height)
+{
+    TRACE("%s: WARN: stub. size=%ix%i\n", __PRETTY_FUNCTION__, width, height);
+    return NO_ERROR;
+}
+// vim: noai:ts=4:sw=4:ss=4:expandtab

--- a/hybris/egl/platforms/fbdev/fbdev_window.h
+++ b/hybris/egl/platforms/fbdev/fbdev_window.h
@@ -1,39 +1,59 @@
+/*
+ * Copyright (C) 2013 libhybris
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef FBDEV_WINDOW_H
 #define FBDEV_WINDOW_H
+
 #include "nativewindowbase.h"
 #include <linux/fb.h>
 #include <android/hardware/gralloc.h>
-#define FRAMEBUFFER_PARTITIONS 2
 
-class FbDevNativeWindowBuffer : public BaseNativeWindowBuffer
-{
-    friend class FbDevNativeWindow;
-    protected:
+#include <list>
+
+
+class FbDevNativeWindowBuffer : public BaseNativeWindowBuffer {
+friend class FbDevNativeWindow;
+
+protected:
     FbDevNativeWindowBuffer(unsigned int width,
                             unsigned int height,
                             unsigned int format,
-                            unsigned int usage) {
-        // Base members
-        ANativeWindowBuffer::width = width;
-        ANativeWindowBuffer::height = height;
-        ANativeWindowBuffer::format = format;
-        ANativeWindowBuffer::usage = usage;
-    };
+                            unsigned int usage) ;
+   virtual ~FbDevNativeWindowBuffer() ;
+
+protected:
+    int busy;
 };
 
-class FbDevNativeWindow : public BaseNativeWindow
-{
+
+class FbDevNativeWindow : public BaseNativeWindow {
 public:
-    FbDevNativeWindow(gralloc_module_t* gralloc, alloc_device_t* alloc, framebuffer_device_t* fbDev);
+    FbDevNativeWindow(gralloc_module_t* gralloc, alloc_device_t* alloc,
+         framebuffer_device_t* fbDev);
     ~FbDevNativeWindow();
 
 protected:
     // overloads from BaseNativeWindow
     virtual int setSwapInterval(int interval);
-    virtual int dequeueBuffer(BaseNativeWindowBuffer **buffer, int *fenceFd);
-    virtual int queueBuffer(BaseNativeWindowBuffer *buffer, int fenceFd);
-    virtual int cancelBuffer(BaseNativeWindowBuffer *buffer, int fenceFd);
-    virtual int lockBuffer(BaseNativeWindowBuffer *buffer);
+
+    virtual int dequeueBuffer(BaseNativeWindowBuffer** buffer, int* fenceFd);
+    virtual int queueBuffer(BaseNativeWindowBuffer* buffer, int fenceFd);
+    virtual int cancelBuffer(BaseNativeWindowBuffer* buffer, int fenceFd);
+    virtual int lockBuffer(BaseNativeWindowBuffer* buffer);
+
     virtual unsigned int type() const;
     virtual unsigned int width() const;
     virtual unsigned int height() const;
@@ -49,11 +69,13 @@ protected:
     virtual int setBufferCount(int cnt);
 
 private:
-    unsigned int m_frontbuffer;
-    unsigned int m_tailbuffer;
-    FbDevNativeWindowBuffer* m_buffers[FRAMEBUFFER_PARTITIONS];
-    alloc_device_t* m_gralloc;
     framebuffer_device_t* m_fbDev;
+    alloc_device_t* m_gralloc;
+    unsigned int m_usage;
+    unsigned int m_bufFormat;
+    int m_freeBufs;
+    std::list<FbDevNativeWindowBuffer*> m_bufList;
 };
 
 #endif
+// vim: noai:ts=4:sw=4:ss=4:expandtab


### PR DESCRIPTION
I've used the same idea from wayland_window.cpp, having
the buffers placed in a std::list and marked busy/free via the busy
member.

Fixed the crash which apparently was caused by reference counting but
in fact was dequeueBuffer not calling incRef on the buffer.

When DEBUG_FBDEV_WINDOW is defined, enable tracing in fbdev_window.cpp

Signed-off-by: Adrian Negreanu adrian.m.negreanu@intel.com
