### PR TITLE
Don't pass a null cond to pthread_cond_destroy

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -476,6 +476,10 @@ static int my_pthread_cond_destroy(pthread_cond_t *cond)
     int ret;
     pthread_cond_t *realcond = (pthread_cond_t *) *(int *) cond;
 
+    if (!realcond) {
+      return EINVAL;
+    }
+
     ret = pthread_cond_destroy(realcond);
     free(realcond);
 


### PR DESCRIPTION
pthread_cond_destroy will happily crash if it gets a null pointer. We need
to make sure the pointer we pass has a value to prevent the crash

Signed-off-by: Mohammed Hassan mohammed.hassan@jollamobile.com
