### PR TITLE
Adapt packaging to make possible to write an external egl platform plugi...

### DIFF
--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -131,6 +131,7 @@ AC_CONFIG_FILES([
 	egl/Makefile
 	egl/platforms/Makefile
 	egl/platforms/common/Makefile
+	egl/platforms/common/hybris-egl-platform.pc
 	egl/platforms/null/Makefile
 	egl/platforms/fbdev/Makefile
 	egl/platforms/wayland/Makefile

--- a/hybris/egl/Makefile.am
+++ b/hybris/egl/Makefile.am
@@ -40,3 +40,7 @@ libEGL_la_LDFLAGS = \
 eglincludedir = $(includedir)/EGL
 eglinclude_HEADERS = \
 	eglhybris.h
+
+wsincludedir = $(includedir)/hybris/eglplatformcommon
+wsinclude_HEADERS = \
+	ws.h

--- a/hybris/egl/platforms/common/Makefile.am
+++ b/hybris/egl/platforms/common/Makefile.am
@@ -6,12 +6,13 @@ libhybris_eglplatformcommon_la_SOURCES = \
 	nativewindowbase.cpp \
 	eglplatformcommon.cpp
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = hybris-egl-platform.pc
+
 if WANT_WAYLAND
 lib_LTLIBRARIES += libwayland-egl.la
 
-pkgconfigdir = $(libdir)/pkgconfig
-pkgconfig_DATA = wayland-egl.pc
-
+pkgconfig_DATA += wayland-egl.pc
 
 
 libhybris_eglplatformcommon_la_SOURCES += \
@@ -93,7 +94,8 @@ libhybris_eglplatformcommon_la_LDFLAGS = \
 eglplatformcommondir = $(includedir)/hybris/eglplatformcommon
 eglplatformcommon_HEADERS = \
 	support.h \
-	nativewindowbase.h
+	nativewindowbase.h \
+	eglplatformcommon.h
 
 if WANT_WAYLAND
 libhybris_eglplatformcommon_la_LDFLAGS += \

--- a/hybris/egl/platforms/common/hybris-egl-platform.pc.in
+++ b/hybris/egl/platforms/common/hybris-egl-platform.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=@libdir@
+includedir=@includedir@
+
+Name: hybris-egl-platform
+Description: libhybris EGL platform library
+Version: 0.1.0
+Libs: -L${libdir} -lhybris-common -lhybris-eglplatformcommon
+Cflags: -I${includedir}


### PR DESCRIPTION
...n for libhybris
- add the files ws.h and eglplatformcommon.h in the {includedir}/hybris/eglplatformcommon directory
  - create a hybris-platform pkg-config file description

Signed-off-by: Christophe Chapuis chris.chapuis@gmail.com
