### PR TITLE
tests: test_egl should destroy the EglImageKHR it creates

### DIFF
--- a/hybris/tests/test_egl.c
+++ b/hybris/tests/test_egl.c
@@ -45,6 +45,7 @@ int main(int argc, char **argv)
 	PFNEGLHYBRISUNLOCKNATIVEBUFFERPROC eglHybrisUnlockNativeBuffer;
 	PFNEGLHYBRISRELEASENATIVEBUFFERPROC eglHybrisReleaseNativeBuffer;
 	PFNEGLCREATEIMAGEKHRPROC eglCreateImageKHR;
+	PFNEGLDESTROYIMAGEKHRPROC eglDestroyImageKHR;
 
 	display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
 	assert(eglGetError() == EGL_SUCCESS);
@@ -89,9 +90,14 @@ int main(int argc, char **argv)
 		eglHybrisUnlockNativeBuffer(buf);
 		assert((eglCreateImageKHR = (PFNEGLCREATEIMAGEKHRPROC) eglGetProcAddress("eglCreateImageKHR")) != NULL);
 		printf("Found eglCreateImageKHR\n");
-		assert(eglCreateImageKHR(
-					display, EGL_NO_CONTEXT, EGL_NATIVE_BUFFER_HYBRIS,
-					(EGLClientBuffer)buf, NULL) != EGL_NO_IMAGE_KHR);
+		EGLImageKHR image = eglCreateImageKHR(
+								display, EGL_NO_CONTEXT, EGL_NATIVE_BUFFER_HYBRIS,
+								(EGLClientBuffer)buf, NULL);
+		assert(image != EGL_NO_IMAGE_KHR);
+		assert((eglDestroyImageKHR = (PFNEGLDESTROYIMAGEKHRPROC) eglGetProcAddress("eglDestroyImageKHR")) != NULL);
+		printf("Found eglDestroyImageKHR\n");
+		assert(eglDestroyImageKHR(display, image));
+
 		assert((eglHybrisReleaseNativeBuffer = (PFNEGLHYBRISRELEASENATIVEBUFFERPROC) eglGetProcAddress("eglHybrisReleaseNativeBuffer")) != NULL);
 		printf("Found eglHybrisReleaseNativeBuffer\n");
 		eglHybrisReleaseNativeBuffer(buf);


### PR DESCRIPTION
test_egl creates an EglImageKHR but never destroys it so the EGL
drivers might be holding on to the native buffer even after test_egl
releases it.

Signed-off-by: Kalle Vahlman kalle.vahlman@movial.com
