### PR TITLE
egl: add HYBRIS_EGLPLATFORM along EGL_PLATFORM

### DIFF
--- a/hybris/egl/ws.c
+++ b/hybris/egl/ws.c
@@ -27,8 +27,14 @@ static void _init_ws()
 {
 	if (ws == NULL)
 	{
-		char *egl_platform = getenv("EGL_PLATFORM");
 		char ws_name[2048];
+		char *egl_platform;
+
+		egl_platform=getenv("EGL_PLATFORM");
+		// Mesa uses EGL_PLATFORM for its own purposes.
+		// Add HYBRIS_EGLPLATFORM to avoid the conflicts
+		if (egl_platform == NULL)
+			egl_platform=getenv("HYBRIS_EGLPLATFORM");
 
 		if (egl_platform == NULL)
 			egl_platform = "null";


### PR DESCRIPTION
Mesa uses EGL_PLATFORM env variables for its own
purposes.
When the EGL_PLATFORM becomes wayland, mesa
will also try to initialize its wayland backend
when instead it should just stick to fbdev.

Signed-off-by: Adrian Negreanu groleo@gmail.com
