### PR TITLE
egl: wayland: Avoid a crash that is likely some race condition

### DIFF
--- a/hybris/egl/platforms/wayland/wayland_window.cpp
+++ b/hybris/egl/platforms/wayland/wayland_window.cpp
@@ -151,6 +151,8 @@ WaylandNativeWindow::WaylandNativeWindow(struct wl_egl_window *window, struct wl
 
 WaylandNativeWindow::~WaylandNativeWindow()
 {
+    // Dispatch here to avoid a racy(?) crash
+    wl_display_dispatch_queue(m_display, wl_queue);
     std::list<WaylandNativeWindowBuffer *>::iterator it = m_bufList.begin();
     for (; it != m_bufList.end(); it++)
     {


### PR DESCRIPTION
Dispatching the wayland queue in WaylandNativeWindow destructor avoids
a crash that seems to happen when the window is first destroyed and quickly
re-created (eg. startup resize).
