### PR TITLE
Camera: adding initial compat files for camera

### DIFF
--- a/compat/camera/Android.mk
+++ b/compat/camera/Android.mk
@@ -1,0 +1,56 @@
+LOCAL_PATH:= $(call my-dir)
+include $(CLEAR_VARS)
+
+HYBRIS_PATH := $(LOCAL_PATH)/../../hybris
+
+LOCAL_SRC_FILES := camera_compatibility_layer.cpp
+
+LOCAL_MODULE := libcamera_compat_layer
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_C_INCLUDES := \
+	$(HYBRIS_PATH)/include
+
+LOCAL_SHARED_LIBRARIES := \
+	libcutils \
+	libcamera_client \
+	libutils \
+	libbinder \
+	libhardware \
+	libui \
+	libgui
+
+include $(BUILD_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+
+HYBRIS_PATH := $(LOCAL_PATH)/../../hybris
+
+LOCAL_SRC_FILES := direct_camera_test.cpp
+
+LOCAL_MODULE := direct_camera_test
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_C_INCLUDES := \
+	$(HYBRIS_PATH)/include \
+	bionic \
+	bionic/libstdc++/include \
+	external/gtest/include \
+	external/stlport/stlport \
+	external/skia/include/core \
+
+LOCAL_SHARED_LIBRARIES := \
+	libis_compat_layer \
+	libsf_compat_layer \
+	libcamera_compat_layer \
+	libcutils \
+	libcamera_client \
+	libutils \
+	libbinder \
+	libhardware \
+	libui \
+	libgui \
+	libEGL \
+	libGLESv2
+
+include $(BUILD_EXECUTABLE)

--- a/compat/camera/camera_compatibility_layer.cpp
+++ b/compat/camera/camera_compatibility_layer.cpp
@@ -1,0 +1,703 @@
+/*
+ * Copyright (C) 2013 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authored by: Thomas Voß <thomas.voss@canonical.com>
+ *              Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
+ */
+
+#include <hybris/internal/camera_control.h>
+#include <hybris/camera/camera_compatibility_layer.h>
+#include <hybris/camera/camera_compatibility_layer_capabilities.h>
+#include <hybris/camera/camera_compatibility_layer_configuration_translator.h>
+
+#include <hybris/internal/surface_flinger_compatibility_layer_internal.h>
+
+#include <binder/ProcessState.h>
+#include <camera/Camera.h>
+#include <camera/CameraParameters.h>
+#include <gui/SurfaceTexture.h>
+
+#undef LOG_TAG
+#define LOG_TAG "CameraCompatibilityLayer"
+#include <utils/KeyedVector.h>
+#include <utils/Log.h>
+
+#define REPORT_FUNCTION() ALOGV("%s \n", __PRETTY_FUNCTION__)
+
+// From android::SurfaceTexture::FrameAvailableListener
+void CameraControl::onFrameAvailable()
+{
+	REPORT_FUNCTION();
+	if (listener)
+		listener->on_preview_texture_needs_update_cb(listener->context);
+}
+
+// From android::CameraListener
+void CameraControl::notify(int32_t msg_type, int32_t ext1, int32_t ext2)
+{
+	REPORT_FUNCTION();
+	printf("\text1: %d, ext2: %d \n", ext1, ext2);
+
+	if (!listener)
+		return;
+
+	switch (msg_type) {
+	case CAMERA_MSG_ERROR:
+		if (listener->on_msg_error_cb)
+			listener->on_msg_error_cb(listener->context);
+		break;
+	case CAMERA_MSG_SHUTTER:
+		if (listener->on_msg_shutter_cb)
+			listener->on_msg_shutter_cb(listener->context);
+		break;
+	case CAMERA_MSG_ZOOM:
+		if (listener->on_msg_zoom_cb)
+			listener->on_msg_zoom_cb(listener->context, ext1);
+		break;
+	case CAMERA_MSG_FOCUS:
+		if (listener->on_msg_focus_cb)
+			listener->on_msg_focus_cb(listener->context);
+		break;
+	default:
+		break;
+	}
+}
+
+void CameraControl::postData(
+		int32_t msg_type,
+		const android::sp<android::IMemory>& data,
+		camera_frame_metadata_t* metadata)
+{
+	REPORT_FUNCTION();
+
+	if (!listener)
+		return;
+
+	switch (msg_type) {
+	case CAMERA_MSG_RAW_IMAGE:
+		if (listener->on_data_raw_image_cb)
+			listener->on_data_raw_image_cb(data->pointer(), data->size(), listener->context);
+		break;
+	case CAMERA_MSG_COMPRESSED_IMAGE:
+		if (listener->on_data_compressed_image_cb)
+			listener->on_data_compressed_image_cb(data->pointer(), data->size(), listener->context);
+		break;
+	default:
+		break;
+	}
+
+	camera->releaseRecordingFrame(data);
+}
+
+void CameraControl::postDataTimestamp(
+		nsecs_t timestamp,
+		int32_t msg_type,
+		const android::sp<android::IMemory>& data)
+{
+	REPORT_FUNCTION();
+	(void) timestamp;
+	(void) msg_type;
+	(void) data;
+}
+
+namespace
+{
+
+android::sp<CameraControl> camera_control_instance;
+
+}
+
+int android_camera_get_number_of_devices()
+{
+	REPORT_FUNCTION();
+	return android::Camera::getNumberOfCameras();
+}
+
+CameraControl* android_camera_connect_to(CameraType camera_type, CameraControlListener* listener)
+{
+	REPORT_FUNCTION();
+
+	int32_t camera_id;
+	int32_t camera_count = camera_id = android::Camera::getNumberOfCameras();
+
+	for (camera_id = 0; camera_id < camera_count; camera_id++) {
+		android::CameraInfo ci;
+		android::Camera::getCameraInfo(camera_id, &ci);
+
+		if (ci.facing == camera_type)
+			break;
+	}
+
+	if (camera_id == camera_count)
+		return NULL;
+
+	CameraControl* cc = new CameraControl();
+	cc->listener = listener;
+	cc->camera = android::Camera::connect(camera_id);
+
+	if (cc->camera == NULL)
+		return NULL;
+
+	cc->camera_parameters = android::CameraParameters(cc->camera->getParameters());
+
+	camera_control_instance = cc;
+	cc->camera->setListener(camera_control_instance);
+	cc->camera->lock();
+
+	// TODO: Move this to a more generic component
+	android::ProcessState::self()->startThreadPool();
+
+	return cc;
+}
+
+void android_camera_disconnect(CameraControl* control)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+	control->camera->disconnect();
+	control->camera->unlock();
+}
+
+int android_camera_lock(CameraControl* control)
+{
+	android::Mutex::Autolock al(control->guard);
+	return control->camera->lock();
+}
+
+int android_camera_unlock(CameraControl* control)
+{
+	android::Mutex::Autolock al(control->guard);
+	return control->camera->unlock();
+}
+
+void android_camera_delete(CameraControl* control)
+{
+	delete control;
+}
+
+void android_camera_dump_parameters(CameraControl* control)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	printf("%s \n", control->camera->getParameters().string());
+}
+
+void android_camera_set_flash_mode(CameraControl* control, FlashMode mode)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+	control->camera_parameters.set(
+			android::CameraParameters::KEY_FLASH_MODE,
+			flash_modes[mode]);
+	control->camera->setParameters(control->camera_parameters.flatten());
+}
+
+void android_camera_get_flash_mode(CameraControl* control, FlashMode* mode)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+	static const char* flash_mode = control->camera_parameters.get(
+			android::CameraParameters::KEY_FLASH_MODE);
+	if (flash_mode)
+		*mode = flash_modes_lut.valueFor(android::String8(flash_mode));
+	else
+		*mode = FLASH_MODE_OFF;
+}
+
+void android_camera_set_white_balance_mode(CameraControl* control, WhiteBalanceMode mode)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	control->camera_parameters.set(
+			android::CameraParameters::KEY_WHITE_BALANCE,
+			white_balance_modes[mode]);
+	control->camera->setParameters(control->camera_parameters.flatten());
+}
+
+void android_camera_get_white_balance_mode(CameraControl* control, WhiteBalanceMode* mode)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	*mode = white_balance_modes_lut.valueFor(
+			android::String8(
+				control->camera_parameters.get(
+					android::CameraParameters::KEY_WHITE_BALANCE)));
+}
+
+void android_camera_set_scene_mode(CameraControl* control, SceneMode mode)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	control->camera_parameters.set(
+			android::CameraParameters::KEY_SCENE_MODE,
+			scene_modes[mode]);
+	control->camera->setParameters(control->camera_parameters.flatten());
+}
+
+void android_camera_get_scene_mode(CameraControl* control, SceneMode* mode)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	*mode = scene_modes_lut.valueFor(
+			android::String8(
+				control->camera_parameters.get(
+					android::CameraParameters::KEY_SCENE_MODE)));
+}
+
+void android_camera_set_auto_focus_mode(CameraControl* control, AutoFocusMode mode)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	control->camera_parameters.set(
+			android::CameraParameters::KEY_FOCUS_MODE,
+			auto_focus_modes[mode]);
+	control->camera->setParameters(control->camera_parameters.flatten());
+}
+
+void android_camera_get_auto_focus_mode(CameraControl* control, AutoFocusMode* mode)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	*mode = auto_focus_modes_lut.valueFor(
+			android::String8(
+				control->camera_parameters.get(
+					android::CameraParameters::KEY_FOCUS_MODE)));
+}
+
+
+void android_camera_set_effect_mode(CameraControl* control, EffectMode mode)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	control->camera_parameters.set(
+			android::CameraParameters::KEY_EFFECT,
+			effect_modes[mode]);
+	control->camera->setParameters(control->camera_parameters.flatten());
+}
+
+void android_camera_get_effect_mode(CameraControl* control, EffectMode* mode)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	*mode = effect_modes_lut.valueFor(
+			android::String8(
+				control->camera_parameters.get(
+					android::CameraParameters::KEY_EFFECT)));
+}
+
+void android_camera_get_preview_fps_range(CameraControl* control, int* min, int* max)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	control->camera_parameters.getPreviewFpsRange(min, max);
+}
+
+void android_camera_set_preview_fps(CameraControl* control, int fps)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+	control->camera_parameters.setPreviewFrameRate(fps);
+	control->camera->setParameters(control->camera_parameters.flatten());
+}
+
+void android_camera_get_preview_fps(CameraControl* control, int* fps)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+	*fps = control->camera_parameters.getPreviewFrameRate();
+}
+
+void android_camera_enumerate_supported_preview_sizes(CameraControl* control, size_callback cb, void* ctx)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+	android::Vector<android::Size> sizes;
+	control->camera_parameters.getSupportedPreviewSizes(sizes);
+
+	for (unsigned int i = 0; i < sizes.size(); i++) {
+		cb(ctx, sizes[i].width, sizes[i].height);
+	}
+}
+
+void android_camera_enumerate_supported_picture_sizes(CameraControl* control, size_callback cb, void* ctx)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+	android::Vector<android::Size> sizes;
+	control->camera_parameters.getSupportedPictureSizes(sizes);
+
+	for (unsigned int i = 0; i < sizes.size(); i++) {
+		cb(ctx, sizes[i].width, sizes[i].height);
+	}
+}
+
+void android_camera_get_preview_size(CameraControl* control, int* width, int* height)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	control->camera_parameters.getPreviewSize(width, height);
+}
+
+void android_camera_set_preview_size(CameraControl* control, int width, int height)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	control->camera_parameters.setPreviewSize(width, height);
+	control->camera->setParameters(control->camera_parameters.flatten());
+}
+
+void android_camera_get_picture_size(CameraControl* control, int* width, int* height)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	control->camera_parameters.getPictureSize(width, height);
+}
+
+void android_camera_set_picture_size(CameraControl* control, int width, int height)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	control->camera_parameters.setPictureSize(width, height);
+	control->camera->setParameters(control->camera_parameters.flatten());
+}
+
+void android_camera_get_current_zoom(CameraControl* control, int* zoom)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	*zoom = control->camera_parameters.getInt(android::CameraParameters::KEY_ZOOM);
+}
+
+void android_camera_get_max_zoom(CameraControl* control, int* zoom)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	*zoom = control->camera_parameters.getInt(android::CameraParameters::KEY_MAX_ZOOM);
+}
+
+void android_camera_set_display_orientation(CameraControl* control, int32_t clockwise_rotation_degree)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+	static const int32_t ignored_parameter = 0;
+	control->camera->sendCommand(CAMERA_CMD_SET_DISPLAY_ORIENTATION, clockwise_rotation_degree, ignored_parameter);
+}
+
+void android_camera_get_preview_texture_transformation(CameraControl* control, float m[16])
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	if (control->preview_texture == NULL)
+		return;
+
+	control->preview_texture->getTransformMatrix(m);
+}
+
+void android_camera_update_preview_texture(CameraControl* control)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	control->preview_texture->updateTexImage();
+}
+
+void android_camera_set_preview_texture(CameraControl* control, int texture_id)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	static const bool allow_synchronous_mode = false;
+
+	if (control->preview_texture == NULL) {
+		control->preview_texture = android::sp<android::SurfaceTexture>(
+				new android::SurfaceTexture(
+					texture_id,
+					allow_synchronous_mode));
+	}
+
+	control->preview_texture->setFrameAvailableListener(
+			android::sp<android::SurfaceTexture::FrameAvailableListener>(control));
+	control->camera->setPreviewTexture(control->preview_texture->getBufferQueue());
+}
+
+void android_camera_set_preview_surface(CameraControl* control, SfSurface* surface)
+{
+	REPORT_FUNCTION();
+	assert(control);
+	assert(surface);
+
+	android::Mutex::Autolock al(control->guard);
+	control->camera->setPreviewDisplay(surface->surface);
+}
+
+void android_camera_start_preview(CameraControl* control)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+	control->camera->startPreview();
+}
+
+void android_camera_stop_preview(CameraControl* control)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	if (control->preview_texture != NULL)
+		control->preview_texture->abandon();
+
+	control->camera->stopPreview();
+}
+
+void android_camera_start_autofocus(CameraControl* control)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+	control->camera->autoFocus();
+}
+
+void android_camera_stop_autofocus(CameraControl* control)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+	control->camera->cancelAutoFocus();
+}
+
+void android_camera_start_zoom(CameraControl* control, int32_t zoom)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	static const int ignored_argument = 0;
+
+	android::Mutex::Autolock al(control->guard);
+	control->camera->sendCommand(CAMERA_CMD_START_SMOOTH_ZOOM,
+			zoom,
+			ignored_argument);
+}
+
+// Adjust the zoom level immediately as opposed to smoothly zoomin gin.
+void android_camera_set_zoom(CameraControl* control, int32_t zoom)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	control->camera_parameters.set(
+			android::CameraParameters::KEY_ZOOM,
+			zoom);
+
+	control->camera->setParameters(control->camera_parameters.flatten());
+}
+
+void android_camera_stop_zoom(CameraControl* control)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	static const int ignored_argument = 0;
+
+	android::Mutex::Autolock al(control->guard);
+	control->camera->sendCommand(CAMERA_CMD_STOP_SMOOTH_ZOOM,
+			ignored_argument,
+			ignored_argument);
+}
+
+void android_camera_take_snapshot(CameraControl* control)
+{
+	REPORT_FUNCTION();
+	assert(control);
+	android::Mutex::Autolock al(control->guard);
+	control->camera->takePicture(CAMERA_MSG_SHUTTER | CAMERA_MSG_COMPRESSED_IMAGE);
+}
+
+void android_camera_set_preview_format(CameraControl* control, CameraPixelFormat pf)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	control->camera_parameters.set(
+			android::CameraParameters::KEY_PREVIEW_FORMAT,
+			camera_pixel_formats[pf]);
+
+	control->camera->setParameters(control->camera_parameters.flatten());
+}
+
+void android_camera_get_preview_format(CameraControl* control, CameraPixelFormat* pf)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	*pf = pixel_formats_lut.valueFor(
+			android::String8(
+				control->camera_parameters.get(
+					android::CameraParameters::KEY_PREVIEW_FORMAT)));
+}
+
+void android_camera_set_focus_region(
+		CameraControl* control,
+		FocusRegion* region)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+	static const char* focus_region_pattern = "(%d,%d,%d,%d,%d)";
+	static char focus_region[256];
+	snprintf(focus_region,
+			sizeof(focus_region),
+			focus_region_pattern,
+			region->left,
+			region->top,
+			region->right,
+			region->bottom,
+			region->weight);
+
+	control->camera_parameters.set(
+			android::CameraParameters::KEY_FOCUS_AREAS,
+			focus_region);
+
+	control->camera->setParameters(control->camera_parameters.flatten());
+}
+
+void android_camera_reset_focus_region(CameraControl* control)
+{
+	static FocusRegion region = { 0, 0, 0, 0, 0 };
+
+	android_camera_set_focus_region(control, &region);
+}
+
+void android_camera_set_rotation(CameraControl* control, int rotation)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+	control->camera_parameters.set(
+			android::CameraParameters::KEY_ROTATION,
+			rotation);
+	control->camera->setParameters(control->camera_parameters.flatten());
+}
+
+void android_camera_enumerate_supported_video_sizes(CameraControl* control, size_callback cb, void* ctx)
+{
+	REPORT_FUNCTION();
+	assert(control);
+	assert(cb);
+
+	android::Mutex::Autolock al(control->guard);
+	android::Vector<android::Size> sizes;
+	control->camera_parameters.getSupportedVideoSizes(sizes);
+
+	for (unsigned int i = 0; i < sizes.size(); i++) {
+		cb(ctx, sizes[i].width, sizes[i].height);
+	}
+}
+
+void android_camera_get_video_size(CameraControl* control, int* width, int* height)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	control->camera_parameters.getVideoSize(width, height);
+}
+
+void android_camera_set_video_size(CameraControl* control, int width, int height)
+{
+	REPORT_FUNCTION();
+	assert(control);
+
+	android::Mutex::Autolock al(control->guard);
+
+	control->camera_parameters.setVideoSize(width, height);
+	control->camera->setParameters(control->camera_parameters.flatten());
+}

--- a/compat/camera/direct_camera_test.cpp
+++ b/compat/camera/direct_camera_test.cpp
@@ -1,0 +1,515 @@
+/*
+ * Copyright (C) 2013 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authored by: Thomas Voß <thomas.voss@canonical.com>
+ *              Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
+ */
+
+#include <hybris/camera/camera_compatibility_layer.h>
+#include <hybris/camera/camera_compatibility_layer_capabilities.h>
+
+#include <hybris/input/input_stack_compatibility_layer.h>
+#include <hybris/input/input_stack_compatibility_layer_codes_key.h>
+#include <hybris/input/input_stack_compatibility_layer_flags_key.h>
+#include <hybris/input/input_stack_compatibility_layer_flags_motion.h>
+
+#include <hybris/surface_flinger/surface_flinger_compatibility_layer.h>
+
+#include <gui/ISurfaceComposer.h>
+
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+int shot_counter = 1;
+int32_t current_zoom_level = 1;
+bool new_camera_frame_available = true;
+
+EffectMode next_effect()
+{
+	static EffectMode current_effect = EFFECT_MODE_NONE;
+
+	EffectMode next = current_effect;
+
+	switch (current_effect) {
+	case EFFECT_MODE_NONE:
+		next = EFFECT_MODE_MONO;
+		break;
+	case EFFECT_MODE_MONO:
+		next = EFFECT_MODE_NEGATIVE;
+		break;
+	case EFFECT_MODE_NEGATIVE:
+		next = EFFECT_MODE_SOLARIZE;
+		break;
+	case EFFECT_MODE_SOLARIZE:
+		next = EFFECT_MODE_SEPIA;
+		break;
+	case EFFECT_MODE_SEPIA:
+		next = EFFECT_MODE_POSTERIZE;
+		break;
+	case EFFECT_MODE_POSTERIZE:
+		next = EFFECT_MODE_WHITEBOARD;
+		break;
+	case EFFECT_MODE_WHITEBOARD:
+		next = EFFECT_MODE_BLACKBOARD;
+		break;
+	case EFFECT_MODE_BLACKBOARD:
+		next = EFFECT_MODE_AQUA;
+		break;
+	case EFFECT_MODE_AQUA:
+		next = EFFECT_MODE_NONE;
+		break;
+	}
+
+	current_effect = next;
+	return next;
+}
+
+void error_msg_cb(void* context)
+{
+	printf("%s \n", __PRETTY_FUNCTION__);
+}
+
+void shutter_msg_cb(void* context)
+{
+	printf("%s \n", __PRETTY_FUNCTION__);
+}
+
+void zoom_msg_cb(void* context, int32_t new_zoom_level)
+{
+	printf("%s \n", __PRETTY_FUNCTION__);
+
+	CameraControl* cc = static_cast<CameraControl*>(context);
+	static int zoom;
+	android_camera_get_current_zoom(cc, &zoom);
+	printf("\t Current zoom: %d\n", zoom);
+	current_zoom_level = new_zoom_level;
+}
+
+void autofocus_msg_cb(void* context)
+{
+	printf("%s \n", __PRETTY_FUNCTION__);
+}
+
+void raw_data_cb(void* data, uint32_t data_size, void* context)
+{
+	printf("%s: %d \n", __PRETTY_FUNCTION__, data_size);
+}
+
+void jpeg_data_cb(void* data, uint32_t data_size, void* context)
+{
+	printf("%s: %d \n", __PRETTY_FUNCTION__, data_size);
+
+	char fn[256];
+	sprintf(fn, "/data/shot_%d.jpeg", shot_counter);
+	int fd = open(fn, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
+	write(fd, data, data_size);
+	close(fd);
+	shot_counter++;
+
+	CameraControl* cc = static_cast<CameraControl*>(context);
+	android_camera_start_preview(cc);
+}
+
+void size_cb(void* ctx, int width, int height)
+{
+	printf("Supported size: [%d,%d]\n", width, height);
+}
+
+void preview_texture_needs_update_cb(void* ctx)
+{
+	new_camera_frame_available = true;
+}
+
+void on_new_input_event(Event* event, void* context)
+{
+    assert(context);
+
+    if (event->type == KEY_EVENT_TYPE && event->action == ISCL_KEY_EVENT_ACTION_UP) {
+	    printf("We have got a key event: %d \n", event->details.key.key_code);
+
+	    CameraControl* cc = static_cast<CameraControl*>(context);
+
+	    switch(event->details.key.key_code) {
+	    case ISCL_KEYCODE_VOLUME_UP:
+		    printf("\tZooming in now.\n");
+		    android_camera_start_zoom(cc, current_zoom_level+1);
+		    break;
+	    case ISCL_KEYCODE_VOLUME_DOWN:
+		    printf("\tZooming out now.\n");
+		    android_camera_start_zoom(cc, current_zoom_level-1);
+		    break;
+	    case ISCL_KEYCODE_POWER:
+		    printf("\tTaking a photo now.\n");
+		    android_camera_take_snapshot(cc);
+		    break;
+	    case ISCL_KEYCODE_HEADSETHOOK:
+		    printf("\tSwitching effect.\n");
+		    android_camera_set_effect_mode(cc, next_effect());
+	    }
+    } else if (event->type == MOTION_EVENT_TYPE &&
+		    event->details.motion.pointer_count == 1) {
+	    if ((event->action & ISCL_MOTION_EVENT_ACTION_MASK) == ISCL_MOTION_EVENT_ACTION_UP) {
+		    printf("\tMotion event(Action up): (%f, %f) \n",
+				    event->details.motion.pointer_coordinates[0].x,
+				    event->details.motion.pointer_coordinates[0].y);
+	    }
+
+	    if ((event->action & ISCL_MOTION_EVENT_ACTION_MASK) == ISCL_MOTION_EVENT_ACTION_DOWN) {
+		    printf("\tMotion event(Action down): (%f, %f) \n",
+				    event->details.motion.pointer_coordinates[0].x,
+				    event->details.motion.pointer_coordinates[0].y);
+	    }
+    }
+}
+
+struct ClientWithSurface
+{
+	SfClient* client;
+	SfSurface* surface;
+};
+
+ClientWithSurface client_with_surface(bool setup_surface_with_egl)
+{
+	ClientWithSurface cs = ClientWithSurface();
+
+	cs.client = sf_client_create();
+
+	if (!cs.client) {
+		printf("Problem creating client ... aborting now.");
+		return cs;
+	}
+
+	static const size_t primary_display = 0;
+
+	SfSurfaceCreationParameters params = {
+		0,
+		0,
+		(int) sf_get_display_width(primary_display),
+		(int) sf_get_display_height(primary_display),
+		-1, //PIXEL_FORMAT_RGBA_8888,
+		15000,
+		0.5f,
+		setup_surface_with_egl, // Do not associate surface with egl, will be done by camera HAL
+		"CameraCompatLayerTestSurface"
+	};
+
+	cs.surface = sf_surface_create(cs.client, &params);
+
+	if (!cs.surface) {
+		printf("Problem creating surface ... aborting now.");
+		return cs;
+	}
+
+	sf_surface_make_current(cs.surface);
+
+	return cs;
+}
+
+#define PRINT_GLERROR() printf("GL error@%d: %x\n", __LINE__, glGetError());
+
+struct RenderData
+{
+	static const char* vertex_shader()
+	{
+		return
+			"#extension GL_OES_EGL_image_external : require              \n"
+			"attribute vec4 a_position;                                  \n"
+			"attribute vec2 a_texCoord;                                  \n"
+			"uniform mat4 m_texMatrix;                                   \n"
+			"varying vec2 v_texCoord;                                    \n"
+			"varying float topDown;                                      \n"
+			"void main()                                                 \n"
+			"{                                                           \n"
+			"   gl_Position = a_position;                                \n"
+			"   v_texCoord = a_texCoord;                                 \n"
+			//                "   v_texCoord = (m_texMatrix * vec4(a_texCoord, 0.0, 1.0)).xy;\n"
+			//"   topDown = v_texCoord.y;                                  \n"
+			"}                                                           \n";
+	}
+
+	static const char* fragment_shader()
+	{
+		return
+			"#extension GL_OES_EGL_image_external : require      \n"
+			"precision mediump float;                            \n"
+			"varying vec2 v_texCoord;                            \n"
+			"uniform samplerExternalOES s_texture;               \n"
+			"void main()                                         \n"
+			"{                                                   \n"
+			"  gl_FragColor = texture2D( s_texture, v_texCoord );\n"
+			"}                                                   \n";
+	}
+
+	static GLuint loadShader(GLenum shaderType, const char* pSource)
+	{
+		GLuint shader = glCreateShader(shaderType);
+
+		if (shader) {
+			glShaderSource(shader, 1, &pSource, NULL);
+			glCompileShader(shader);
+			GLint compiled = 0;
+			glGetShaderiv(shader, GL_COMPILE_STATUS, &compiled);
+
+			if (!compiled) {
+				GLint infoLen = 0;
+				glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &infoLen);
+				if (infoLen) {
+					char* buf = (char*) malloc(infoLen);
+					if (buf) {
+						glGetShaderInfoLog(shader, infoLen, NULL, buf);
+						fprintf(stderr, "Could not compile shader %d:\n%s\n",
+								shaderType, buf);
+						free(buf);
+					}
+					glDeleteShader(shader);
+					shader = 0;
+				}
+			}
+		} else {
+			printf("Error, during shader creation: %i\n", glGetError());
+		}
+
+		return shader;
+	}
+
+	static GLuint create_program(const char* pVertexSource, const char* pFragmentSource)
+	{
+		GLuint vertexShader = loadShader(GL_VERTEX_SHADER, pVertexSource);
+		if (!vertexShader) {
+			printf("vertex shader not compiled\n");
+			return 0;
+		}
+
+		GLuint pixelShader = loadShader(GL_FRAGMENT_SHADER, pFragmentSource);
+		if (!pixelShader) {
+			printf("frag shader not compiled\n");
+			return 0;
+		}
+
+		GLuint program = glCreateProgram();
+		if (program) {
+			glAttachShader(program, vertexShader);
+			glAttachShader(program, pixelShader);
+			glLinkProgram(program);
+			GLint linkStatus = GL_FALSE;
+			glGetProgramiv(program, GL_LINK_STATUS, &linkStatus);
+
+			if (linkStatus != GL_TRUE) {
+				GLint bufLength = 0;
+				glGetProgramiv(program, GL_INFO_LOG_LENGTH, &bufLength);
+				if (bufLength) {
+					char* buf = (char*) malloc(bufLength);
+					if (buf) {
+						glGetProgramInfoLog(program, bufLength, NULL, buf);
+						fprintf(stderr, "Could not link program:\n%s\n", buf);
+						free(buf);
+					}
+				}
+				glDeleteProgram(program);
+				program = 0;
+			}
+		}
+
+		return program;
+	}
+
+	RenderData() : program_object(create_program(vertex_shader(), fragment_shader()))
+	{
+		position_loc = glGetAttribLocation(program_object, "a_position");
+		tex_coord_loc = glGetAttribLocation(program_object, "a_texCoord");
+		sampler_loc = glGetUniformLocation(program_object, "s_texture");
+		matrix_loc = glGetUniformLocation(program_object, "m_texMatrix");
+	}
+
+	// Handle to a program object
+	GLuint program_object;
+	// Attribute locations
+	GLint  position_loc;
+	GLint  tex_coord_loc;
+	// Sampler location
+	GLint sampler_loc;
+	// Matrix location
+	GLint matrix_loc;
+};
+
+int main(int argc, char** argv)
+{
+	CameraControlListener listener;
+	memset(&listener, 0, sizeof(listener));
+	listener.on_msg_error_cb = error_msg_cb;
+	listener.on_msg_shutter_cb = shutter_msg_cb;
+	listener.on_msg_focus_cb = autofocus_msg_cb;
+	listener.on_msg_zoom_cb = zoom_msg_cb;
+
+	listener.on_data_raw_image_cb = raw_data_cb;
+	listener.on_data_compressed_image_cb = jpeg_data_cb;
+	listener.on_preview_texture_needs_update_cb = preview_texture_needs_update_cb;
+	CameraControl* cc = android_camera_connect_to(FRONT_FACING_CAMERA_TYPE,
+			&listener);
+
+	if (cc == NULL) {
+		printf("Problem connecting to camera");
+		return 1;
+	}
+
+	listener.context = cc;
+
+	AndroidEventListener event_listener;
+	event_listener.on_new_event = on_new_input_event;
+	event_listener.context = cc;
+
+	InputStackConfiguration input_configuration = { true, 25000 };
+
+	android_input_stack_initialize(&event_listener, &input_configuration);
+	android_input_stack_start();
+
+	android_camera_dump_parameters(cc);
+	android_camera_enumerate_supported_picture_sizes(cc, size_cb, NULL);
+	android_camera_enumerate_supported_preview_sizes(cc, size_cb, NULL);
+
+	int min_fps, max_fps, current_fps;
+	android_camera_get_preview_fps_range(cc, &min_fps, &max_fps);
+	printf("Preview fps range: [%d,%d]\n", min_fps, max_fps);
+	android_camera_get_preview_fps(cc, &current_fps);
+	printf("Current preview fps range: %d\n", current_fps);
+
+	android_camera_set_preview_size(cc, 960, 720);
+
+	int width, height;
+	android_camera_get_preview_size(cc, &width, &height);
+	printf("Current preview size: [%d,%d]\n", width, height);
+	android_camera_get_picture_size(cc, &width, &height);
+	printf("Current picture size: [%d,%d]\n", width, height);
+	int zoom;
+	android_camera_get_current_zoom(cc, &zoom);
+	printf("Current zoom: %d \n", zoom);
+	android_camera_get_max_zoom(cc, &zoom);
+	printf("Max zoom: %d \n", zoom);
+
+	EffectMode effect_mode;
+	FlashMode flash_mode;
+	WhiteBalanceMode wb_mode;
+	SceneMode scene_mode;
+	AutoFocusMode af_mode;
+	CameraPixelFormat pixel_format;
+	android_camera_get_effect_mode(cc, &effect_mode);
+	android_camera_get_flash_mode(cc, &flash_mode);
+	android_camera_get_white_balance_mode(cc, &wb_mode);
+	android_camera_get_scene_mode(cc, &scene_mode);
+	android_camera_get_auto_focus_mode(cc, &af_mode);
+	android_camera_get_preview_format(cc, &pixel_format);
+	printf("Current effect mode: %d \n", effect_mode);
+	printf("Current flash mode: %d \n", flash_mode);
+	printf("Current wb mode: %d \n", wb_mode);
+	printf("Current scene mode: %d \n", scene_mode);
+	printf("Current af mode: %d \n", af_mode);
+	printf("Current preview pixel format: %d \n", pixel_format);
+	//android_camera_set_focus_region(cc, -200, -200, 200, 200, 300);
+
+	ClientWithSurface cs = client_with_surface(true /* Associate surface with egl. */);
+
+	if (!cs.surface) {
+		printf("Problem acquiring surface for preview");
+		return 1;
+	}
+
+	EGLDisplay disp = sf_client_get_egl_display(cs.client);
+	EGLSurface surface = sf_surface_get_egl_surface(cs.surface);
+
+	RenderData render_data;
+	GLuint preview_texture_id;
+	glGenTextures(1, &preview_texture_id);
+	glClearColor(1.0, 0., 0.5, 1.);
+	glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(
+			GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(
+			GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	android_camera_set_preview_texture(cc, preview_texture_id);
+	android_camera_set_effect_mode(cc, EFFECT_MODE_SEPIA);
+	android_camera_set_flash_mode(cc, FLASH_MODE_AUTO);
+	android_camera_set_auto_focus_mode(cc, AUTO_FOCUS_MODE_CONTINUOUS_PICTURE);
+	android_camera_start_preview(cc);
+
+	GLfloat transformation_matrix[16];
+	android_camera_get_preview_texture_transformation(cc, transformation_matrix);
+	glUniformMatrix4fv(render_data.matrix_loc, 1, GL_FALSE, transformation_matrix);
+
+	printf("Started camera preview.\n");
+
+	while (true) {
+		/*if (new_camera_frame_available)
+		  {
+		  printf("Updating texture");
+		  new_camera_frame_available = false;
+		  }*/
+		static GLfloat vVertices[] = { 0.0f, 0.0f, 0.0f, // Position 0
+			0.0f, 0.0f, // TexCoord 0
+			0.0f, 1.0f, 0.0f, // Position 1
+			0.0f, 1.0f, // TexCoord 1
+			1.0f, 1.0f, 0.0f, // Position 2
+			1.0f, 1.0f, // TexCoord 2
+			1.0f, 0.0f, 0.0f, // Position 3
+			1.0f, 0.0f // TexCoord 3
+		};
+
+		GLushort indices[] = { 0, 1, 2, 0, 2, 3 };
+
+		// Set the viewport
+		// Clear the color buffer
+		glClear(GL_COLOR_BUFFER_BIT);
+		// Use the program object
+		glUseProgram(render_data.program_object);
+		// Enable attributes
+		glEnableVertexAttribArray(render_data.position_loc);
+		glEnableVertexAttribArray(render_data.tex_coord_loc);
+		// Load the vertex position
+		glVertexAttribPointer(render_data.position_loc,
+				3,
+				GL_FLOAT,
+				GL_FALSE,
+				5 * sizeof(GLfloat),
+				vVertices);
+		// Load the texture coordinate
+		glVertexAttribPointer(render_data.tex_coord_loc,
+				2,
+				GL_FLOAT,
+				GL_FALSE,
+				5 * sizeof(GLfloat),
+				vVertices+3);
+
+		glActiveTexture(GL_TEXTURE0);
+		// Set the sampler texture unit to 0
+		glUniform1i(render_data.sampler_loc, 0);
+		glUniform1i(render_data.matrix_loc, 0);
+		android_camera_update_preview_texture(cc);
+		glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, indices);
+		glDisableVertexAttribArray(render_data.position_loc);
+		glDisableVertexAttribArray(render_data.tex_coord_loc);
+
+		eglSwapBuffers(disp, surface);
+	}
+}

--- a/hybris/Makefile.am
+++ b/hybris/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = include common hardware libsync egl glesv2 ui sf input tests
+SUBDIRS = include common hardware libsync egl glesv2 ui sf input camera tests
 
 MAINTAINERCLEANFILES = \
 	aclocal.m4 compile config.guess config.sub \

--- a/hybris/camera/Makefile.am
+++ b/hybris/camera/Makefile.am
@@ -1,0 +1,14 @@
+lib_LTLIBRARIES = \
+	libcamera.la
+
+libcamera_la_SOURCES = camera.c
+libcamera_la_CFLAGS = -I$(top_srcdir)/include
+if WANT_TRACE
+libcamera_la_CFLAGS += -DDEBUG
+endif
+if WANT_DEBUG
+libcamera_la_CFLAGS += -ggdb -O0
+endif
+libcamera_la_LDFLAGS = \
+	$(top_builddir)/common/libhybris-common.la \
+	-version-info "1":"0":"0"

--- a/hybris/camera/camera.c
+++ b/hybris/camera/camera.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2013 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authored by: Michael Frey <michael.frey@canonical.com>
+ *              Ricardo Salveti de Araujo <ricardo.salveti@canonical.com>
+ */
+
+#include <dlfcn.h>
+#include <stddef.h>
+
+#include <hybris/internal/binding.h>
+#include <hybris/camera/camera_compatibility_layer.h>
+#include <hybris/camera/camera_compatibility_layer_capabilities.h>
+#include <hybris/surface_flinger/surface_flinger_compatibility_layer.h>
+
+#define COMPAT_LIBRARY_PATH "/system/lib/libcamera_compat_layer.so"
+
+#ifdef __ARM_PCS_VFP
+#define FP_ATTRIB __attribute__((pcs("aapcs")))
+#else
+#define FP_ATTRIB
+#endif
+
+HYBRIS_LIBRARY_INITIALIZE(camera, COMPAT_LIBRARY_PATH);
+
+HYBRIS_IMPLEMENT_FUNCTION0(camera, int, android_camera_get_number_of_devices);
+HYBRIS_IMPLEMENT_FUNCTION2(camera, struct CameraControl*, android_camera_connect_to,
+	CameraType, struct CameraControlListener*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(camera, android_camera_disconnect,
+	struct CameraControl*);
+HYBRIS_IMPLEMENT_FUNCTION1(camera, int, android_camera_lock, struct CameraControl*);
+HYBRIS_IMPLEMENT_FUNCTION1(camera, int, android_camera_unlock, struct CameraControl*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(camera, android_camera_delete, struct CameraControl*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(camera, android_camera_dump_parameters,
+	struct CameraControl*);
+
+// Setters
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_set_effect_mode,
+	struct CameraControl*, EffectMode);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_set_flash_mode,
+	struct CameraControl*, FlashMode);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_set_white_balance_mode,
+	struct CameraControl*, WhiteBalanceMode);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_set_scene_mode,
+	struct CameraControl*, SceneMode);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_set_auto_focus_mode,
+	struct CameraControl*, AutoFocusMode);
+HYBRIS_IMPLEMENT_VOID_FUNCTION3(camera, android_camera_set_picture_size,
+	struct CameraControl*, int, int);
+HYBRIS_IMPLEMENT_VOID_FUNCTION3(camera, android_camera_set_preview_size,
+	struct CameraControl*, int, int);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_set_display_orientation,
+	struct CameraControl*, int32_t);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_set_preview_texture,
+	struct CameraControl*, int);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_set_preview_surface,
+	struct CameraControl*, struct SfSurface*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_set_focus_region,
+	struct CameraControl*, FocusRegion*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(camera, android_camera_reset_focus_region,
+	struct CameraControl*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_set_preview_fps,
+	struct CameraControl*, int);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_set_rotation,
+	struct CameraControl*, int);
+HYBRIS_IMPLEMENT_VOID_FUNCTION3(camera, android_camera_set_video_size,
+	struct CameraControl*, int, int);
+
+// Getters
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_get_effect_mode,
+	struct CameraControl*, EffectMode*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_get_flash_mode,
+	struct CameraControl*, FlashMode*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_get_white_balance_mode,
+	struct CameraControl*, WhiteBalanceMode*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_get_scene_mode,
+	struct CameraControl*, SceneMode*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_get_auto_focus_mode,
+	struct CameraControl*, AutoFocusMode*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_get_max_zoom,
+	struct CameraControl*, int*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION3(camera, android_camera_get_picture_size,
+	struct CameraControl*, int*, int*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION3(camera, android_camera_get_preview_size,
+	struct CameraControl*, int*, int*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION3(camera, android_camera_get_preview_fps_range,
+	struct CameraControl*, int*, int*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_get_preview_fps,
+	struct CameraControl*, int*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_get_preview_texture_transformation,
+	struct CameraControl*, float*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION3(camera, android_camera_get_video_size,
+	struct CameraControl*, int*, int*);
+
+// Enumerators
+HYBRIS_IMPLEMENT_VOID_FUNCTION3(camera, android_camera_enumerate_supported_picture_sizes,
+	struct CameraControl*, size_callback, void*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION3(camera, android_camera_enumerate_supported_preview_sizes,
+	struct CameraControl*, size_callback, void*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION3(camera, android_camera_enumerate_supported_video_sizes,
+	struct CameraControl*, size_callback, void*);
+
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(camera, android_camera_update_preview_texture, struct CameraControl*);
+
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(camera, android_camera_start_preview, struct CameraControl*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(camera, android_camera_stop_preview, struct CameraControl*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(camera, android_camera_start_autofocus, struct CameraControl*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(camera, android_camera_stop_autofocus, struct CameraControl*);
+
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_start_zoom, struct CameraControl*, int32_t);
+HYBRIS_IMPLEMENT_VOID_FUNCTION2(camera, android_camera_set_zoom, struct CameraControl*, int32_t);
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(camera, android_camera_stop_zoom, struct CameraControl*);
+HYBRIS_IMPLEMENT_VOID_FUNCTION1(camera, android_camera_take_snapshot, struct CameraControl*);

--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -141,6 +141,7 @@ AC_CONFIG_FILES([
 	ui/Makefile
 	sf/Makefile
 	input/Makefile
+	camera/Makefile
 	include/Makefile
 	tests/Makefile
 ])

--- a/hybris/include/Makefile.am
+++ b/hybris/include/Makefile.am
@@ -80,6 +80,12 @@ inputinclude_HEADERS = \
 	hybris/input/input_stack_compatibility_layer_flags_motion.h \
 	hybris/input/input_stack_compatibility_layer.h
 
+cameraincludedir = $(includedir)/hybris/camera
+camerainclude_HEADERS = \
+	hybris/camera/camera_compatibility_layer_capabilities.h \
+	hybris/camera/camera_compatibility_layer_configuration_translator.h \
+	hybris/camera/camera_compatibility_layer.h
+
 android/version.h: android/version.h.in
 	@sed -e "s|\@android_version\@|$(ANDROID_VERSION)|" $<> $@
 

--- a/hybris/include/hybris/camera/camera_compatibility_layer.h
+++ b/hybris/include/hybris/camera/camera_compatibility_layer.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2013 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authored by: Thomas Voss <thomas.voss@canonical.com>
+ */
+
+#ifndef CAMERA_COMPATIBILITY_LAYER_H_
+#define CAMERA_COMPATIBILITY_LAYER_H_
+
+#include <stdint.h>
+#include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    // Forward declarations
+    struct SfSurface;
+
+    typedef enum
+    {
+        // This camera has higher quality and features like high resolution and flash
+        BACK_FACING_CAMERA_TYPE,
+        // The camera that is on the same side as the touch display. Usually used for video calls
+        FRONT_FACING_CAMERA_TYPE
+    } CameraType;
+
+    struct CameraControl;
+
+    typedef void (*on_msg_error)(void* context);
+    typedef void (*on_msg_shutter)(void* context);
+    typedef void (*on_msg_focus)(void* context);
+    typedef void (*on_msg_zoom)(void* context, int32_t new_zoom_level);
+
+    typedef void (*on_data_raw_image)(void* data, uint32_t data_size, void* context);
+    typedef void (*on_data_compressed_image)(void* data, uint32_t data_size, void* context);
+    typedef void (*on_preview_texture_needs_update)(void* context);
+
+    struct CameraControlListener
+    {
+        // Called whenever an error occurs while the camera HAL executes a command
+        on_msg_error on_msg_error_cb;
+        // Called while taking a picture when the shutter has been triggered
+        on_msg_shutter on_msg_shutter_cb;
+        // Called while focusing
+        on_msg_focus on_msg_focus_cb;
+        // Called while zooming
+        on_msg_zoom on_msg_zoom_cb;
+
+        // Raw image data (Bayer pattern) is reported over this callback
+        on_data_raw_image on_data_raw_image_cb;
+        // JPEG-compressed image is reported over this callback
+        on_data_compressed_image on_data_compressed_image_cb;
+
+        // If a texture has been set as a destination for preview frames,
+        // this callback is invoked whenever a new buffer from the camera is available
+        // and needs to be uploaded to the texture by means of calling
+        // android_camera_update_preview_texture. Please note that this callback can
+        // be invoked on any thread, and android_camera_update_preview_texture must only
+        // be called on the thread that setup the EGL/GL context.
+        on_preview_texture_needs_update on_preview_texture_needs_update_cb;
+
+        void* context;
+    };
+
+    // Initializes a connection to the camera, returns NULL on error.
+    struct CameraControl* android_camera_connect_to(CameraType camera_type, struct CameraControlListener* listener);
+
+    // Disconnects the camera and deletes the pointer
+    void android_camera_disconnect(struct CameraControl* control);
+
+    int android_camera_lock(struct CameraControl* control);
+    int android_camera_unlock(struct CameraControl* control);
+
+    // Deletes the CameraControl
+    void android_camera_delete(struct CameraControl* control);
+
+    // Passes the rotation r of the display in [°] relative to the camera to the camera HAL. r \in [0, 359].
+    void android_camera_set_display_orientation(struct CameraControl* control, int32_t clockwise_rotation_degree);
+
+    // Prepares the camera HAL to display preview images to the
+    // supplied surface/texture in a H/W-acclerated way.  New frames
+    // are reported via the
+    // 'on_preview_texture_needs_update'-callback, and clients of this
+    // API should invoke android_camera_update_preview_texture
+    // subsequently. Please note that the texture is bound automatically by the underlying
+    // implementation.
+    void android_camera_set_preview_texture(struct CameraControl* control, int texture_id);
+
+    // Reads out the transformation matrix that needs to be applied when displaying the texture
+    void android_camera_get_preview_texture_transformation(struct CameraControl* control, float m[16]);
+
+    // Updates the texture to the last received frame and binds the texture
+    void android_camera_update_preview_texture(struct CameraControl* control);
+
+    // Prepares the camera HAL to display preview images to the supplied surface/texture in a H/W-acclerated way.
+    void android_camera_set_preview_surface(struct CameraControl* control, struct SfSurface* surface);
+
+    // Starts the camera preview
+    void android_camera_start_preview(struct CameraControl* control);
+
+    // Stops the camera preview
+    void android_camera_stop_preview(struct CameraControl* control);
+
+    // Starts an autofocus operation of the camera, results are reported via callback.
+    void android_camera_start_autofocus(struct CameraControl* control);
+
+    // Stops an ongoing autofocus operation.
+    void android_camera_stop_autofocus(struct CameraControl* control);
+
+    // Starts a zooming operation, zoom values are absolute, valid values [1, \infty].
+    void android_camera_start_zoom(struct CameraControl* control, int32_t zoom);
+
+    // Stops an ongoing zoom operation.
+    void android_camera_stop_zoom(struct CameraControl* control);
+
+    // Adjust the zoom level immediately as opposed to smoothly zoomin gin.
+    void android_camera_set_zoom(struct CameraControl* control, int32_t zoom);
+
+    // Takes a picture and reports back image data via
+    // callback. Please note that this stops the preview and thus, the
+    // preview needs to be restarted after the picture operation has
+    // completed. Ideally, this is done from the raw data callback.
+    void android_camera_take_snapshot(struct CameraControl* control);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CAMERA_COMPATIBILITY_LAYER_H_

--- a/hybris/include/hybris/camera/camera_compatibility_layer_capabilities.h
+++ b/hybris/include/hybris/camera/camera_compatibility_layer_capabilities.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2013 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authored by: Thomas Voss <thomas.voss@canonical.com>
+ */
+
+#ifndef CAMERA_COMPATIBILITY_LAYER_CONFIGURATION_H_
+#define CAMERA_COMPATIBILITY_LAYER_CONFIGURATION_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    struct CameraControl;
+
+    typedef enum
+    {
+        FLASH_MODE_OFF,
+        FLASH_MODE_AUTO,
+        FLASH_MODE_ON,
+        FLASH_MODE_TORCH
+    } FlashMode;
+
+    typedef enum
+    {
+        WHITE_BALANCE_MODE_AUTO,
+        WHITE_BALANCE_MODE_DAYLIGHT,
+        WHITE_BALANCE_MODE_CLOUDY_DAYLIGHT,
+        WHITE_BALANCE_MODE_FLUORESCENT,
+        WHITE_BALANCE_MODE_INCANDESCENT
+    } WhiteBalanceMode;
+
+    typedef enum
+    {
+        SCENE_MODE_AUTO,
+        SCENE_MODE_ACTION,
+        SCENE_MODE_NIGHT,
+        SCENE_MODE_PARTY,
+        SCENE_MODE_SUNSET
+    } SceneMode;
+
+    typedef enum
+    {
+        AUTO_FOCUS_MODE_OFF,
+        AUTO_FOCUS_MODE_CONTINUOUS_VIDEO,
+        AUTO_FOCUS_MODE_AUTO,
+        AUTO_FOCUS_MODE_MACRO,
+        AUTO_FOCUS_MODE_CONTINUOUS_PICTURE,
+        AUTO_FOCUS_MODE_INFINITY
+    } AutoFocusMode;
+
+    typedef enum
+    {
+        EFFECT_MODE_NONE,
+        EFFECT_MODE_MONO,
+        EFFECT_MODE_NEGATIVE,
+        EFFECT_MODE_SOLARIZE,
+        EFFECT_MODE_SEPIA,
+        EFFECT_MODE_POSTERIZE,
+        EFFECT_MODE_WHITEBOARD,
+        EFFECT_MODE_BLACKBOARD,
+        EFFECT_MODE_AQUA
+    } EffectMode;
+
+    typedef enum
+    {
+        CAMERA_PIXEL_FORMAT_YUV422SP,
+        CAMERA_PIXEL_FORMAT_YUV420SP,
+        CAMERA_PIXEL_FORMAT_YUV422I,
+        CAMERA_PIXEL_FORMAT_YUV420P,
+        CAMERA_PIXEL_FORMAT_RGB565,
+        CAMERA_PIXEL_FORMAT_RGBA8888,
+        CAMERA_PIXEL_FORMAT_BAYER_RGGB
+    } CameraPixelFormat;
+
+    typedef struct
+    {
+        int top;
+        int left;
+        int bottom;
+        int right;
+        int weight;
+    } FocusRegion;
+
+    typedef void (*size_callback)(void* ctx, int width, int height);
+
+    // Dumps the camera parameters to stdout.
+    void android_camera_dump_parameters(struct CameraControl* control);
+
+    // Query camera parameters
+    int android_camera_get_number_of_devices();
+    void android_camera_enumerate_supported_preview_sizes(struct CameraControl* control, size_callback cb, void* ctx);
+    void android_camera_get_preview_fps_range(struct CameraControl* control, int* min, int* max);
+    void android_camera_get_preview_fps(struct CameraControl* control, int* fps);
+    void android_camera_enumerate_supported_picture_sizes(struct CameraControl* control, size_callback cb, void* ctx);
+    void android_camera_get_preview_size(struct CameraControl* control, int* width, int* height);
+    void android_camera_get_picture_size(struct CameraControl* control, int* width, int* height);
+
+    void android_camera_get_current_zoom(struct CameraControl* control, int* zoom);
+    void android_camera_get_max_zoom(struct CameraControl* control, int* max_zoom);
+
+    void android_camera_get_effect_mode(struct CameraControl* control, EffectMode* mode);
+    void android_camera_get_flash_mode(struct CameraControl* control, FlashMode* mode);
+    void android_camera_get_white_balance_mode(struct CameraControl* control, WhiteBalanceMode* mode);
+    void android_camera_get_scene_mode(struct CameraControl* control, SceneMode* mode);
+    void android_camera_get_auto_focus_mode(struct CameraControl* control, AutoFocusMode* mode);
+    void android_camera_get_preview_format(struct CameraControl* control, CameraPixelFormat* format);
+
+    // Adjusts camera parameters
+    void android_camera_set_preview_size(struct CameraControl* control, int width, int height);
+    void android_camera_set_preview_fps(struct CameraControl* control, int fps);
+    void android_camera_set_picture_size(struct CameraControl* control, int width, int height);
+    void android_camera_set_effect_mode(struct CameraControl* control, EffectMode mode);
+    void android_camera_set_flash_mode(struct CameraControl* control, FlashMode mode);
+    void android_camera_set_white_balance_mode(struct CameraControl* control, WhiteBalanceMode mode);
+    void android_camera_set_scene_mode(struct CameraControl* control, SceneMode mode);
+    void android_camera_set_auto_focus_mode(struct CameraControl* control, AutoFocusMode mode);
+    void android_camera_set_preview_format(struct CameraControl* control, CameraPixelFormat format);
+
+    void android_camera_set_focus_region(struct CameraControl* control, FocusRegion* region);
+    void android_camera_reset_focus_region(struct CameraControl* control);
+
+    // Set photo metadata
+    void android_camera_set_rotation(struct CameraControl* control, int rotation);
+
+    // Video support
+    void android_camera_enumerate_supported_video_sizes(struct CameraControl* control, size_callback cb, void* ctx);
+    void android_camera_get_video_size(struct CameraControl* control, int* width, int* height);
+    void android_camera_set_video_size(struct CameraControl* control, int width, int height);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CAMERA_COMPATIBILITY_LAYER_CONFIGURATION_H_

--- a/hybris/include/hybris/camera/camera_compatibility_layer_configuration_translator.h
+++ b/hybris/include/hybris/camera/camera_compatibility_layer_configuration_translator.h
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2013 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authored by: Thomas Voss <thomas.voss@canonical.com>
+ */
+
+#ifndef CAMERA_COMPATIBILITY_LAYER_CONFIGURATION_TRANSLATOR_H_
+#define CAMERA_COMPATIBILITY_LAYER_CONFIGURATION_TRANSLATOR_H_
+
+#include <hybris/camera/camera_compatibility_layer_capabilities.h>
+
+#include <camera/CameraParameters.h>
+#include <utils/KeyedVector.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    static const char* effect_modes[] =
+    {
+        android::CameraParameters::EFFECT_NONE,
+        android::CameraParameters::EFFECT_MONO,
+        android::CameraParameters::EFFECT_NEGATIVE,
+        android::CameraParameters::EFFECT_SOLARIZE,
+        android::CameraParameters::EFFECT_SEPIA,
+        android::CameraParameters::EFFECT_POSTERIZE,
+        android::CameraParameters::EFFECT_WHITEBOARD,
+        android::CameraParameters::EFFECT_BLACKBOARD,
+        android::CameraParameters::EFFECT_AQUA
+    };
+
+    android::KeyedVector<android::String8, EffectMode> init_effect_modes_lut()
+    {
+        android::KeyedVector<android::String8, EffectMode> m;
+        m.add(android::String8(android::CameraParameters::EFFECT_NONE), EFFECT_MODE_NONE);
+        m.add(android::String8(android::CameraParameters::EFFECT_MONO), EFFECT_MODE_MONO);
+        m.add(android::String8(android::CameraParameters::EFFECT_NEGATIVE), EFFECT_MODE_NEGATIVE);
+        m.add(android::String8(android::CameraParameters::EFFECT_SOLARIZE), EFFECT_MODE_SOLARIZE);
+        m.add(android::String8(android::CameraParameters::EFFECT_SEPIA), EFFECT_MODE_SEPIA);
+        m.add(android::String8(android::CameraParameters::EFFECT_POSTERIZE), EFFECT_MODE_POSTERIZE);
+        m.add(android::String8(android::CameraParameters::EFFECT_WHITEBOARD), EFFECT_MODE_WHITEBOARD);
+        m.add(android::String8(android::CameraParameters::EFFECT_BLACKBOARD), EFFECT_MODE_BLACKBOARD);
+        m.add(android::String8(android::CameraParameters::EFFECT_AQUA), EFFECT_MODE_AQUA);
+
+        return m;
+    }
+
+    static android::KeyedVector<android::String8, EffectMode> effect_modes_lut = init_effect_modes_lut();
+
+    static const char* white_balance_modes[] =
+    {
+        android::CameraParameters::WHITE_BALANCE_AUTO,
+        android::CameraParameters::WHITE_BALANCE_DAYLIGHT,
+        android::CameraParameters::WHITE_BALANCE_CLOUDY_DAYLIGHT,
+        android::CameraParameters::WHITE_BALANCE_FLUORESCENT,
+        android::CameraParameters::WHITE_BALANCE_INCANDESCENT
+    };
+
+    android::KeyedVector<android::String8, WhiteBalanceMode> init_white_balance_modes_lut()
+    {
+        android::KeyedVector<android::String8, WhiteBalanceMode> m;
+        m.add(android::String8(android::CameraParameters::WHITE_BALANCE_AUTO), WHITE_BALANCE_MODE_AUTO);
+        m.add(android::String8(android::CameraParameters::WHITE_BALANCE_DAYLIGHT), WHITE_BALANCE_MODE_DAYLIGHT);
+        m.add(android::String8(android::CameraParameters::WHITE_BALANCE_CLOUDY_DAYLIGHT), WHITE_BALANCE_MODE_CLOUDY_DAYLIGHT);
+        m.add(android::String8(android::CameraParameters::WHITE_BALANCE_FLUORESCENT), WHITE_BALANCE_MODE_FLUORESCENT);
+        m.add(android::String8(android::CameraParameters::WHITE_BALANCE_INCANDESCENT), WHITE_BALANCE_MODE_INCANDESCENT);
+        return m;
+    }
+
+    static android::KeyedVector<android::String8, WhiteBalanceMode> white_balance_modes_lut = init_white_balance_modes_lut();
+
+    static const char* flash_modes[] =
+    {
+        android::CameraParameters::FLASH_MODE_OFF,
+        android::CameraParameters::FLASH_MODE_AUTO,
+        android::CameraParameters::FLASH_MODE_ON,
+        android::CameraParameters::FLASH_MODE_TORCH
+    };
+
+    static android::KeyedVector<android::String8, FlashMode> init_flash_modes_lut()
+    {
+        android::KeyedVector<android::String8, FlashMode> m;
+        m.add(android::String8(android::CameraParameters::FLASH_MODE_OFF), FLASH_MODE_OFF);
+        m.add(android::String8(android::CameraParameters::FLASH_MODE_AUTO), FLASH_MODE_AUTO);
+        m.add(android::String8(android::CameraParameters::FLASH_MODE_ON), FLASH_MODE_ON);
+        m.add(android::String8(android::CameraParameters::FLASH_MODE_TORCH), FLASH_MODE_TORCH);
+
+        return m;
+    }
+
+    static android::KeyedVector<android::String8, FlashMode> flash_modes_lut = init_flash_modes_lut();
+
+    static const char* scene_modes[] =
+    {
+        android::CameraParameters::SCENE_MODE_AUTO,
+        android::CameraParameters::SCENE_MODE_ACTION,
+        android::CameraParameters::SCENE_MODE_NIGHT,
+        android::CameraParameters::SCENE_MODE_PARTY,
+        android::CameraParameters::SCENE_MODE_SUNSET
+    };
+
+    static android::KeyedVector<android::String8, SceneMode> init_scene_modes_lut()
+    {
+        android::KeyedVector<android::String8, SceneMode> m;
+        m.add(android::String8(android::CameraParameters::SCENE_MODE_AUTO), SCENE_MODE_AUTO);
+        m.add(android::String8(android::CameraParameters::SCENE_MODE_ACTION), SCENE_MODE_ACTION);
+        m.add(android::String8(android::CameraParameters::SCENE_MODE_NIGHT), SCENE_MODE_NIGHT);
+        m.add(android::String8(android::CameraParameters::SCENE_MODE_PARTY), SCENE_MODE_PARTY);
+        m.add(android::String8(android::CameraParameters::SCENE_MODE_SUNSET), SCENE_MODE_SUNSET);
+
+        return m;
+    }
+
+    static android::KeyedVector<android::String8, SceneMode> scene_modes_lut = init_scene_modes_lut();
+
+    static const char* auto_focus_modes[] =
+    {
+        android::CameraParameters::FOCUS_MODE_FIXED,
+        android::CameraParameters::FOCUS_MODE_CONTINUOUS_VIDEO,
+        android::CameraParameters::FOCUS_MODE_AUTO,
+        android::CameraParameters::FOCUS_MODE_MACRO,
+        android::CameraParameters::FOCUS_MODE_CONTINUOUS_PICTURE,
+        android::CameraParameters::FOCUS_MODE_INFINITY
+    };
+
+    static android::KeyedVector<android::String8, AutoFocusMode> init_auto_focus_modes_lut()
+    {
+        android::KeyedVector<android::String8, AutoFocusMode> m;
+        m.add(android::String8(android::CameraParameters::FOCUS_MODE_FIXED), AUTO_FOCUS_MODE_OFF);
+        m.add(android::String8(android::CameraParameters::FOCUS_MODE_CONTINUOUS_VIDEO), AUTO_FOCUS_MODE_CONTINUOUS_VIDEO);
+        m.add(android::String8(android::CameraParameters::FOCUS_MODE_AUTO), AUTO_FOCUS_MODE_AUTO);
+        m.add(android::String8(android::CameraParameters::FOCUS_MODE_MACRO), AUTO_FOCUS_MODE_MACRO);
+        m.add(android::String8(android::CameraParameters::FOCUS_MODE_CONTINUOUS_PICTURE), AUTO_FOCUS_MODE_CONTINUOUS_PICTURE);
+        m.add(android::String8(android::CameraParameters::FOCUS_MODE_INFINITY), AUTO_FOCUS_MODE_INFINITY);
+
+        return m;
+    }
+
+    static android::KeyedVector<android::String8, AutoFocusMode> auto_focus_modes_lut = init_auto_focus_modes_lut();
+
+    static const char* camera_pixel_formats[] =
+    {
+        android::CameraParameters::PIXEL_FORMAT_YUV422SP,
+        android::CameraParameters::PIXEL_FORMAT_YUV420SP,
+        android::CameraParameters::PIXEL_FORMAT_YUV422I,
+        android::CameraParameters::PIXEL_FORMAT_YUV420P,
+        android::CameraParameters::PIXEL_FORMAT_RGB565,
+        android::CameraParameters::PIXEL_FORMAT_RGBA8888,
+        android::CameraParameters::PIXEL_FORMAT_BAYER_RGGB
+    };
+
+    static android::KeyedVector<android::String8, CameraPixelFormat> init_pixel_formats_lut()
+    {
+        android::KeyedVector<android::String8, CameraPixelFormat> m;
+        m.add(android::String8(android::CameraParameters::PIXEL_FORMAT_YUV422SP), CAMERA_PIXEL_FORMAT_YUV422SP);
+        m.add(android::String8(android::CameraParameters::PIXEL_FORMAT_YUV420SP), CAMERA_PIXEL_FORMAT_YUV420SP);
+        m.add(android::String8(android::CameraParameters::PIXEL_FORMAT_YUV422I), CAMERA_PIXEL_FORMAT_YUV422I);
+        m.add(android::String8(android::CameraParameters::PIXEL_FORMAT_YUV420P), CAMERA_PIXEL_FORMAT_YUV420P);
+        m.add(android::String8(android::CameraParameters::PIXEL_FORMAT_RGB565), CAMERA_PIXEL_FORMAT_RGB565);
+        m.add(android::String8(android::CameraParameters::PIXEL_FORMAT_RGBA8888), CAMERA_PIXEL_FORMAT_RGBA8888);
+        m.add(android::String8(android::CameraParameters::PIXEL_FORMAT_BAYER_RGGB), CAMERA_PIXEL_FORMAT_BAYER_RGGB);
+        return m;
+    }
+
+    static android::KeyedVector<android::String8, CameraPixelFormat> pixel_formats_lut = init_pixel_formats_lut();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/hybris/include/hybris/internal/camera_control.h
+++ b/hybris/include/hybris/internal/camera_control.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2013 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CAMERA_CONTROL_H_
+#define CAMERA_CONTROL_H_
+
+#include <camera/Camera.h>
+#include <camera/CameraParameters.h>
+#include <gui/SurfaceTexture.h>
+
+#include <stdint.h>
+#include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct CameraControlListener;
+
+struct CameraControl : public android::CameraListener,
+    public android::SurfaceTexture::FrameAvailableListener
+{
+    android::Mutex guard;
+    CameraControlListener* listener;
+    android::sp<android::Camera> camera;
+    android::CameraParameters camera_parameters;
+    android::sp<android::SurfaceTexture> preview_texture;
+
+    // From android::SurfaceTexture::FrameAvailableListener
+    void onFrameAvailable();
+
+    // From android::CameraListener
+    void notify(int32_t msg_type, int32_t ext1, int32_t ext2);
+
+    void postData(
+        int32_t msg_type,
+        const android::sp<android::IMemory>& data,
+        camera_frame_metadata_t* metadata);
+
+    void postDataTimestamp(
+        nsecs_t timestamp,
+        int32_t msg_type,
+        const android::sp<android::IMemory>& data);
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CAMERA_CONTROL_H_

--- a/hybris/tests/Makefile.am
+++ b/hybris/tests/Makefile.am
@@ -6,6 +6,7 @@ bin_PROGRAMS = \
 	test_ui \
 	test_sf \
 	test_input \
+	test_camera \
 	test_gps
 
 test_egl_SOURCES = test_egl.c
@@ -65,6 +66,16 @@ test_input_CFLAGS = \
 	-I$(top_srcdir)/include
 test_input_LDADD = \
 	$(top_builddir)/common/libhybris-common.la \
+	$(top_builddir)/input/libis.la
+
+test_camera_SOURCES = test_camera.c
+test_camera_CFLAGS = \
+	-I$(top_srcdir)/include
+test_camera_LDADD = \
+	$(top_builddir)/common/libhybris-common.la \
+	$(top_builddir)/egl/libEGL.la \
+	$(top_builddir)/glesv2/libGLESv2.la \
+	$(top_builddir)/camera/libcamera.la \
 	$(top_builddir)/input/libis.la
 
 test_gps_SOURCES = test_gps.c

--- a/hybris/tests/test_camera.c
+++ b/hybris/tests/test_camera.c
@@ -1,0 +1,474 @@
+/*
+ * Copyright (C) 2012 Canonical Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <hybris/camera/camera_compatibility_layer.h>
+#include <hybris/camera/camera_compatibility_layer_capabilities.h>
+
+#include <hybris/input/input_stack_compatibility_layer.h>
+#include <hybris/input/input_stack_compatibility_layer_codes_key.h>
+#include <hybris/input/input_stack_compatibility_layer_flags_key.h>
+#include <hybris/input/input_stack_compatibility_layer_flags_motion.h>
+
+#include <EGL/egl.h>
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <limits.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+int shot_counter = 1;
+int32_t current_zoom_level = 1;
+bool new_camera_frame_available = true;
+
+static GLuint gProgram;
+static GLuint gaPositionHandle, gaTexHandle, gsTextureHandle, gmTexMatrix;
+
+EffectMode next_effect()
+{
+    static EffectMode current_effect = EFFECT_MODE_NONE;
+
+    EffectMode next = current_effect;
+
+    switch (current_effect) {
+    case EFFECT_MODE_NONE:
+	    next = EFFECT_MODE_MONO;
+	    break;
+    case EFFECT_MODE_MONO:
+	    next = EFFECT_MODE_NEGATIVE;
+	    break;
+    case EFFECT_MODE_NEGATIVE:
+	    next = EFFECT_MODE_SOLARIZE;
+	    break;
+    case EFFECT_MODE_SOLARIZE:
+	    next = EFFECT_MODE_SEPIA;
+	    break;
+    case EFFECT_MODE_SEPIA:
+	    next = EFFECT_MODE_POSTERIZE;
+	    break;
+    case EFFECT_MODE_POSTERIZE:
+	    next = EFFECT_MODE_WHITEBOARD;
+	    break;
+    case EFFECT_MODE_WHITEBOARD:
+	    next = EFFECT_MODE_BLACKBOARD;
+	    break;
+    case EFFECT_MODE_BLACKBOARD:
+	    next = EFFECT_MODE_AQUA;
+	    break;
+    case EFFECT_MODE_AQUA:
+	    next = EFFECT_MODE_NONE;
+	    break;
+    }
+
+    current_effect = next;
+    return next;
+}
+
+void error_msg_cb(void* context)
+{
+	printf("%s \n", __PRETTY_FUNCTION__);
+}
+
+void shutter_msg_cb(void* context)
+{
+	printf("%s \n", __PRETTY_FUNCTION__);
+}
+
+void zoom_msg_cb(void* context, int32_t new_zoom_level)
+{
+	printf("%s \n", __PRETTY_FUNCTION__);
+
+	struct CameraControl* cc = (struct CameraControl*) context;
+	static int zoom;
+	current_zoom_level = new_zoom_level;
+}
+
+void autofocus_msg_cb(void* context)
+{
+	printf("%s \n", __PRETTY_FUNCTION__);
+}
+
+void raw_data_cb(void* data, uint32_t data_size, void* context)
+{
+	printf("%s: %d \n", __PRETTY_FUNCTION__, data_size);
+}
+
+void jpeg_data_cb(void* data, uint32_t data_size, void* context)
+{
+	printf("%s: %d \n", __PRETTY_FUNCTION__, data_size);
+
+	char fn[256];
+	sprintf(fn, "/tmp/shot_%d.jpeg", shot_counter);
+	int fd = open(fn, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+	ssize_t ret = write(fd, data, data_size);
+	close(fd);
+	shot_counter++;
+
+	struct CameraControl* cc = (struct CameraControl*) context;
+	android_camera_start_preview(cc);
+}
+
+void size_cb(void* ctx, int width, int height)
+{
+	printf("Supported size: [%d,%d]\n", width, height);
+}
+
+void preview_texture_needs_update_cb(void* ctx)
+{
+	new_camera_frame_available = true;
+}
+
+void on_new_input_event(struct Event* event, void* context)
+{
+	assert(context);
+
+	if (event->type == KEY_EVENT_TYPE && event->action == ISCL_KEY_EVENT_ACTION_UP) {
+		printf("We have got a key event: %d \n", event->details.key.key_code);
+
+		struct CameraControl* cc = (struct CameraControl*) context;
+
+		switch(event->details.key.key_code) {
+		case ISCL_KEYCODE_VOLUME_UP:
+			printf("\tZooming in now.\n");
+			android_camera_start_zoom(cc, current_zoom_level+1);
+			break;
+		case ISCL_KEYCODE_VOLUME_DOWN:
+			printf("\tZooming out now.\n");
+			android_camera_start_zoom(cc, current_zoom_level-1);
+			break;
+		case ISCL_KEYCODE_POWER:
+			printf("\tTaking a photo now.\n");
+			android_camera_take_snapshot(cc);
+			break;
+		case ISCL_KEYCODE_HEADSETHOOK:
+			printf("\tSwitching effect.\n");
+			android_camera_set_effect_mode(cc, next_effect());
+
+		}
+	} else if (event->type == MOTION_EVENT_TYPE &&
+			event->details.motion.pointer_count == 1) {
+		if ((event->action & ISCL_MOTION_EVENT_ACTION_MASK) == ISCL_MOTION_EVENT_ACTION_UP) {
+			printf("\tMotion event(Action up): (%f, %f) \n",
+					event->details.motion.pointer_coordinates[0].x,
+					event->details.motion.pointer_coordinates[0].y);
+		}
+
+		if ((event->action & ISCL_MOTION_EVENT_ACTION_MASK) == ISCL_MOTION_EVENT_ACTION_DOWN) {
+			printf("\tMotion event(Action down): (%f, %f) \n",
+					event->details.motion.pointer_coordinates[0].x,
+					event->details.motion.pointer_coordinates[0].y);
+		}
+	}
+}
+
+static const char* vertex_shader()
+{
+	return
+		"#extension GL_OES_EGL_image_external : require              \n"
+		"attribute vec4 a_position;                                  \n"
+		"attribute vec2 a_texCoord;                                  \n"
+		"uniform mat4 m_texMatrix;                                   \n"
+		"varying vec2 v_texCoord;                                    \n"
+		"varying float topDown;                                      \n"
+		"void main()                                                 \n"
+		"{                                                           \n"
+		"   gl_Position = a_position;                                \n"
+		"   v_texCoord = a_texCoord;                                 \n"
+		// "   v_texCoord = (m_texMatrix * vec4(a_texCoord, 0.0, 1.0)).xy;\n"
+		// "   topDown = v_texCoord.y;                                  \n"
+		"}                                                           \n";
+}
+
+static const char* fragment_shader()
+{
+	return
+		"#extension GL_OES_EGL_image_external : require      \n"
+		"precision mediump float;                            \n"
+		"varying vec2 v_texCoord;                            \n"
+		"uniform samplerExternalOES s_texture;               \n"
+		"void main()                                         \n"
+		"{                                                   \n"
+		"  gl_FragColor = texture2D( s_texture, v_texCoord );\n"
+		"}                                                   \n";
+}
+
+static GLuint loadShader(GLenum shaderType, const char* pSource) {
+	GLuint shader = glCreateShader(shaderType);
+
+	if (shader) {
+		glShaderSource(shader, 1, &pSource, NULL);
+		glCompileShader(shader);
+		GLint compiled = 0;
+		glGetShaderiv(shader, GL_COMPILE_STATUS, &compiled);
+
+		if (!compiled) {
+			GLint infoLen = 0;
+			glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &infoLen);
+			if (infoLen) {
+				char* buf = (char*) malloc(infoLen);
+				if (buf) {
+					glGetShaderInfoLog(shader, infoLen, NULL, buf);
+					fprintf(stderr, "Could not compile shader %d:\n%s\n",
+							shaderType, buf);
+					free(buf);
+				}
+				glDeleteShader(shader);
+				shader = 0;
+			}
+		}
+	} else {
+		printf("Error, during shader creation: %i\n", glGetError());
+	}
+
+	return shader;
+}
+
+static GLuint create_program(const char* pVertexSource, const char* pFragmentSource) {
+	GLuint vertexShader = loadShader(GL_VERTEX_SHADER, pVertexSource);
+	if (!vertexShader) {
+		printf("vertex shader not compiled\n");
+		return 0;
+	}
+
+	GLuint pixelShader = loadShader(GL_FRAGMENT_SHADER, pFragmentSource);
+	if (!pixelShader) {
+		printf("frag shader not compiled\n");
+		return 0;
+	}
+
+	GLuint program = glCreateProgram();
+	if (program) {
+		glAttachShader(program, vertexShader);
+		glAttachShader(program, pixelShader);
+		glLinkProgram(program);
+		GLint linkStatus = GL_FALSE;
+		glGetProgramiv(program, GL_LINK_STATUS, &linkStatus);
+
+		if (linkStatus != GL_TRUE) {
+			GLint bufLength = 0;
+			glGetProgramiv(program, GL_INFO_LOG_LENGTH, &bufLength);
+			if (bufLength) {
+				char* buf = (char*) malloc(bufLength);
+				if (buf) {
+					glGetProgramInfoLog(program, bufLength, NULL, buf);
+					fprintf(stderr, "Could not link program:\n%s\n", buf);
+					free(buf);
+				}
+			}
+			glDeleteProgram(program);
+			program = 0;
+		}
+
+	}
+	return program;
+}
+
+int main(int argc, char** argv)
+{
+	struct CameraControlListener listener;
+	memset(&listener, 0, sizeof(listener));
+	listener.on_msg_error_cb = error_msg_cb;
+	listener.on_msg_shutter_cb = shutter_msg_cb;
+	listener.on_msg_focus_cb = autofocus_msg_cb;
+	listener.on_msg_zoom_cb = zoom_msg_cb;
+
+	listener.on_data_raw_image_cb = raw_data_cb;
+	listener.on_data_compressed_image_cb = jpeg_data_cb;
+	listener.on_preview_texture_needs_update_cb = preview_texture_needs_update_cb;
+	struct CameraControl* cc = android_camera_connect_to(FRONT_FACING_CAMERA_TYPE,
+			&listener);
+	if (cc == NULL) {
+		printf("Problem connecting to camera");
+		return 1;
+	}
+
+	listener.context = cc;
+
+	struct AndroidEventListener event_listener;
+	event_listener.on_new_event = on_new_input_event;
+	event_listener.context = cc;
+
+	struct InputStackConfiguration input_configuration = { false, 25000 };
+
+	android_input_stack_initialize(&event_listener, &input_configuration);
+	android_input_stack_start();
+
+	android_camera_dump_parameters(cc);
+	android_camera_enumerate_supported_picture_sizes(cc, size_cb, NULL);
+	android_camera_enumerate_supported_preview_sizes(cc, size_cb, NULL);
+
+	int min_fps, max_fps, current_fps;
+	android_camera_get_preview_fps_range(cc, &min_fps, &max_fps);
+	printf("Preview fps range: [%d,%d]\n", min_fps, max_fps);
+	android_camera_get_preview_fps(cc, &current_fps);
+	printf("Current preview fps range: %d\n", current_fps);
+
+	android_camera_set_preview_size(cc, 960, 720);
+
+	int width, height;
+	android_camera_get_preview_size(cc, &width, &height);
+	printf("Current preview size: [%d,%d]\n", width, height);
+	android_camera_get_picture_size(cc, &width, &height);
+	printf("Current picture size: [%d,%d]\n", width, height);
+	int zoom;
+	android_camera_get_max_zoom(cc, &zoom);
+	printf("Max zoom: %d \n", zoom);
+	android_camera_set_zoom(cc, 10);
+
+	EffectMode effect_mode;
+	FlashMode flash_mode;
+	WhiteBalanceMode wb_mode;
+	SceneMode scene_mode;
+	AutoFocusMode af_mode;
+	android_camera_get_effect_mode(cc, &effect_mode);
+	android_camera_get_flash_mode(cc, &flash_mode);
+	android_camera_get_white_balance_mode(cc, &wb_mode);
+	android_camera_get_scene_mode(cc, &scene_mode);
+	android_camera_get_auto_focus_mode(cc, &af_mode);
+	printf("Current effect mode: %d \n", effect_mode);
+	printf("Current flash mode: %d \n", flash_mode);
+	printf("Current wb mode: %d \n", wb_mode);
+	printf("Current scene mode: %d \n", scene_mode);
+	printf("Current af mode: %d \n", af_mode);
+	FocusRegion fr = { top: -200, left: -200, bottom: 200, right: 200, weight: 300};
+	android_camera_set_focus_region(cc, &fr);
+
+	/* EGL Setup */
+	EGLConfig ecfg;
+	EGLBoolean rv;
+	EGLint num_config;
+	EGLContext context;
+	EGLint attr[] = {
+		EGL_BUFFER_SIZE, 32,
+		EGL_RENDERABLE_TYPE,
+		EGL_OPENGL_ES2_BIT,
+		EGL_NONE
+	};
+	EGLint ctxattr[] = {
+		EGL_CONTEXT_CLIENT_VERSION, 2,
+		EGL_NONE
+	};
+
+	EGLDisplay disp = eglGetDisplay(NULL);
+	assert(eglGetError() == EGL_SUCCESS);
+	assert(disp != EGL_NO_DISPLAY);
+
+	rv = eglInitialize(disp, 0, 0);
+	assert(eglGetError() == EGL_SUCCESS);
+	assert(rv == EGL_TRUE);
+
+	eglChooseConfig((EGLDisplay) disp, attr, &ecfg, 1, &num_config);
+	assert(eglGetError() == EGL_SUCCESS);
+	assert(rv == EGL_TRUE);
+
+	EGLSurface surface = eglCreateWindowSurface((EGLDisplay) disp, ecfg,
+			(EGLNativeWindowType) NULL, NULL);
+	assert(eglGetError() == EGL_SUCCESS);
+	assert(surface != EGL_NO_SURFACE);
+
+	context = eglCreateContext((EGLDisplay) disp, ecfg, EGL_NO_CONTEXT, ctxattr);
+	assert(eglGetError() == EGL_SUCCESS);
+	assert(context != EGL_NO_CONTEXT);
+
+	assert(eglMakeCurrent((EGLDisplay) disp, surface, surface, context) == EGL_TRUE);
+
+	gProgram = create_program(vertex_shader(), fragment_shader());
+	gaPositionHandle = glGetAttribLocation(gProgram, "a_position");
+	gaTexHandle = glGetAttribLocation(gProgram, "a_texCoord");
+	gsTextureHandle = glGetUniformLocation(gProgram, "s_texture");
+	gmTexMatrix = glGetUniformLocation(gProgram, "m_texMatrix");
+
+	GLuint preview_texture_id;
+	glGenTextures(1, &preview_texture_id);
+	glClearColor(1.0, 0., 0.5, 1.);
+	glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(
+			GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(
+			GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	android_camera_set_preview_texture(cc, preview_texture_id);
+	android_camera_set_effect_mode(cc, EFFECT_MODE_SEPIA);
+	android_camera_set_flash_mode(cc, FLASH_MODE_AUTO);
+	android_camera_set_auto_focus_mode(cc, AUTO_FOCUS_MODE_CONTINUOUS_PICTURE);
+	android_camera_start_preview(cc);
+
+	GLfloat transformation_matrix[16];
+	android_camera_get_preview_texture_transformation(cc, transformation_matrix);
+	glUniformMatrix4fv(gmTexMatrix, 1, GL_FALSE, transformation_matrix);
+
+	printf("Started camera preview.\n");
+
+	while(true) {
+		/*if (new_camera_frame_available)
+		  {
+		  printf("Updating texture");
+		  new_camera_frame_available = false;
+		  }*/
+		static GLfloat vVertices[] = { 0.0f, 0.0f, 0.0f, // Position 0
+			0.0f, 0.0f, // TexCoord 0
+			0.0f, 1.0f, 0.0f, // Position 1
+			0.0f, 1.0f, // TexCoord 1
+			1.0f, 1.0f, 0.0f, // Position 2
+			1.0f, 1.0f, // TexCoord 2
+			1.0f, 0.0f, 0.0f, // Position 3
+			1.0f, 0.0f // TexCoord 3
+		};
+
+		GLushort indices[] = { 0, 1, 2, 0, 2, 3 };
+
+		// Set the viewport
+		// Clear the color buffer
+		glClear(GL_COLOR_BUFFER_BIT);
+		// Use the program object
+		glUseProgram(gProgram);
+		// Enable attributes
+		glEnableVertexAttribArray(gaPositionHandle);
+		glEnableVertexAttribArray(gaTexHandle);
+		// Load the vertex position
+		glVertexAttribPointer(gaPositionHandle,
+				3,
+				GL_FLOAT,
+				GL_FALSE,
+				5 * sizeof(GLfloat),
+				vVertices);
+		// Load the texture coordinate
+		glVertexAttribPointer(gaTexHandle,
+				2,
+				GL_FLOAT,
+				GL_FALSE,
+				5 * sizeof(GLfloat),
+				vVertices+3);
+
+		glActiveTexture(GL_TEXTURE0);
+		// Set the sampler texture unit to 0
+		glUniform1i(gsTextureHandle, 0);
+		glUniform1i(gmTexMatrix, 0);
+		android_camera_update_preview_texture(cc);
+		glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_SHORT, indices);
+		glDisableVertexAttribArray(gaPositionHandle);
+		glDisableVertexAttribArray(gaTexHandle);
+
+		eglSwapBuffers((EGLDisplay) disp, surface);
+	}
+}


### PR DESCRIPTION
Camera compat layer so we're able to use Android's camera layer (HAL, etc).

To test you'd need the HAL to be in place and also the Android media service running.

Tested with Nexus 4, via native and over hybris.
