### PR TITLE
Add access function hook

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -1440,6 +1440,8 @@ static struct _hook hooks[] = {
     {"timer_getoverrun", timer_getoverrun},
     {"abort", abort},
     {"writev", writev},
+    /* unistd.h */
+    {"access", access},
     /* grp.h */
     {"getgrgid", getgrgid},
     {"__cxa_atexit", __cxa_atexit},


### PR DESCRIPTION
Added hook to this function so that it is handled by glibc instead
of bionic.

Signed-off-by: Mikko Hurskainen mikko.hurskainen@nomovok.com
