### PR TITLE
egl: fbdev: Allow multiple eglGetDisplay() calls

### DIFF
--- a/hybris/egl/platforms/fbdev/eglplatform_fbdev.cpp
+++ b/hybris/egl/platforms/fbdev/eglplatform_fbdev.cpp
@@ -51,7 +51,7 @@ extern "C" int fbdevws_IsValidDisplay(EGLNativeDisplayType display)
 
 extern "C" EGLNativeWindowType fbdevws_CreateWindow(EGLNativeWindowType win, EGLNativeDisplayType display)
 {
-	assert (inited == 1);
+	assert (inited >= 1);
 	assert (_nativewindow == NULL);
 
 	_nativewindow = new FbDevNativeWindow(gralloc, alloc, framebuffer);


### PR DESCRIPTION
We don't support multiple windows but if the previous window has been
dealt with there is no reason why starting from scratch with eglGetDisplay()
would not work.

Signed-off-by: Kalle Vahlman kalle.vahlman@movial.com
