### PR TITLE
Move FP_ATTRIB to floating_point_abi.h, use in binding.h

### DIFF
--- a/hybris/camera/camera.c
+++ b/hybris/camera/camera.c
@@ -27,12 +27,6 @@
 
 #define COMPAT_LIBRARY_PATH "/system/lib/libcamera_compat_layer.so"
 
-#ifdef __ARM_PCS_VFP
-#define FP_ATTRIB __attribute__((pcs("aapcs")))
-#else
-#define FP_ATTRIB
-#endif
-
 HYBRIS_LIBRARY_INITIALIZE(camera, COMPAT_LIBRARY_PATH);
 
 HYBRIS_IMPLEMENT_FUNCTION0(camera, int, android_camera_get_number_of_devices);

--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -17,6 +17,8 @@
  *
  */
 
+#include <hybris/internal/floating_point_abi.h>
+
 #include "properties.h"
 #include "hooks_shm.h"
 
@@ -75,12 +77,6 @@
  *  - if p <= ANDROID_TOP_ADDR_VALUE_MUTEX then it is an android mutex, not one we processed
  *  - if p > VMALLOC_END, then the pointer is not a result of malloc ==> it is an shm offset
  */
-
-#ifdef __ARM_PCS_VFP
-#define FP_ATTRIB __attribute__((pcs("aapcs")))
-#else
-#define FP_ATTRIB
-#endif
 
 struct _hook {
     const char *name;

--- a/hybris/glesv2/glesv2.c
+++ b/hybris/glesv2/glesv2.c
@@ -23,12 +23,7 @@
 #include <stdlib.h>
 
 #include <hybris/internal/binding.h>
-
-#ifdef __ARM_PCS_VFP
-#define FP_ATTRIB __attribute__((pcs("aapcs")))
-#else
-#define FP_ATTRIB
-#endif
+#include <hybris/internal/floating_point_abi.h>
 
 static void *_libglesv2 = NULL;
 

--- a/hybris/include/hybris/internal/binding.h
+++ b/hybris/include/hybris/internal/binding.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2013 Simon Busch <morphis@gravedo.de>
  *               2012 Canonical Ltd
+ *               2013 Jolla Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +18,9 @@
 
 #ifndef HYBRIS_BINDING_H_
 #define HYBRIS_BINDING_H_
+
+/* floating_point_abi.h defines FP_ATTRIB */
+#include <hybris/internal/floating_point_abi.h>
 
 void *android_dlopen(const char *filename, int flag);
 void *android_dlsym(void *name, const char *symbol);
@@ -39,7 +43,7 @@ void *android_dlsym(void *name, const char *symbol);
 #define HYBRIS_IMPLEMENT_FUNCTION0(name, return_type, symbol)  \
     return_type symbol()                          \
     {                                             \
-        static return_type (*f)() = NULL;         \
+        static return_type (*f)() FP_ATTRIB = NULL;      \
         HYBRIS_DLSYSM(name, &f, #symbol);                \
         return f(); \
     }
@@ -47,7 +51,7 @@ void *android_dlsym(void *name, const char *symbol);
 #define HYBRIS_IMPLEMENT_FUNCTION1(name, return_type, symbol, arg1) \
     return_type symbol(arg1 _1)                        \
     {                                                  \
-        static return_type (*f)(arg1) = NULL;          \
+        static return_type (*f)(arg1) FP_ATTRIB = NULL;\
         HYBRIS_DLSYSM(name, &f, #symbol);                     \
         return f(_1); \
     }
@@ -55,7 +59,7 @@ void *android_dlsym(void *name, const char *symbol);
 #define HYBRIS_IMPLEMENT_FUNCTION2(name, return_type, symbol, arg1, arg2) \
     return_type symbol(arg1 _1, arg2 _2)                        \
     {                                                  \
-        static return_type (*f)(arg1, arg2) = NULL;          \
+        static return_type (*f)(arg1, arg2) FP_ATTRIB = NULL;\
         HYBRIS_DLSYSM(name, &f, #symbol);                     \
         return f(_1, _2); \
     }
@@ -63,7 +67,7 @@ void *android_dlsym(void *name, const char *symbol);
 #define HYBRIS_IMPLEMENT_FUNCTION3(name, return_type, symbol, arg1, arg2, arg3) \
     return_type symbol(arg1 _1, arg2 _2, arg3 _3)                        \
     {                                                  \
-        static return_type (*f)(arg1, arg2, arg3) = NULL;          \
+        static return_type (*f)(arg1, arg2, arg3) FP_ATTRIB = NULL; \
         HYBRIS_DLSYSM(name, &f, #symbol);                     \
         return f(_1, _2, _3); \
     }
@@ -71,7 +75,7 @@ void *android_dlsym(void *name, const char *symbol);
 #define HYBRIS_IMPLEMENT_FUNCTION4(name, return_type, symbol, arg1, arg2, arg3, arg4) \
     return_type symbol(arg1 _1, arg2 _2, arg3 _3, arg4 _4)                        \
     {                                                  \
-        static return_type (*f)(arg1, arg2, arg3, arg4) = NULL;          \
+        static return_type (*f)(arg1, arg2, arg3, arg4) FP_ATTRIB = NULL;\
         HYBRIS_DLSYSM(name, &f, #symbol);                     \
         return f(_1, _2, _3, _4); \
     }
@@ -79,7 +83,7 @@ void *android_dlsym(void *name, const char *symbol);
 #define HYBRIS_IMPLEMENT_FUNCTION5(name, return_type, symbol, arg1, arg2, arg3, arg4, arg5) \
     return_type symbol(arg1 _1, arg2 _2, arg3 _3, arg4 _4, arg5 _5)                        \
     {                                                  \
-        static return_type (*f)(arg1, arg2, arg3, arg4, arg5) = NULL;          \
+        static return_type (*f)(arg1, arg2, arg3, arg4, arg5) FP_ATTRIB = NULL;\
         HYBRIS_DLSYSM(name, &f, #symbol);                     \
         return f(_1, _2, _3, _4, _5); \
     }
@@ -87,7 +91,7 @@ void *android_dlsym(void *name, const char *symbol);
 #define HYBRIS_IMPLEMENT_FUNCTION6(name, return_type, symbol, arg1, arg2, arg3, arg4, arg5, arg6) \
     return_type symbol(arg1 _1, arg2 _2, arg3 _3, arg4 _4, arg5 _5, arg6 _6)                        \
     {                                                  \
-        static return_type (*f)(arg1, arg2, arg3, arg4, arg5, arg6) = NULL;          \
+        static return_type (*f)(arg1, arg2, arg3, arg4, arg5, arg6) FP_ATTRIB = NULL;\
         HYBRIS_DLSYSM(name, &f, #symbol);                     \
         return f(_1, _2, _3, _4, _5, _6); \
     }
@@ -95,7 +99,7 @@ void *android_dlsym(void *name, const char *symbol);
 #define HYBRIS_IMPLEMENT_FUNCTION7(name, return_type, symbol, arg1, arg2, arg3, arg4, arg5, arg6, arg7) \
     return_type symbol(arg1 _1, arg2 _2, arg3 _3, arg4 _4, arg5 _5, arg6 _6, arg7 _7)                        \
     {                                                  \
-        static return_type (*f)(arg1, arg2, arg3, arg4, arg5, arg6, arg7) = NULL;          \
+        static return_type (*f)(arg1, arg2, arg3, arg4, arg5, arg6, arg7) FP_ATTRIB = NULL;          \
         HYBRIS_DLSYSM(name, &f, #symbol);                     \
         return f(_1, _2, _3, _4, _5, _6, _7); \
     }
@@ -103,7 +107,7 @@ void *android_dlsym(void *name, const char *symbol);
 #define HYBRIS_IMPLEMENT_VOID_FUNCTION0(name, symbol)        \
     void symbol()                                            \
     {                                                        \
-        static void (*f)() = NULL;                           \
+        static void (*f)() FP_ATTRIB = NULL;                 \
         HYBRIS_DLSYSM(name, &f, #symbol);                    \
         f();                                                 \
     }
@@ -111,7 +115,7 @@ void *android_dlsym(void *name, const char *symbol);
 #define HYBRIS_IMPLEMENT_VOID_FUNCTION1(name, symbol, arg1)               \
     void symbol(arg1 _1)                                     \
     {                                                        \
-        static void (*f)(arg1) = NULL;                       \
+        static void (*f)(arg1) FP_ATTRIB = NULL;             \
         HYBRIS_DLSYSM(name, &f, #symbol);                           \
         f(_1); \
     }
@@ -119,7 +123,7 @@ void *android_dlsym(void *name, const char *symbol);
 #define HYBRIS_IMPLEMENT_VOID_FUNCTION2(name, symbol, arg1, arg2)            \
     void symbol(arg1 _1, arg2 _2)                               \
     {                                                           \
-        static void (*f)(arg1, arg2) = NULL;                    \
+        static void (*f)(arg1, arg2) FP_ATTRIB = NULL;          \
         HYBRIS_DLSYSM(name, &f, #symbol);                              \
         f(_1, _2); \
     }
@@ -127,7 +131,7 @@ void *android_dlsym(void *name, const char *symbol);
 #define HYBRIS_IMPLEMENT_VOID_FUNCTION3(name, symbol, arg1, arg2, arg3)      \
     void symbol(arg1 _1, arg2 _2, arg3 _3)                      \
     {                                                           \
-        static void (*f)(arg1, arg2, arg3) = NULL;              \
+        static void (*f)(arg1, arg2, arg3) FP_ATTRIB = NULL;    \
         HYBRIS_DLSYSM(name, &f, #symbol);                              \
         f(_1, _2, _3); \
     }

--- a/hybris/include/hybris/internal/floating_point_abi.h
+++ b/hybris/include/hybris/internal/floating_point_abi.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2013 Jolla Ltd.
+ * Contact: Thomas Perl <thomas.perl@jollamobile.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HYBRIS_FLOATING_POINT_ABI_H_
+#define HYBRIS_FLOATING_POINT_ABI_H_
+
+/**
+ * Make sure to use FP_ATTRIB on all functions that are loaded from
+ * Android (bionic libc) libraries to make sure floating point arguments
+ * are passed the right way.
+ *
+ * See: http://wiki.debian.org/ArmHardFloatPort/VfpComparison
+ *      http://gcc.gnu.org/onlinedocs/gcc/Function-Attributes.html
+ *
+ * It doesn't hurt to have it added for non-floating point arguments and
+ * return types, even though it does not really have any effect.
+ *
+ * If you use the convenience macros in hybris/internal/binding.h, your
+ * wrapper functions will automatically make use of this attribute.
+ **/
+
+#ifdef __ARM_PCS_VFP
+#  define FP_ATTRIB __attribute__((pcs("aapcs")))
+#else
+#  define FP_ATTRIB
+#endif
+
+#endif /* HYBRIS_FLOATING_POINT_ABI_H_ */

--- a/hybris/sf/sf.c
+++ b/hybris/sf/sf.c
@@ -26,12 +26,6 @@
 
 #define COMPAT_LIBRARY_PATH "/system/lib/libsf_compat_layer.so"
 
-#ifdef __ARM_PCS_VFP
-#define FP_ATTRIB __attribute__((pcs("aapcs")))
-#else
-#define FP_ATTRIB
-#endif
-
 HYBRIS_LIBRARY_INITIALIZE(sf, COMPAT_LIBRARY_PATH);
 
 HYBRIS_IMPLEMENT_VOID_FUNCTION1(sf, sf_blank, size_t);


### PR DESCRIPTION
The floating point ABI attribute needs to be set on all
bionic-based Android library functions (theoretically only
if the function has floating point arguments or return
values, but it does not hurt to have it for all functions).

Move all duplicate definitions of FP_ATTRIB into a central
place and use FP_ATTRIB in the macros of binding.h to make
sure generated wrapper functions work correctly.
