### PR TITLE
hwcomposer: fix parallel builds

### DIFF
--- a/hybris/egl/platforms/hwcomposer/Makefile.am
+++ b/hybris/egl/platforms/hwcomposer/Makefile.am
@@ -1,5 +1,3 @@
-lib_LTLIBRARIES = libhybris-hwcomposerwindow.la
-
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = hwcomposer-egl.pc
 
@@ -7,36 +5,11 @@ hwcomposerwindowincludedir = $(includedir)/hybris/hwcomposerwindow
 hwcomposerwindowinclude_HEADERS = \
         hwcomposer_window.h
 
-libhybris_hwcomposerwindow_la_SOURCES = \
-	hwcomposer_window.cpp
-
-libhybris_hwcomposerwindow_la_CXXFLAGS = \
-	-I$(top_srcdir)/include \
-	-I$(top_srcdir)/common \
-	-I$(top_srcdir)/egl \
-	-I$(top_srcdir)/egl/platforms/common \
-	-I$(top_srcdir)/include/android
-
-if WANT_TRACE
-libhybris_hwcomposerwindow_la_CXXFLAGS += -DDEBUG
-endif
-if WANT_DEBUG
-libhybris_hwcomposerwindow_la_CXXFLAGS += -ggdb -O0
-endif
-
-libhybris_hwcomposerwindow_la_LDFLAGS = \
-	-version-info "1":"0":"0" \
-	$(top_builddir)/egl/platforms/common/libhybris-eglplatformcommon.la \
-	$(top_builddir)/hardware/libhardware.la
-
-if HAS_ANDROID_4_2_0
-libhybris_hwcomposerwindow_la_LDFLAGS += $(top_builddir)/libsync/libsync.la
-endif
-
 pkglib_LTLIBRARIES = eglplatform_hwcomposer.la
 
 eglplatform_hwcomposer_la_SOURCES = \
-	eglplatform_hwcomposer.cpp
+	eglplatform_hwcomposer.cpp \
+	hwcomposer_window.cpp
 
 eglplatform_hwcomposer_la_CXXFLAGS = \
 	-I$(top_srcdir)/include \
@@ -53,8 +26,12 @@ eglplatform_hwcomposer_la_CXXFLAGS += -ggdb -O0
 endif
 
 eglplatform_hwcomposer_la_LDFLAGS = \
+	-version-info "1":"0":"0" \
 	-avoid-version -module -shared -export-dynamic \
-	$(top_builddir)/egl/platforms/hwcomposer/libhybris-hwcomposerwindow.la \
 	$(top_builddir)/egl/platforms/common/libhybris-eglplatformcommon.la \
 	$(top_builddir)/hardware/libhardware.la
+
+if HAS_ANDROID_4_2_0
+eglplatform_hwcomposer_la_LDFLAGS += $(top_builddir)/libsync/libsync.la
+endif
 

--- a/hybris/tests/Makefile.am
+++ b/hybris/tests/Makefile.am
@@ -65,7 +65,7 @@ endif
 test_hwcomposer_LDADD = \
 	-lm \
 	$(top_builddir)/common/libhybris-common.la \
-	$(top_builddir)/egl/platforms/hwcomposer/libhybris-hwcomposerwindow.la \
+	$(top_builddir)/egl/platforms/hwcomposer/eglplatform_hwcomposer.la \
 	$(top_builddir)/egl/platforms/common/libhybris-eglplatformcommon.la \
 	$(top_builddir)/egl/libEGL.la \
 	$(top_builddir)/glesv2/libGLESv2.la \


### PR DESCRIPTION
libhybris-hwcomposerwindow.la was not built before eglplatform_hwcomposer.la thus the error.
this leaves only eglplatform_hwcomposer.la

Signed-off-by: groleo adrian.m.negreanu@intel.com
