### PR TITLE
Fix a typo in egl/platforms/common/Makefile.am

### DIFF
--- a/hybris/egl/platforms/common/Makefile.am
+++ b/hybris/egl/platforms/common/Makefile.am
@@ -72,7 +72,7 @@ libhybris_eglplatformcommon_la_CFLAGS += -ggdb -O0
 endif
 
 
-libhybris_eglplatformcommon_la_CXXFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/egl -I$(top_src)/include/android -I$(top_srcdir)/common/
+libhybris_eglplatformcommon_la_CXXFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/egl -I$(top_srcdir)/include/android -I$(top_srcdir)/common/
 if WANT_MESA
 libhybris_eglplatformcommon_la_CXXFLAGS += -DLIBHYBRIS_WANTS_MESA_X11_HEADERS
 endif


### PR DESCRIPTION
A typo in egl/platforms/common/Makefile.am prevents the Android headers from being found.
