### PR TITLE
Only read NDEF messages from tags verified to have NDEF messages.

### DIFF
--- a/hybris/tests/test_nfc.c
+++ b/hybris/tests/test_nfc.c
@@ -268,7 +268,9 @@ void testNfc(int readNdefMessages)
                             pthread_cond_wait(&cond, &mut);
                         pthread_mutex_unlock(&mut);
 
-                        if (targetStatus == NFCSTATUS_SUCCESS) {
+                        if (targetStatus == NFCSTATUS_SUCCESS &&
+                            (ndefInfo.NdefCardState == PHLIBNFC_NDEF_CARD_READ_WRITE ||
+                             ndefInfo.NdefCardState == PHLIBNFC_NDEF_CARD_READ_ONLY)) {
                             phLibNfc_Data_t ndefBuffer;
                             ndefBuffer.length = ndefInfo.MaxNdefMsgLength;
                             ndefBuffer.buffer = malloc(ndefBuffer.length);


### PR DESCRIPTION
The phLibNfc_Ndef_CheckNdef() function reports the NDEF card state.
Attempting to read an NDEF message from a tag in the INVALID or
INITIALIZED state fails to call the read NDEF callback function. Don't
read NDEF messages unless the tag is in the READ_WRITE or READ_ONLY
states.
