### PR TITLE
configure: add --enable-trace

### DIFF
--- a/hybris/common/Makefile.am
+++ b/hybris/common/Makefile.am
@@ -24,8 +24,11 @@ libhybris_common_la_SOURCES = \
 libhybris_common_la_CFLAGS = \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/common
+if WANT_TRACE
+libhybris_common_la_CFLAGS += -DDEBUG
+endif
 if WANT_DEBUG
-libhybris_common_la_CFLAGS += -ggdb -O0 -DDEBUG
+libhybris_common_la_CFLAGS += -ggdb -O0
 endif
 libhybris_common_la_LDFLAGS = \
 	-ldl \

--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -42,6 +42,12 @@ AC_ARG_ENABLE(debug,
   [debug="no"])
 AM_CONDITIONAL( [WANT_DEBUG], [test x"$debug" = x"yes"])
 
+AC_ARG_ENABLE(trace,
+  [  --enable-trace            Enable TRACE statements (default=disabled)],
+  [trace=$enableval],
+  [trace="no"])
+AM_CONDITIONAL( [WANT_TRACE], [test x"$trace" = x"yes"])
+
 AC_ARG_ENABLE(mesa,
   [  --enable-mesa            Enable mesa headers (default=disabled)],
   [mesa=$enableval],
@@ -135,6 +141,8 @@ echo
 echo "Configuration Options:"
 echo
 echo "  debug build.............: $debug"
+echo
+echo "  trace...................: $trace"
 echo
 echo "  prefix..................: $prefix"
 echo

--- a/hybris/egl/Makefile.am
+++ b/hybris/egl/Makefile.am
@@ -11,15 +11,22 @@ libEGL_la_CFLAGS = -I$(top_srcdir)/include -DPKGLIBDIR="\"$(pkglibdir)/\""
 if WANT_MESA
 libEGL_la_CFLAGS += -DLIBHYBRIS_WANTS_MESA_X11_HEADERS
 endif
-if WANT_DEBUG
-libEGL_la_CFLAGS += -ggdb -O0 -DDEBUG
+if WANT_TRACE
+libEGL_la_CFLAGS += -DDEBUG
 endif
+if WANT_DEBUG
+libEGL_la_CFLAGS += -ggdb -O0
+endif
+
 libEGL_la_CXXFLAGS = -I$(top_srcdir)/include -DPKGLIBDIR="\"$(pkglibdir)/\""
 if WANT_MESA
 libEGL_la_CXXFLAGS += -DLIBHYBRIS_WANTS_MESA_X11_HEADERS
 endif
+if WANT_TRACE
+libEGL_la_CXXFLAGS += -DDEBUG
+endif
 if WANT_DEBUG
-libEGL_la_CXXFLAGS += -ggdb -O0 -DDEBUG
+libEGL_la_CXXFLAGS += -ggdb -O0
 endif
 libEGL_la_LDFLAGS = \
 	-ldl \

--- a/hybris/egl/platforms/common/Makefile.am
+++ b/hybris/egl/platforms/common/Makefile.am
@@ -29,13 +29,21 @@ BUILT_SOURCES = wayland-android-protocol.c \
 	$(AM_V_GEN)$(WAYLAND_SCANNER) client-header < $< > $@
 
 libwayland_egl_la_SOURCES = wayland-egl.c
+
 libwayland_egl_la_CFLAGS = -I. -I$(top_srcdir)/include $(WAYLAND_CLIENT_CFLAGS) $(WAYLAND_SERVER_CFLAGS)
-if WANT_DEBUG
-libwayland_egl_la_CFLAGS += -ggdb -O0 -DDEBUG
+if WANT_TRACE
+libwayland_egl_la_CFLAGS += -DDEBUG
 endif
-libwayland_egl_la_CXXFLAGS = -I. -I$(top_srcdir)/include $(WAYLAND_CLIENT_CFLAGS) $(WAYLAND_SERVER_CFLAGS)
 if WANT_DEBUG
-libwayland_egl_la_CXXFLAGS += -ggdb -O0 -DDEBUG
+libwayland_egl_la_CFLAGS += -ggdb -O0
+endif
+
+libwayland_egl_la_CXXFLAGS = -I. -I$(top_srcdir)/include $(WAYLAND_CLIENT_CFLAGS) $(WAYLAND_SERVER_CFLAGS)
+if WANT_TRACE
+libwayland_egl_la_CXXFLAGS += -DDEBUG
+endif
+if WANT_DEBUG
+libwayland_egl_la_CXXFLAGS += -ggdb -O0
 endif
 libwayland_egl_la_LDFLAGS = \
 	-version-info "1":"0"
@@ -50,8 +58,11 @@ endif
 if WANT_MESA
 libhybris_eglplatformcommon_la_CFLAGS += -DLIBHYBRIS_WANTS_MESA_X11_HEADERS
 endif
+if WANT_TRACE
+libhybris_eglplatformcommon_la_CFLAGS += -DDEBUG
+endif
 if WANT_DEBUG
-libhybris_eglplatformcommon_la_CFLAGS += -ggdb -O0 -DDEBUG
+libhybris_eglplatformcommon_la_CFLAGS += -ggdb -O0
 endif
 libhybris_eglplatformcommon_la_CXXFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/egl
 if WANT_MESA
@@ -62,8 +73,11 @@ if WANT_WAYLAND
 libhybris_eglplatformcommon_la_CXXFLAGS += $(WAYLAND_CLIENT_CFLAGS) $(WAYLAND_SERVER_CFLAGS) -I$(top_srcdir)/include/android
 endif
 
+if WANT_TRACE
+libhybris_eglplatformcommon_la_CXXFLAGS += -DDEBUG
+endif
 if WANT_DEBUG
-libhybris_eglplatformcommon_la_CXXFLAGS += -ggdb -O0 -DDEBUG
+libhybris_eglplatformcommon_la_CXXFLAGS += -ggdb -O0
 endif
 libhybris_eglplatformcommon_la_LDFLAGS = \
 	$(top_builddir)/common/libhybris-common.la \

--- a/hybris/egl/platforms/fbdev/Makefile.am
+++ b/hybris/egl/platforms/fbdev/Makefile.am
@@ -9,8 +9,11 @@ eglplatform_fbdev_la_CXXFLAGS = \
 	-I$(top_srcdir)/egl \
 	-I$(top_srcdir)/egl/platforms/common
 
+if WANT_TRACE
+eglplatform_fbdev_la_CXXFLAGS += -DDEBUG
+endif
 if WANT_DEBUG
-eglplatform_fbdev_la_CXXFLAGS += -ggdb -O0 -DDEBUG
+eglplatform_fbdev_la_CXXFLAGS += -ggdb -O0
 endif
 
 eglplatform_fbdev_la_LDFLAGS = \

--- a/hybris/glesv2/Makefile.am
+++ b/hybris/glesv2/Makefile.am
@@ -6,8 +6,11 @@ libGLESv2_la_CFLAGS = -I$(top_srcdir)/include
 if WANT_MESA
 libGLESv2_la_CFLAGS += -DLIBHYBRIS_WANTS_MESA_X11_HEADERS
 endif
+if WANT_TRACE
+libGLESv2_la_CFLAGS += -DDEBUG
+endif
 if WANT_DEBUG
-libGLESv2_la_CFLAGS += -ggdb -O0 -DDEBUG
+libGLESv2_la_CFLAGS += -ggdb -O0
 endif
 libGLESv2_la_LDFLAGS = \
 	$(top_builddir)/common/libhybris-common.la \

--- a/hybris/hardware/Makefile.am
+++ b/hybris/hardware/Makefile.am
@@ -3,8 +3,11 @@ lib_LTLIBRARIES = \
 
 libhardware_la_SOURCES = hardware.c
 libhardware_la_CFLAGS = -I$(top_srcdir)/include
+if WANT_TRACE
+libhardware_la_CFLAGS += -DDEBUG
+endif
 if WANT_DEBUG
-libhardware_la_CFLAGS += -ggdb -O0 -DDEBUG
+libhardware_la_CFLAGS += -ggdb -O0
 endif
 libhardware_la_LDFLAGS = \
 	$(top_builddir)/common/libhybris-common.la \

--- a/hybris/ui/Makefile.am
+++ b/hybris/ui/Makefile.am
@@ -3,8 +3,11 @@ lib_LTLIBRARIES = \
 
 libui_la_SOURCES = ui.c
 libui_la_CFLAGS = -I$(top_srcdir)/include
+if WANT_TRACE
+libui_la_CFLAGS += -DDEBUG
+endif
 if WANT_DEBUG
-libui_la_CFLAGS += -ggdb -O0 -DDEBUG
+libui_la_CFLAGS += -ggdb -O0
 endif
 libui_la_LDFLAGS = \
 	$(top_builddir)/common/libhybris-common.la \


### PR DESCRIPTION
Previously, --enable-debug did that but also added debug symbols.
This enables the TRACE statements separately from debug symbols

Signed-off-by: Adrian Negreanu groleo@gmail.com
