### PR TITLE
add .pc files for egl and glesv2

### DIFF
--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -127,12 +127,14 @@ AC_CONFIG_FILES([
 	common/gingerbread/Makefile
 	common/ics/Makefile
 	common/jb/Makefile
+	egl/egl.pc
 	egl/Makefile
 	egl/platforms/Makefile
 	egl/platforms/common/Makefile
 	egl/platforms/null/Makefile
 	egl/platforms/fbdev/Makefile
 	egl/platforms/wayland/Makefile
+	glesv2/glesv2.pc
 	glesv2/Makefile
 	hardware/Makefile
 	ui/Makefile

--- a/hybris/egl/Makefile.am
+++ b/hybris/egl/Makefile.am
@@ -7,6 +7,9 @@ libEGL_la_SOURCES = \
 	egl.c \
 	ws.c
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = egl.pc
+
 libEGL_la_CFLAGS = -I$(top_srcdir)/include -DPKGLIBDIR="\"$(pkglibdir)/\""
 if WANT_MESA
 libEGL_la_CFLAGS += -DLIBHYBRIS_WANTS_MESA_X11_HEADERS

--- a/hybris/egl/egl.pc.in
+++ b/hybris/egl/egl.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=@libdir@
+includedir=@includedir@
+
+Name: egl
+Description: libhybris EGL library
+Requires.private: @GL_PC_REQ_PRIV@
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lEGL
+Libs.private: @GL_PC_LIB_PRIV@
+Cflags: -I${includedir} @GL_PC_CFLAGS@

--- a/hybris/glesv2/Makefile.am
+++ b/hybris/glesv2/Makefile.am
@@ -3,6 +3,10 @@ lib_LTLIBRARIES = \
 
 libGLESv2_la_SOURCES = glesv2.c
 libGLESv2_la_CFLAGS = -I$(top_srcdir)/include
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = glesv2.pc
+
 if WANT_MESA
 libGLESv2_la_CFLAGS += -DLIBHYBRIS_WANTS_MESA_X11_HEADERS
 endif

--- a/hybris/glesv2/glesv2.pc.in
+++ b/hybris/glesv2/glesv2.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=@libdir@
+includedir=@includedir@
+
+Name: glesv2
+Description: libhybris OpenGL ES 2.0 library
+Requires.private:
+Version: @VERSION@
+Libs: -L${libdir} -lGLESv2
+Libs.private: @GLESv2_PC_LIB_PRIV@
+Cflags: -I${includedir}


### PR DESCRIPTION
this way, libhybris provide the build dependencis for egl and gles2

Signed-off-by: Adrian Negreanu adrian.m.negreanu@intel.com
