### PR TITLE
Buffer management cleanups for Wayland platform

### DIFF
--- a/hybris/egl/platforms/wayland/wayland_window.h
+++ b/hybris/egl/platforms/wayland/wayland_window.h
@@ -113,6 +113,8 @@ protected:
     virtual int setBuffersDimensions(int width, int height);
     virtual int setBufferCount(int cnt);
 private:
+    WaylandNativeWindowBuffer *addBuffer();
+    void destroyBuffer(WaylandNativeWindowBuffer *);
     void destroyBuffers();
     std::list<WaylandNativeWindowBuffer *> m_bufList;
     std::list<WaylandNativeWindowBuffer *> fronted;


### PR DESCRIPTION
Instead of reallocating the whole stack of buffers at once when attributes
(dimensions, format, usage..) change, let's reallocate one-by-one when the
buffers are dequeued. This will save reallocations in situations where
multiple attributes are changed in succession, which is common when starting
up.

Also make setBufferCount() avoid reallocations by just adjusting the buffer
list size towards the desired rather than reallocating the whole list.

As a bonus, we now also react to wl_egl_window resizes.
