### PR TITLE
 compat/surface_flinger: adding compatibility layer to talk with Android's Surface Flinger

### DIFF
--- a/compat/surface_flinger/Android.mk
+++ b/compat/surface_flinger/Android.mk
@@ -1,0 +1,44 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+
+HYBRIS_PATH := $(LOCAL_PATH)/../../hybris
+
+LOCAL_SRC_FILES:= \
+	surface_flinger_compatibility_layer.cpp
+
+LOCAL_MODULE:= libsf_compat_layer
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_C_INCLUDES := \
+	$(HYBRIS_PATH)/include
+
+LOCAL_SHARED_LIBRARIES := \
+	libui \
+	libutils \
+	libgui \
+	libEGL \
+	libGLESv2
+
+include $(BUILD_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+
+HYBRIS_PATH := $(LOCAL_PATH)/../../hybris
+
+LOCAL_SRC_FILES:= \
+	direct_sf_test.cpp
+
+LOCAL_MODULE:= direct_sf_test
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_C_INCLUDES := \
+	$(HYBRIS_PATH)/include
+
+LOCAL_SHARED_LIBRARIES := \
+	libui \
+	libutils \
+	libEGL \
+	libGLESv2 \
+	libsf_compat_layer
+
+include $(BUILD_EXECUTABLE)

--- a/compat/surface_flinger/direct_sf_test.cpp
+++ b/compat/surface_flinger/direct_sf_test.cpp
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2013 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authored by: Thomas Voß <thomas.voss@canonical.com>
+ *              Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
+ */
+
+#include <hybris/surface_flinger_compatibility_layer.h>
+
+#include <cstdio>
+#include <unistd.h>
+
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+
+/* animation state variables */
+GLfloat rotation_angle = 0.0f;
+
+static GLuint gProgram;
+static GLuint gvPositionHandle, gvColorHandle;
+static GLuint rotation_uniform;
+static GLint num_vertex = 3;
+static const GLfloat triangle[] = {
+	-0.125f, -0.125f, 0.0f, 0.5f,
+	0.0f,  0.125f, 0.0f, 0.5f,
+	0.125f, -0.125f, 0.0f, 0.5f
+};
+static const GLfloat color_triangle[] = {
+	0.0f, 0.0f, 1.0f, 1.0f,
+	0.0f, 1.0f, 0.0f, 1.0f,
+	1.0f, 0.0f, 0.0f, 0.0f
+};
+const GLfloat * vertex_data;
+const GLfloat * color_data;
+static const char gVertexShader[] =
+	"attribute vec4 vPosition;\n"
+	"attribute vec4 vColor;\n"
+	"uniform float angle;\n"
+	"varying vec4 colorinfo;\n"
+	"void main() {\n"
+	"  mat3 rot_z = mat3( vec3( cos(angle),  sin(angle), 0.0),\n"
+	"                     vec3(-sin(angle),  cos(angle), 0.0),\n"
+	"                     vec3(       0.0,         0.0, 1.0));\n"
+	"  gl_Position = vec4(rot_z * vPosition.xyz, 1.0);\n"
+	"  colorinfo = vColor;\n"
+	"}\n";
+
+static const char gFragmentShader[] = "precision mediump float;\n"
+				      "varying vec4 colorinfo;\n"
+				      "void main() {\n"
+				      "  gl_FragColor = colorinfo;\n"
+				      "}\n";
+
+/* util functions */
+GLuint loadShader(GLenum shaderType, const char* pSource)
+{
+	GLuint shader = glCreateShader(shaderType);
+	if (shader) {
+		glShaderSource(shader, 1, &pSource, NULL);
+		glCompileShader(shader);
+		GLint compiled = 0;
+		glGetShaderiv(shader, GL_COMPILE_STATUS, &compiled);
+
+		if (!compiled) {
+			GLint infoLen = 0;
+			glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &infoLen);
+			if (infoLen) {
+				char* buf = (char*) malloc(infoLen);
+				if (buf) {
+					glGetShaderInfoLog(shader, infoLen, NULL, buf);
+					fprintf(stderr, "Could not compile shader %d:\n%s\n",
+							shaderType, buf);
+					free(buf);
+				}
+				glDeleteShader(shader);
+				shader = 0;
+			}
+		}
+	} else {
+		printf("Error, during shader creation: %i\n", glGetError());
+	}
+
+	return shader;
+}
+
+GLuint createProgram(const char* pVertexSource, const char* pFragmentSource)
+{
+	GLuint vertexShader = loadShader(GL_VERTEX_SHADER, pVertexSource);
+	if (!vertexShader) {
+		printf("vertex shader not compiled\n");
+		return 0;
+	}
+
+	GLuint pixelShader = loadShader(GL_FRAGMENT_SHADER, pFragmentSource);
+	if (!pixelShader) {
+		printf("frag shader not compiled\n");
+		return 0;
+	}
+
+	GLuint program = glCreateProgram();
+	if (program) {
+		glAttachShader(program, vertexShader);
+		glAttachShader(program, pixelShader);
+		glLinkProgram(program);
+		GLint linkStatus = GL_FALSE;
+		glGetProgramiv(program, GL_LINK_STATUS, &linkStatus);
+
+		if (linkStatus != GL_TRUE) {
+			GLint bufLength = 0;
+			glGetProgramiv(program, GL_INFO_LOG_LENGTH, &bufLength);
+			if (bufLength) {
+				char* buf = (char*) malloc(bufLength);
+				if (buf) {
+					glGetProgramInfoLog(program, bufLength, NULL, buf);
+					fprintf(stderr, "Could not link program:\n%s\n", buf);
+					free(buf);
+				}
+			}
+			glDeleteProgram(program);
+			program = 0;
+		}
+	}
+
+	return program;
+}
+
+bool setupGraphics()
+{
+	vertex_data = triangle;
+	color_data = color_triangle;
+
+	gProgram = createProgram(gVertexShader, gFragmentShader);
+	if (!gProgram) {
+		printf("error making program\n");
+		return 0;
+	}
+
+	gvPositionHandle = glGetAttribLocation(gProgram, "vPosition");
+	gvColorHandle = glGetAttribLocation(gProgram, "vColor");
+
+	rotation_uniform = glGetUniformLocation(gProgram, "angle");
+
+	return true;
+}
+
+void hw_render(EGLDisplay displ, EGLSurface surface)
+{
+	glUseProgram(gProgram);
+
+	glClear( GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
+
+	glUniform1fv(rotation_uniform,1, &rotation_angle);
+
+	glVertexAttribPointer(gvColorHandle,    num_vertex, GL_FLOAT, GL_FALSE, sizeof(GLfloat)*4, color_data);
+	glVertexAttribPointer(gvPositionHandle, num_vertex, GL_FLOAT, GL_FALSE, 0, vertex_data);
+	glEnableVertexAttribArray(gvPositionHandle);
+	glEnableVertexAttribArray(gvColorHandle);
+
+	glDrawArrays(GL_TRIANGLE_STRIP, 0, num_vertex);
+	glDisableVertexAttribArray(gvPositionHandle);
+	glDisableVertexAttribArray(gvColorHandle);
+
+	eglSwapBuffers(displ, surface);
+}
+
+void hw_step()
+{
+	rotation_angle += 0.01;
+	return;
+}
+
+int main(int argc, char** argv)
+{
+	SfClient* sf_client = sf_client_create();
+
+	if (!sf_client) {
+		printf("Problem creating client ... aborting now.");
+		return 1;
+	}
+
+	SfSurfaceCreationParameters params = {
+		200,
+		200,
+		500,
+		500,
+		-1, //PIXEL_FORMAT_RGBA_8888,
+		INT_MAX,
+		0.5f,
+		true, // Associate surface with egl
+		"A test surface"
+	};
+
+	SfSurface* sf_surface = sf_surface_create(sf_client, &params);
+
+	if (!sf_surface) {
+		printf("Problem creating surface ... aborting now.");
+		return 1;
+	}
+
+	sf_surface_make_current(sf_surface);
+
+	EGLDisplay disp = sf_client_get_egl_display(sf_client);
+	EGLSurface surface = sf_surface_get_egl_surface(sf_surface);
+
+	setupGraphics();
+
+	printf("Turning off screen\n");
+	sf_blank(0);
+
+	sleep(1);
+
+	printf("Turning on screen\n");
+	sf_unblank(0);
+
+	for(;;) {
+		hw_render(disp, surface);
+		hw_step();
+	}
+}
+
+

--- a/compat/surface_flinger/surface_flinger_compatibility_layer.cpp
+++ b/compat/surface_flinger/surface_flinger_compatibility_layer.cpp
@@ -1,0 +1,355 @@
+/*
+ * Copyright (C) 2013 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authored by: Thomas Voss <thomas.voss@canonical.com>
+ *              Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
+ */
+
+#include <hybris/surface_flinger_compatibility_layer.h>
+#include <hybris/internal/surface_flinger_compatibility_layer_internal.h>
+
+#include <utils/misc.h>
+
+#include <gui/SurfaceComposerClient.h>
+#include <gui/ISurfaceComposer.h>
+#include <ui/DisplayInfo.h>
+#include <ui/PixelFormat.h>
+#include <ui/Region.h>
+#include <ui/Rect.h>
+
+#include <cassert>
+#include <cstdio>
+
+namespace
+{
+void report_failed_to_allocate_surface_flinger_composer_client_on_creation()
+{
+	printf("Problem allocating an object of type SurfaceComposerClient during client creation");
+}
+
+void report_failed_to_get_egl_default_display_on_creation()
+{
+	printf("Problem accessing default egl display during client creation");
+}
+
+void report_failed_to_initialize_egl_on_creation()
+{
+	printf("Problem initializing egl during client creation");
+}
+
+void report_failed_to_choose_egl_config_on_creation()
+{
+	printf("Problem choosing egl config on creation");
+}
+
+void report_surface_control_is_null_during_creation()
+{
+	printf("Could not acquire surface control object during surface creation");
+}
+
+void report_surface_is_null_during_creation()
+{
+	printf("Could not acquire surface from surface control during surface creation");
+}
+}
+
+void sf_blank(size_t display_id)
+{
+	android::sp<android::IBinder> display;
+
+	if (display_id == 0) {
+		display = android::SurfaceComposerClient::getBuiltInDisplay(
+				android::ISurfaceComposer::eDisplayIdMain);
+	} else if (display_id == 1) {
+		display = android::SurfaceComposerClient::getBuiltInDisplay(
+				android::ISurfaceComposer::eDisplayIdHdmi);
+	} else {
+		fprintf(stderr, "Warning: sf_blank invalid display_id (0 || 1)\n");
+		return;
+	}
+
+	android::SurfaceComposerClient::blankDisplay(display);
+}
+
+void sf_unblank(size_t display_id)
+{
+	android::sp<android::IBinder> display;
+
+	if (display_id == 0) {
+		display = android::SurfaceComposerClient::getBuiltInDisplay(
+				android::ISurfaceComposer::eDisplayIdMain);
+	} else if (display_id == 1) {
+		display = android::SurfaceComposerClient::getBuiltInDisplay(
+				android::ISurfaceComposer::eDisplayIdHdmi);
+	} else {
+		fprintf(stderr, "Warning: sf_unblank invalid display_id (0 || 1)\n");
+		return;
+	}
+
+	android::SurfaceComposerClient::unblankDisplay(display);
+}
+
+size_t sf_get_display_width(size_t display_id)
+{
+	android::sp<android::IBinder> display;
+
+	if (display_id == 0) {
+		display = android::SurfaceComposerClient::getBuiltInDisplay(
+				android::ISurfaceComposer::eDisplayIdMain);
+	} else if (display_id == 1) {
+		display = android::SurfaceComposerClient::getBuiltInDisplay(
+				android::ISurfaceComposer::eDisplayIdHdmi);
+	} else {
+		fprintf(stderr, "Warning: sf_get_display_width invalid display_id (0 || 1)\n");
+		return -1;
+	}
+
+	android::DisplayInfo info;
+	android::SurfaceComposerClient::getDisplayInfo(display, &info);
+	return info.w;
+}
+
+size_t sf_get_display_height(size_t display_id)
+{
+	android::sp<android::IBinder> display;
+
+	if (display_id == 0) {
+		display = android::SurfaceComposerClient::getBuiltInDisplay(
+				android::ISurfaceComposer::eDisplayIdMain);
+	} else if (display_id == 1) {
+		display = android::SurfaceComposerClient::getBuiltInDisplay(
+				android::ISurfaceComposer::eDisplayIdHdmi);
+	} else {
+		fprintf(stderr, "Warning: sf_get_display_height invalid display_id (0 || 1)\n");
+		return -1;
+	}
+
+	android::DisplayInfo info;
+	android::SurfaceComposerClient::getDisplayInfo(display, &info);
+	return info.h;
+}
+
+SfClient* sf_client_create_full(bool egl_support)
+{
+	SfClient* client = new SfClient();
+
+	client->client = new android::SurfaceComposerClient();
+	if (client->client == NULL) {
+		report_failed_to_allocate_surface_flinger_composer_client_on_creation();
+		delete client;
+		return NULL;
+	}
+
+	client->egl_support = egl_support;
+	if (egl_support) {
+		client->egl_display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+		if (client->egl_display == EGL_NO_DISPLAY) {
+			report_failed_to_get_egl_default_display_on_creation();
+			delete client;
+			return NULL;
+		}
+
+		int major, minor;
+		int rc = eglInitialize(client->egl_display, &major, &minor);
+		if (rc == EGL_FALSE) {
+			report_failed_to_initialize_egl_on_creation();
+			delete client;
+			return NULL;
+		}
+
+		EGLint attribs[] = {
+			EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+			EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+			EGL_NONE
+		};
+
+		int n;
+		if (eglChooseConfig(client->egl_display,
+					attribs,
+					&client->egl_config, 1,
+					&n) == EGL_FALSE) {
+			report_failed_to_choose_egl_config_on_creation();
+			delete client;
+			return NULL;
+		}
+
+		EGLint context_attribs[] = {
+			EGL_CONTEXT_CLIENT_VERSION, 2,
+			EGL_NONE
+		};
+
+		client->egl_context = eglCreateContext(
+				client->egl_display,
+				client->egl_config,
+				EGL_NO_CONTEXT,
+				context_attribs);
+	}
+
+	return client;
+}
+
+SfClient* sf_client_create()
+{
+	return sf_client_create_full(true);
+}
+
+EGLDisplay sf_client_get_egl_display(SfClient* client)
+{
+	assert(client);
+
+	if (client->egl_support)
+		return client->egl_display;
+	else {
+		fprintf(stderr, "Warning: sf_client_get_egl_display not supported, EGL "
+				"support disabled\n");
+		return NULL;
+	}
+}
+
+EGLConfig sf_client_get_egl_config(SfClient* client)
+{
+	assert(client);
+
+	if (client->egl_support)
+		return client->egl_config;
+	else {
+		fprintf(stderr, "Warning: sf_client_get_egl_config not supported, EGL "
+				"support disabled\n");
+		return NULL;
+	}
+}
+
+void sf_client_begin_transaction(SfClient* client)
+{
+	assert(client);
+	client->client->openGlobalTransaction();
+}
+
+void sf_client_end_transaction(SfClient* client)
+{
+	assert(client);
+	client->client->closeGlobalTransaction();
+}
+
+SfSurface* sf_surface_create(SfClient* client, SfSurfaceCreationParameters* params)
+{
+	assert(client);
+	assert(params);
+
+	SfSurface* surface = new SfSurface();
+	surface->client = client;
+	surface->surface_control = surface->client->client->createSurface(
+					android::String8(params->name),
+					params->w,
+					params->h,
+					android::PIXEL_FORMAT_RGBA_8888,
+					0x300);
+
+	if (surface->surface_control == NULL) {
+		report_surface_control_is_null_during_creation();
+		delete(surface);
+		return NULL;
+	}
+
+	surface->surface = surface->surface_control->getSurface();
+
+	if (surface->surface == NULL) {
+		report_surface_is_null_during_creation();
+		delete(surface);
+		return NULL;
+	}
+
+	sf_client_begin_transaction(client);
+	{
+		surface->surface_control->setPosition(params->x, params->y);
+		surface->surface_control->setLayer(params->layer);
+		surface->surface_control->setAlpha(params->alpha);
+	}
+	sf_client_end_transaction(client);
+
+	if (params->create_egl_window_surface) {
+		if (client->egl_support) {
+			android::sp<ANativeWindow> anw(surface->surface);
+			surface->egl_surface = eglCreateWindowSurface(
+						surface->client->egl_display,
+						surface->client->egl_config,
+						anw.get(),
+						NULL);
+		} else
+			fprintf(stderr, "Warning: params->create_egl_window_surface not "
+					"supported, EGL support disabled\n");
+	}
+
+	return surface;
+}
+
+EGLSurface sf_surface_get_egl_surface(SfSurface* surface)
+{
+	assert(surface);
+
+	if (surface->client->egl_support)
+		return surface->egl_surface;
+	else {
+		fprintf(stderr, "Warning: sf_surface_get_egl_surface not supported, "
+				"EGL support disabled\n");
+		return NULL;
+	}
+}
+
+EGLNativeWindowType sf_surface_get_egl_native_window(SfSurface* surface)
+{
+	assert(surface);
+	return surface->surface.get();
+}
+
+void sf_surface_make_current(SfSurface* surface)
+{
+	assert(surface);
+
+	if (surface->client->egl_support) {
+		eglMakeCurrent(
+				surface->client->egl_display,
+				surface->egl_surface,
+				surface->egl_surface,
+				surface->client->egl_context);
+	} else {
+		fprintf(stderr, "Warning: sf_surface_make_current not supported, EGL "
+				"support disabled\n");
+	}
+}
+
+void sf_surface_move_to(SfSurface* surface, int x, int y)
+{
+	assert(surface);
+	surface->surface_control->setPosition(x, y);
+}
+
+void sf_surface_set_size(SfSurface* surface, int w, int h)
+{
+	assert(surface);
+	surface->surface_control->setSize(w, h);
+}
+
+void sf_surface_set_layer(SfSurface* surface, int layer)
+{
+	assert(surface);
+	surface->surface_control->setLayer(layer);
+}
+
+void sf_surface_set_alpha(SfSurface* surface, float alpha)
+{
+	assert(surface);
+	surface->surface_control->setAlpha(alpha);
+}

--- a/hybris/Makefile.am
+++ b/hybris/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = include common hardware egl glesv2 ui tests
+SUBDIRS = include common hardware egl glesv2 ui sf tests
 
 MAINTAINERCLEANFILES = \
 	aclocal.m4 compile config.guess config.sub \

--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -136,6 +136,7 @@ AC_CONFIG_FILES([
 	glesv2/Makefile
 	hardware/Makefile
 	ui/Makefile
+	sf/Makefile
 	include/Makefile
 	tests/Makefile
 ])

--- a/hybris/include/hybris/internal/surface_flinger_compatibility_layer_internal.h
+++ b/hybris/include/hybris/internal/surface_flinger_compatibility_layer_internal.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2013 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authored by: Thomas Voss <thomas.voss@canonical.com>
+ */
+
+#ifndef SURFACE_FLINGER_COMPATIBILITY_LAYER_INTERNAL_H_
+#define SURFACE_FLINGER_COMPATIBILITY_LAYER_INTERNAL_H_
+
+#ifndef __ANDROID__
+#error "Using this header is only safe when compiling for Android."
+#endif
+
+#include <utils/misc.h>
+
+#include <gui/SurfaceComposerClient.h>
+#include <ui/PixelFormat.h>
+#include <ui/Region.h>
+#include <ui/Rect.h>
+
+#include <cassert>
+#include <cstdio>
+
+struct SfClient
+{
+	android::sp<android::SurfaceComposerClient> client;
+	EGLDisplay egl_display;
+	EGLConfig egl_config;
+	EGLContext egl_context;
+	bool egl_support;
+};
+
+struct SfSurface
+{
+	SfSurface() : client(NULL)
+	{
+	}
+
+	SfClient* client;
+	android::sp<android::SurfaceControl> surface_control;
+	android::sp<android::Surface> surface;
+	EGLSurface egl_surface;
+};
+
+#endif // SURFACE_FLINGER_COMPATIBILITY_LAYER_INTERNAL_H_

--- a/hybris/include/hybris/surface_flinger_compatibility_layer.h
+++ b/hybris/include/hybris/surface_flinger_compatibility_layer.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2013 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authored by: Thomas Voss <thomas.voss@canonical.com>
+ */
+
+#ifndef SURFACE_FLINGER_COMPATIBILITY_LAYER_H_
+#define SURFACE_FLINGER_COMPATIBILITY_LAYER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+
+	struct SfClient;
+	struct SfSurface;
+
+	enum
+	{
+		SURFACE_FLINGER_DEFAULT_DISPLAY_ID = 0
+	};
+
+	void sf_blank(size_t display_id);
+	void sf_unblank(size_t display_id);
+
+	size_t sf_get_display_width(size_t display_id);
+	size_t sf_get_display_height(size_t display_id);
+
+	// The egl_support parameter disables the use of EGL inside the
+	// library. sf_client_create() enables the use of EGL by default. When
+	// disabled, the functions sf_client_get_egl_display(),
+	// sf_client_get_egl_config(), sf_surface_get_egl_surface(),
+	// sf_surface_make_current() and the create_egl_window_surface feature are
+	// not supported anymore.
+	struct SfClient* sf_client_create_full(int egl_support);
+	struct SfClient* sf_client_create();
+
+	EGLDisplay sf_client_get_egl_display(struct SfClient* display);
+	EGLConfig sf_client_get_egl_config(struct SfClient* client);
+	void sf_client_begin_transaction(struct SfClient*);
+	void sf_client_end_transaction(struct SfClient*);
+
+	typedef struct
+	{
+		int x;
+		int y;
+		int w;
+		int h;
+		int format;
+		int layer;
+		float alpha;
+		int create_egl_window_surface;
+		const char* name;
+	} SfSurfaceCreationParameters;
+
+	struct SfSurface* sf_surface_create(struct SfClient* client,
+			SfSurfaceCreationParameters* params);
+	EGLSurface sf_surface_get_egl_surface(struct SfSurface*);
+	EGLNativeWindowType sf_surface_get_egl_native_window(struct SfSurface*);
+	void sf_surface_make_current(struct SfSurface* surface);
+
+	void sf_surface_move_to(struct SfSurface* surface, int x, int y);
+	void sf_surface_set_size(struct SfSurface* surface, int w, int h);
+	void sf_surface_set_layer(struct SfSurface* surface, int layer);
+	void sf_surface_set_alpha(struct SfSurface* surface, float alpha);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SURFACE_FLINGER_COMPATIBILITY_LAYER_H_

--- a/hybris/sf/Makefile.am
+++ b/hybris/sf/Makefile.am
@@ -1,0 +1,14 @@
+lib_LTLIBRARIES = \
+	libsf.la
+
+libsf_la_SOURCES = sf.c
+libsf_la_CFLAGS = -I$(top_srcdir)/include
+if WANT_TRACE
+libsf_la_CFLAGS += -DDEBUG
+endif
+if WANT_DEBUG
+libsf_la_CFLAGS += -ggdb -O0
+endif
+libsf_la_LDFLAGS = \
+	$(top_builddir)/common/libhybris-common.la \
+	-version-info "1":"0":"0"

--- a/hybris/sf/sf.c
+++ b/hybris/sf/sf.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2013 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authored by: Michael Frey <michael.frey@canonical.com>
+ *              Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
+ */
+
+#include <EGL/egl.h>
+#include <dlfcn.h>
+#include <stddef.h>
+
+#include <hybris/internal/binding.h>
+#include <hybris/surface_flinger_compatibility_layer.h>
+
+#define COMPAT_LIBRARY_PATH "/system/lib/libsf_compat_layer.so"
+
+#ifdef __ARM_PCS_VFP
+#define FP_ATTRIB __attribute__((pcs("aapcs")))
+#else
+#define FP_ATTRIB
+#endif
+
+HYBRIS_LIBRARY_INITIALIZE(sf, COMPAT_LIBRARY_PATH);
+
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(sf, sf_blank, size_t);
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(sf, sf_unblank, size_t);
+HYBRIS_IMPLEMENT_FUNCTION1(sf, size_t, sf_get_display_width, size_t);
+HYBRIS_IMPLEMENT_FUNCTION1(sf, size_t, sf_get_display_height, size_t);
+HYBRIS_IMPLEMENT_FUNCTION1(sf, struct SfClient*, sf_client_create_full, int);
+HYBRIS_IMPLEMENT_FUNCTION0(sf, struct SfClient*, sf_client_create);
+HYBRIS_IMPLEMENT_FUNCTION1(sf, EGLDisplay, sf_client_get_egl_display,
+	struct SfClient*);
+HYBRIS_IMPLEMENT_FUNCTION1(sf, EGLConfig, sf_client_get_egl_config,
+	struct SfClient*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(sf, sf_client_begin_transaction,
+	struct SfClient*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(sf, sf_client_end_transaction,
+	struct SfClient*);
+HYBRIS_IMPLEMENT_FUNCTION2(sf, struct SfSurface*, sf_surface_create,
+	struct SfClient*, SfSurfaceCreationParameters*);
+HYBRIS_IMPLEMENT_FUNCTION1(sf, EGLSurface, sf_surface_get_egl_surface,
+	struct SfSurface*);
+HYBRIS_IMPLEMENT_FUNCTION1(sf, EGLNativeWindowType,
+	sf_surface_get_egl_native_window, struct SfSurface*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(sf, sf_surface_make_current, struct SfSurface*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION3(sf, sf_surface_move_to,
+	struct SfSurface*, int, int);
+HYBRIS_IMPLEMENT_VOID_FUNCTION3(sf, sf_surface_set_size,
+	struct SfSurface*, int, int);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(sf, sf_surface_set_layer,
+	struct SfSurface*, int);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(sf, sf_surface_set_alpha,
+	struct SfSurface*, float);

--- a/hybris/tests/Makefile.am
+++ b/hybris/tests/Makefile.am
@@ -4,6 +4,7 @@ bin_PROGRAMS = \
 	test_sensors \
 	test_lights \
 	test_ui \
+	test_sf \
 	test_gps
 
 test_egl_SOURCES = test_egl.c
@@ -48,6 +49,15 @@ test_ui_CFLAGS = \
 test_ui_LDADD = \
 	$(top_builddir)/common/libhybris-common.la \
 	$(top_builddir)/ui/libui.la
+
+test_sf_SOURCES = test_sf.c
+test_sf_CFLAGS = \
+	-I$(top_srcdir)/include
+test_sf_LDADD = \
+	$(top_builddir)/common/libhybris-common.la \
+	$(top_builddir)/egl/libEGL.la \
+	$(top_builddir)/glesv2/libGLESv2.la \
+	$(top_builddir)/sf/libsf.la
 
 test_gps_SOURCES = test_gps.c
 test_gps_CFLAGS = -pthread \

--- a/hybris/tests/test_sf.c
+++ b/hybris/tests/test_sf.c
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2013 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authored by: Thomas Voss <thomas.voss@canonical.com>
+ *              Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
+ */
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <limits.h>
+
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+
+#include <hybris/surface_flinger_compatibility_layer.h>
+
+struct SfSurface* sf_surface_create(struct SfClient* client, SfSurfaceCreationParameters* params);
+EGLSurface sf_surface_get_egl_surface(struct SfSurface*);
+void sf_surface_make_current(struct SfSurface* surface);
+
+void sf_surface_move_to(struct SfSurface* surface, int x, int y);
+void sf_surface_set_layer(struct SfSurface* surface, int layer);
+void sf_surface_set_alpha(struct SfSurface* surface, float alpha);
+
+double rotation_increment = 0.01;
+
+/* animation state variables */
+GLfloat rotation_angle = 0.0f;
+
+static GLuint gProgram;
+static GLuint gvPositionHandle, gvColorHandle;
+static GLuint rotation_uniform;
+static GLint num_vertex = 3;
+static const GLfloat triangle[] = {
+	-0.125f, -0.125f, 0.0f, 0.5f,
+	0.0f,  0.125f, 0.0f, 0.5f,
+	0.125f, -0.125f, 0.0f, 0.5f };
+static const GLfloat color_triangle[] = {
+	0.0f, 0.0f, 1.0f, 1.0f,
+	0.0f, 1.0f, 0.0f, 1.0f,
+	1.0f, 0.0f, 0.0f, 0.0f };
+const GLfloat * vertex_data;
+const GLfloat * color_data;
+static const char gVertexShader[] =
+	"attribute vec4 vPosition;\n"
+	"attribute vec4 vColor;\n"
+	"uniform float angle;\n"
+	"varying vec4 colorinfo;\n"
+	"void main() {\n"
+	"  mat3 rot_z = mat3( vec3( cos(angle),  sin(angle), 0.0),\n"
+	"                     vec3(-sin(angle),  cos(angle), 0.0),\n"
+	"                     vec3(       0.0,         0.0, 1.0));\n"
+	"  gl_Position = vec4(rot_z * vPosition.xyz, 1.0);\n"
+	"  colorinfo = vColor;\n"
+	"}\n";
+
+static const char gFragmentShader[] = "precision mediump float;\n"
+	"varying vec4 colorinfo;\n"
+	"void main() {\n"
+	"  gl_FragColor = colorinfo;\n"
+	"}\n";
+
+/* util functions */
+GLuint loadShader(GLenum shaderType, const char* pSource)
+{
+	GLuint shader = glCreateShader(shaderType);
+	if (shader) {
+		glShaderSource(shader, 1, &pSource, NULL);
+		glCompileShader(shader);
+		GLint compiled = 0;
+		glGetShaderiv(shader, GL_COMPILE_STATUS, &compiled);
+
+		if (!compiled) {
+			GLint infoLen = 0;
+			glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &infoLen);
+			if (infoLen) {
+				char* buf = (char*) malloc(infoLen);
+				if (buf) {
+					glGetShaderInfoLog(shader, infoLen, NULL, buf);
+					fprintf(stderr, "Could not compile shader %d:\n%s\n",
+							shaderType, buf);
+					free(buf);
+				}
+				glDeleteShader(shader);
+				shader = 0;
+			}
+		}
+	} else {
+		printf("Error, during shader creation: %i\n", glGetError());
+	}
+
+	return shader;
+}
+
+GLuint createProgram(const char* pVertexSource, const char* pFragmentSource)
+{
+	GLuint vertexShader = loadShader(GL_VERTEX_SHADER, pVertexSource);
+	if (!vertexShader) {
+		printf("vertex shader not compiled\n");
+		return 0;
+	}
+
+	GLuint pixelShader = loadShader(GL_FRAGMENT_SHADER, pFragmentSource);
+	if (!pixelShader) {
+		printf("frag shader not compiled\n");
+		return 0;
+	}
+
+	GLuint program = glCreateProgram();
+	if (program) {
+		glAttachShader(program, vertexShader);
+		glAttachShader(program, pixelShader);
+		glLinkProgram(program);
+		GLint linkStatus = GL_FALSE;
+		glGetProgramiv(program, GL_LINK_STATUS, &linkStatus);
+
+		if (linkStatus != GL_TRUE) {
+			GLint bufLength = 0;
+			glGetProgramiv(program, GL_INFO_LOG_LENGTH, &bufLength);
+			if (bufLength) {
+				char* buf = (char*) malloc(bufLength);
+				if (buf) {
+					glGetProgramInfoLog(program, bufLength, NULL, buf);
+					fprintf(stderr, "Could not link program:\n%s\n", buf);
+					free(buf);
+				}
+			}
+			glDeleteProgram(program);
+			program = 0;
+		}
+	}
+
+	return program;
+}
+
+int setupGraphics()
+{
+	vertex_data = triangle;
+	color_data = color_triangle;
+
+	gProgram = createProgram(gVertexShader, gFragmentShader);
+	if (!gProgram) {
+		printf("error making program\n");
+		return 0;
+	}
+
+	gvPositionHandle = glGetAttribLocation(gProgram, "vPosition");
+	gvColorHandle = glGetAttribLocation(gProgram, "vColor");
+
+	rotation_uniform = glGetUniformLocation(gProgram, "angle");
+
+	return 1;
+}
+
+void hw_render(EGLDisplay displ, EGLSurface surface)
+{
+	glUseProgram(gProgram);
+
+	glClear( GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
+
+	glUniform1fv(rotation_uniform,1, &rotation_angle);
+
+	glVertexAttribPointer(gvColorHandle,    num_vertex, GL_FLOAT, GL_FALSE, sizeof(GLfloat)*4, color_data);
+	glVertexAttribPointer(gvPositionHandle, num_vertex, GL_FLOAT, GL_FALSE, 0, vertex_data);
+	glEnableVertexAttribArray(gvPositionHandle);
+	glEnableVertexAttribArray(gvColorHandle);
+
+	glDrawArrays(GL_TRIANGLE_STRIP, 0, num_vertex);
+	glDisableVertexAttribArray(gvPositionHandle);
+	glDisableVertexAttribArray(gvColorHandle);
+
+	eglSwapBuffers(displ, surface);
+}
+
+void hw_step()
+{
+	rotation_angle += rotation_increment;
+	return;
+}
+
+int main(int argc, char** argv)
+{
+	struct SfClient* sf_client = sf_client_create();
+
+	if (!sf_client) {
+		printf("Problem creating client ... aborting now.");
+		return 1;
+	}
+
+	int x = getenv("X") ? atoi(getenv("X")) : 200;
+	int y = getenv("Y") ? atoi(getenv("Y")) : 200;
+
+	int w = getenv("W") ? atoi(getenv("W")) : 500;
+	int h = getenv("H") ? atoi(getenv("H")) : 500;
+
+	float opacity = getenv("O") ? atof(getenv("O")) : 0.5;
+	rotation_increment = getenv("RI") ? atof(getenv("RI")) : 0.01;
+
+	SfSurfaceCreationParameters params = {
+		x,
+		y,
+		w,
+		h,
+		-1, // PIXEL_FORMAT_RGBA_8888,
+		INT_MAX,
+		opacity,
+		1,
+		"A test surface"
+	};
+
+	struct SfSurface* sf_surface = sf_surface_create(sf_client, &params);
+
+	if (!sf_surface) {
+		printf("Problem creating surface ... aborting now.");
+		return 1;
+	}
+
+	sf_surface_make_current(sf_surface);
+
+	EGLDisplay disp = sf_client_get_egl_display(sf_client);
+	EGLSurface surface = sf_surface_get_egl_surface(sf_surface);
+
+	setupGraphics();
+
+	printf("Turning off screen\n");
+	sf_blank(0);
+
+	sleep(1);
+
+	printf("Turning on screen\n");
+	sf_unblank(0);
+
+	for (;;) {
+		hw_render(disp, surface);
+		hw_step();
+	}
+}


### PR DESCRIPTION
 compat/surface_flinger: adding compatibility layer to talk with Android's Surface Flinger

Basic layer used to test if surface flinger is indeed working as expected.

Signed-off-by: Ricardo Salveti de Araujo ricardo.salveti@canonical.com
