### PR TITLE
EGL: Add support for ws_DestroyWindow

### DIFF
--- a/hybris/egl/Makefile.am
+++ b/hybris/egl/Makefile.am
@@ -5,6 +5,7 @@ lib_LTLIBRARIES = \
 
 libEGL_la_SOURCES = \
 	egl.c \
+	helper.cpp \
 	ws.c
 
 pkgconfigdir = $(libdir)/pkgconfig

--- a/hybris/egl/helper.cpp
+++ b/hybris/egl/helper.cpp
@@ -1,0 +1,54 @@
+
+/*
+ * Copyright (c) 2013 Jolla Ltd.
+ * Contact: Thomas Perl <thomas.perl@jollamobile.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+#include "helper.h"
+
+#include <assert.h>
+#include <map>
+
+
+/* Keep track of active EGL window surfaces */
+static std::map<EGLSurface,EGLNativeWindowType> _surface_window_map;
+
+
+void egl_helper_push_mapping(EGLSurface surface, EGLNativeWindowType window)
+{
+    assert(!egl_helper_has_mapping(surface));
+
+    _surface_window_map[surface] = window;
+}
+
+int egl_helper_has_mapping(EGLSurface surface)
+{
+    return (_surface_window_map.find(surface) != _surface_window_map.end());
+}
+
+EGLNativeWindowType egl_helper_pop_mapping(EGLSurface surface)
+{
+    std::map<EGLSurface,EGLNativeWindowType>::iterator it;
+    it = _surface_window_map.find(surface);
+
+    /* Caller must check with egl_helper_has_mapping() before */
+    assert(it != _surface_window_map.end());
+
+    EGLNativeWindowType result = it->second;
+    _surface_window_map.erase(it);
+    return result;
+}

--- a/hybris/egl/helper.h
+++ b/hybris/egl/helper.h
@@ -1,0 +1,47 @@
+
+/*
+ * Copyright (c) 2013 Jolla Ltd.
+ * Contact: Thomas Perl <thomas.perl@jollamobile.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+#ifndef LIBHYBRIS_EGL_HELPER_H
+#define LIBHYBRIS_EGL_HELPER_H
+
+
+#include <EGL/egl.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Add new mapping from surface to window */
+void egl_helper_push_mapping(EGLSurface surface, EGLNativeWindowType window);
+
+/* Check if a mapping for a surface exist */
+int egl_helper_has_mapping(EGLSurface surface);
+
+/* Return and remove the mapping for a surface */
+EGLNativeWindowType egl_helper_pop_mapping(EGLSurface surface);
+
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif /* LIBHYBRIS_EGL_HELPER_H */

--- a/hybris/egl/platforms/hwcomposer/eglplatform_hwcomposer.cpp
+++ b/hybris/egl/platforms/hwcomposer/eglplatform_hwcomposer.cpp
@@ -60,6 +60,12 @@ extern "C" EGLNativeWindowType hwcomposerws_CreateWindow(EGLNativeWindowType win
 	return win;
 }
 
+extern "C" void hwcomposerws_DestroyWindow(EGLNativeWindowType win)
+{
+	HWComposerNativeWindow *window = static_cast<HWComposerNativeWindow *>((ANativeWindow *) win);
+	// TODO: Do any necessary cleanup on window
+}
+
 extern "C" __eglMustCastToProperFunctionPointerType hwcomposerws_eglGetProcAddress(const char *procname) 
 {
 	return eglplatformcommon_eglGetProcAddress(procname);
@@ -73,6 +79,7 @@ extern "C" void hwcomposerws_passthroughImageKHR(EGLenum *target, EGLClientBuffe
 struct ws_module ws_module_info = {
 	hwcomposerws_IsValidDisplay,
 	hwcomposerws_CreateWindow,
+	hwcomposerws_DestroyWindow,
 	hwcomposerws_eglGetProcAddress,
 	hwcomposerws_passthroughImageKHR,
 	eglplatformcommon_eglQueryString

--- a/hybris/egl/platforms/null/eglplatform_null.c
+++ b/hybris/egl/platforms/null/eglplatform_null.c
@@ -38,6 +38,11 @@ static EGLNativeWindowType nullws_CreateWindow(EGLNativeWindowType win, EGLNativ
 		return win;
 }
 
+static void nullws_DestroyWindow(EGLNativeWindowType win)
+{
+	// TODO: Cleanup?
+}
+
 static __eglMustCastToProperFunctionPointerType nullws_eglGetProcAddress(const char *procname) 
 {
 	return NULL;
@@ -56,6 +61,7 @@ const char *nullws_eglQueryString(EGLDisplay dpy, EGLint name, const char *(*rea
 struct ws_module ws_module_info = {
 	nullws_IsValidDisplay,
 	nullws_CreateWindow,
+	nullws_DestroyWindow,
 	nullws_eglGetProcAddress,
 	nullws_passthroughImageKHR,
 	nullws_eglQueryString

--- a/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
+++ b/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
@@ -68,6 +68,13 @@ extern "C" EGLNativeWindowType waylandws_CreateWindow(EGLNativeWindowType win, E
 	return (EGLNativeWindowType) *(new WaylandNativeWindow((struct wl_egl_window *) win, (struct wl_display *) display, gralloc, alloc));
 }
 
+extern "C" void waylandws_DestroyWindow(EGLNativeWindowType win)
+{
+	struct wl_egl_window *eglwin = (struct wl_egl_window *) win;
+	WaylandNativeWindow *window = (WaylandNativeWindow *)(eglwin->nativewindow);
+	// TODO: Do any necessary cleanup on window, then delete it
+}
+
 extern "C" int waylandws_post(EGLNativeWindowType win, void *buffer)
 {
 	struct wl_egl_window *eglwin = (struct wl_egl_window *) win;
@@ -93,6 +100,7 @@ extern "C" void waylandws_passthroughImageKHR(EGLenum *target, EGLClientBuffer *
 struct ws_module ws_module_info = {
 	waylandws_IsValidDisplay,
 	waylandws_CreateWindow,
+	waylandws_DestroyWindow,
 	waylandws_eglGetProcAddress,
 	waylandws_passthroughImageKHR,
 	eglplatformcommon_eglQueryString

--- a/hybris/egl/ws.c
+++ b/hybris/egl/ws.c
@@ -66,6 +66,12 @@ EGLNativeWindowType ws_CreateWindow(EGLNativeWindowType win, EGLNativeDisplayTyp
 	return ws->CreateWindow(win, display);
 }
 
+void ws_DestroyWindow(EGLNativeWindowType win)
+{
+	_init_ws();
+	return ws->DestroyWindow(win);
+}
+
 __eglMustCastToProperFunctionPointerType ws_eglGetProcAddress(const char *procname)
 {
 	_init_ws();

--- a/hybris/egl/ws.h
+++ b/hybris/egl/ws.h
@@ -5,6 +5,7 @@
 struct ws_module {
 	int (*IsValidDisplay)(EGLNativeDisplayType display_id);
 	EGLNativeWindowType (*CreateWindow)(EGLNativeWindowType win, EGLNativeDisplayType display);
+	void (*DestroyWindow)(EGLNativeWindowType win);
 	__eglMustCastToProperFunctionPointerType (*eglGetProcAddress)(const char *procname);
 	void (*passthroughImageKHR)(EGLenum *target, EGLClientBuffer *buffer);
 	const char *(*eglQueryString)(EGLDisplay dpy, EGLint name, const char *(*real_eglQueryString)(EGLDisplay dpy, EGLint name));
@@ -12,6 +13,7 @@ struct ws_module {
 
 int ws_IsValidDisplay(EGLNativeDisplayType display);
 EGLNativeWindowType ws_CreateWindow(EGLNativeWindowType win, EGLNativeDisplayType display);
+void ws_DestroyWindow(EGLNativeWindowType win);
 __eglMustCastToProperFunctionPointerType ws_eglGetProcAddress(const char *procname);
 void ws_passthroughImageKHR(EGLenum *target, EGLClientBuffer *buffer);
 const char *ws_eglQueryString(EGLDisplay dpy, EGLint name, const char *(*real_eglQueryString)(EGLDisplay dpy, EGLint name));


### PR DESCRIPTION
This is mostly needed so we can call `eglCreateWindowSurface` and `eglDestroySurface` in alternating fashion without all calls but the first failing (with `EGLPLATFORM=fbdev`).

However, it might also make sense for other platforms to clean up resources allocated in `CreateWindow` (see `TODO` comments in the platforms for which I wasn't sure what kind of clean-up is necessary).
