### PR TITLE
Only build NFC if libnfc-nxp headers are available.

### DIFF
--- a/hybris/Makefile.am
+++ b/hybris/Makefile.am
@@ -5,7 +5,9 @@ SUBDIRS += libsync
 endif
 
 SUBDIRS += egl glesv1 glesv2 ui sf input camera
+if HAS_LIBNFC_NXP_HEADERS
 SUBDIRS += libnfc_nxp libnfc_ndef_nxp
+endif
 SUBDIRS += tests
 
 

--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -131,6 +131,8 @@ AM_CONDITIONAL([HAS_ANDROID_4_1_0], [test $android_headers_major -ge 4 -a $andro
 AM_CONDITIONAL([HAS_ANDROID_4_0_0], [test $android_headers_major -ge 4 -a $android_headers_minor -ge 0 ])
 AM_CONDITIONAL([HAS_ANDROID_2_3_0], [test $android_headers_major -ge 2 -a $android_headers_minor -ge 3 ])
 
+AM_CONDITIONAL([HAS_LIBNFC_NXP_HEADERS], [test -f ${android_headers_path}/libnfc-nxp/phLibNfc.h])
+
 AC_CONFIG_FILES([
 	Makefile
 	common/Makefile

--- a/hybris/tests/Makefile.am
+++ b/hybris/tests/Makefile.am
@@ -5,14 +5,16 @@ bin_PROGRAMS = \
 	test_sf \
 	test_sensors \
 	test_input \
-	test_camera \
-	test_nfc
+	test_camera
 
 if HAS_ANDROID_4_2_0
 bin_PROGRAMS += test_hwcomposer
 bin_PROGRAMS += test_gps
 endif
 
+if HAS_LIBNFC_NXP_HEADERS
+bin_PROGRAMS += test_nfc
+endif
 
 # Please re-enable your test programs according to android
 # if HAS_ANDROID_X_Y_Z


### PR DESCRIPTION
NFC headers may not always be available so cannot use the existing Android version checks. Instead check if the main libnfc-nxp header is available.
