### PR TITLE
eglQueryWaylandBufferWL: drop EGL_TEXTURE_Y_UV_WL

### DIFF
--- a/hybris/egl/platforms/common/eglplatformcommon.cpp
+++ b/hybris/egl/platforms/common/eglplatformcommon.cpp
@@ -98,9 +98,6 @@ extern "C" EGLBoolean eglplatformcommon_eglQueryWaylandBufferWL(EGLDisplay dpy,
 		case HAL_PIXEL_FORMAT_RGBA_8888:
 			*value = EGL_TEXTURE_RGBA;
 			break;
-		case 0x3231564E: // HAL_PIXEL_FORMAT_NV12
-			*value = EGL_TEXTURE_Y_UV_WL;
-			break;
 		default:
 			*value =  EGL_TEXTURE_EXTERNAL_WL;
 		}


### PR DESCRIPTION
using EGL_TEXTURE_Y_UV_WL will also require EGL_WAYLAND_PLANE_WL,
but we don't support EGL_WAYLAND_PLANE_WL.

Signed-off-by: Adrian Negreanu adrian.m.negreanu@intel.com
