### PR TITLE
logging: Add thread id and some formatting to HYBRIS_LOG

### DIFF
--- a/hybris/common/logging.c
+++ b/hybris/common/logging.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <pthread.h>
 
 FILE *hybris_logging_target = NULL;
 
@@ -77,3 +78,8 @@ hybris_set_log_level(enum hybris_log_level level)
     hybris_minimum_log_level = level;
 }
 
+void *
+hybris_get_thread_id()
+{
+    return (void *)pthread_self();
+}

--- a/hybris/common/logging.h
+++ b/hybris/common/logging.h
@@ -58,6 +58,9 @@ hybris_should_log(enum hybris_log_level level);
 void
 hybris_set_log_level(enum hybris_log_level level);
 
+void *
+hybris_get_thread_id();
+
 #ifdef __cplusplus
 }
 #endif
@@ -67,7 +70,8 @@ extern FILE *hybris_logging_target;
 #if defined(DEBUG)
 #    define HYBRIS_LOG_(level, module, message, ...) do { \
           if (hybris_should_log(level)) { \
-              fprintf(hybris_logging_target, "%s %s:%d (%s) %s: " message "\n", \
+              fprintf(hybris_logging_target, "<%p> [%s] %s:%d (%s) %s: " message "\n", \
+                      hybris_get_thread_id(), \
                       module, __FILE__, __LINE__, __PRETTY_FUNCTION__, \
                       #level + 11 /* + 11 = strip leading "HYBRIS_LOG_" */, \
                       ##__VA_ARGS__); \


### PR DESCRIPTION
Since we are doing multithreaded rendering, current thread is usually
relevant information.

Since touching it, add some formatting to visually separate elements
in the beginning of the line.
