### PR TITLE
Also extract the android headers folder. because android/log.h is require...

### DIFF
--- a/utils/extract-headers.sh
+++ b/utils/extract-headers.sh
@@ -55,6 +55,9 @@ cp $ANDROID_ROOT/system/core/include/cutils/* $HEADERPATH/cutils/
 mkdir -p $HEADERPATH/system/
 cp $ANDROID_ROOT/system/core/include/system/* $HEADERPATH/system/
 
+mkdir -p $HEADERPATH/android/
+cp $ANDROID_ROOT/system/core/include/android/* $HEADERPATH/android/
+
 if [ -e $ANDROID_ROOT/external/kernel-headers/original/linux/sync.h ]; then
 	mkdir -p $HEADERPATH/linux
 	cp $ANDROID_ROOT/external/kernel-headers/original/linux/sync.h $HEADERPATH/linux


### PR DESCRIPTION
 This is because android/log.h is required by cutils/logd.h.
