### PR TITLE
egl,QueryWaylandBufferWL: return EGL_TEXTURE_* as EGL_TEXTURE_FORMAT

### DIFF
--- a/hybris/egl/platforms/common/eglplatformcommon.cpp
+++ b/hybris/egl/platforms/common/eglplatformcommon.cpp
@@ -91,7 +91,19 @@ extern "C" EGLBoolean eglplatformcommon_eglQueryWaylandBufferWL(EGLDisplay dpy,
 	ANativeWindowBuffer* anwb = (ANativeWindowBuffer *) buf->buf;
 
 	if (attribute == EGL_TEXTURE_FORMAT) {
-		*value = anwb->format;
+		switch(anwb->format) {
+		case HAL_PIXEL_FORMAT_RGB_565:
+			*value = EGL_TEXTURE_RGB;
+			break;
+		case HAL_PIXEL_FORMAT_RGBA_8888:
+			*value = EGL_TEXTURE_RGBA;
+			break;
+		case 0x3231564E: // HAL_PIXEL_FORMAT_NV12
+			*value = EGL_TEXTURE_Y_UV_WL;
+			break;
+		default:
+			*value = anwb->format;
+		}
 		return EGL_TRUE;
 	}
 	if (attribute == EGL_WIDTH) {


### PR DESCRIPTION
problem:
    the native buffer format was returned (HAL_PIXEL_FORMAT__)
fix:
    map HAL_PIXEL_FORMAT__ to EGL_TEXTURE_*

Signed-off-by: Adrian Negreanu adrian.m.negreanu@intel.com
