### PR TITLE
hooks: return 0xD15EA5E for unsafe pthread functions

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -1451,7 +1451,6 @@ static struct _hook hooks[] = {
 void *get_hooked_symbol(char *sym)
 {
     struct _hook *ptr = &hooks[0];
-    static int counter = -1;
 
     while (ptr->name != NULL)
     {
@@ -1465,10 +1464,10 @@ void *get_hooked_symbol(char *sym)
         /* safe */
         if (strcmp(sym, "pthread_sigmask") == 0)
            return NULL;
+
         /* not safe */
-        counter--;
-        LOGD("%s %i\n", sym, counter);
-        return (void *) counter;
+        LOGD("0xD15EA5E %s\n", sym);
+        return (void *) 0xD15EA5E;
     }
     return NULL;
 }


### PR DESCRIPTION
if a crash was caused by an unsafe pthread function,
the backtrace had the last PC=0xFFFFFx, which isn't helping much.

To make it easier to identify the crash cause,
return 0xD15EA5E ("disease") for those unsafe pthread functions.

Signed-off-by: Adrian Negreanu adrian.m.negreanu@intel.com
