### PR TITLE
tests: add HAS_ANDROID_4_2_0 to CFLAGS for test_gps

### DIFF
--- a/hybris/tests/Makefile.am
+++ b/hybris/tests/Makefile.am
@@ -135,6 +135,10 @@ test_gps_CFLAGS = -pthread \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/include/android
 
+if HAS_ANDROID_4_2_0
+test_gps_CFLAGS += -DHAS_ANDROID_4_2_0
+endif
+
 test_gps_LDFLAGS = -pthread
 test_gps_LDADD =  \
 	$(top_builddir)/common/libhybris-common.la \


### PR DESCRIPTION
test_gps uses HAS_ANDROID_4_2_0 to determine the right GPS API to call and without
forwarding the define at compilation time it fails to compile if the wrong header set is
installed within sysroot which doesn't provide the old API.

Signed-off-by: Simon Busch morphis@gravedo.de
