### PR TITLE
hooks.c: also add a matching sysconf for _SC_NPROCESSORS_ONLN

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -1186,6 +1186,8 @@ long my_sysconf(int name)
     return sysconf(_SC_PAGE_SIZE);
   case 0x60:
     return sysconf(_SC_NPROCESSORS_CONF);
+  case 0x61:
+    return sysconf(_SC_NPROCESSORS_ONLN);
   default:
     break;
   }


### PR DESCRIPTION
Used by libstagefright.

Signed-off-by: Ricardo Salveti de Araujo ricardo.salveti@canonical.com
