### PR TITLE
Random build warning fixes (implicit declarations etc)

### DIFF
--- a/hybris/egl/egl.c
+++ b/hybris/egl/egl.c
@@ -23,8 +23,12 @@
 #include <GLES2/gl2ext.h>
 #include <dlfcn.h>
 #include <stddef.h>
+#include <stdlib.h>
 #include <malloc.h>
 #include "ws.h"
+
+#include <hybris/internal/binding.h>
+#include <string.h>
 
 static void *_libegl = NULL;
 static void *_libgles = NULL;

--- a/hybris/egl/platforms/null/eglplatform_null.c
+++ b/hybris/egl/platforms/null/eglplatform_null.c
@@ -2,6 +2,8 @@
 #include <dlfcn.h>
 #include <stdlib.h>
 
+#include <hybris/internal/binding.h>
+
 static void * (*_androidCreateDisplaySurface)();
 
 static void *_libui = NULL;

--- a/hybris/egl/ws.c
+++ b/hybris/egl/ws.c
@@ -5,6 +5,8 @@
 #include <dlfcn.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <stdio.h>
+
 static struct ws_module *ws = NULL;
 
 static void _init_ws()

--- a/hybris/glesv2/glesv2.c
+++ b/hybris/glesv2/glesv2.c
@@ -20,6 +20,9 @@
 #include <GLES2/gl2ext.h>
 #include <dlfcn.h>
 #include <stddef.h>
+#include <stdlib.h>
+
+#include <hybris/internal/binding.h>
 
 #ifdef __ARM_PCS_VFP
 #define FP_ATTRIB __attribute__((pcs("aapcs")))

--- a/hybris/hardware/hardware.c
+++ b/hybris/hardware/hardware.c
@@ -17,6 +17,8 @@
 
 #include <dlfcn.h>
 #include <stddef.h>
+#include <android/hardware/hardware.h>
+#include <hybris/internal/binding.h>
 
 static void *_libhardware = NULL;
 

--- a/hybris/tests/test_egl.c
+++ b/hybris/tests/test_egl.c
@@ -72,6 +72,7 @@ int main(int argc, char **argv)
     printf("terminated\n");
     android_dlclose(baz);
 #endif
+	return 0;
 }
 
 // vim:ts=4:sw=4:noexpandtab


### PR DESCRIPTION
Fix a number of gcc warnings during build.

Signed-off-by: Philippe De Swert philippe.deswert@jollamobile.com
