### PR TITLE
libnfc_nxp: Add support for building against Android 4.3 headers

### DIFF
--- a/hybris/libnfc_nxp/libnfc_nxp.c
+++ b/hybris/libnfc_nxp/libnfc_nxp.c
@@ -21,6 +21,8 @@
  * https://github.com/thp/libhybris-nfc-wrapper-generator
  **/
 
+#include <android/android-version.h>
+
 #include <libnfc-nxp/phNfcTypes.h>
 #include <libnfc-nxp/phNfcIoctlCode.h>
 #include <libnfc-nxp/phLibNfc.h>
@@ -457,7 +459,12 @@ HYBRIS_IMPLEMENT_FUNCTION1(libnfc_so, uint32_t, phFriNfc_Llcp_CyclicFifoAvailabl
 HYBRIS_IMPLEMENT_FUNCTION3(libnfc_so, uint32_t, phFriNfc_Llcp_Buffer2Sequence, uint8_t *, uint32_t, phFriNfc_Llcp_sPacketSequence_t *);
 HYBRIS_IMPLEMENT_VOID_FUNCTION5(libnfc_so, Handle_ConnectionOriented_IncommingFrame, phFriNfc_LlcpTransport_t *, phNfc_sData_t *, uint8_t, uint8_t, uint8_t);
 HYBRIS_IMPLEMENT_VOID_FUNCTION4(libnfc_so, Handle_Connectionless_IncommingFrame, phFriNfc_LlcpTransport_t *, phNfc_sData_t *, uint8_t, uint8_t);
+#if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=3
+/* see libnfc-nxp commit 7c4b4fad -- since Android 4.3 */
+HYBRIS_IMPLEMENT_FUNCTION7(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_LinkSend, phFriNfc_LlcpTransport_t *, phFriNfc_Llcp_sPacketHeader_t *, phFriNfc_Llcp_sPacketSequence_t *, phNfc_sData_t *, phFriNfc_Llcp_LinkSend_CB_t, uint8_t, void *);
+#else
 HYBRIS_IMPLEMENT_FUNCTION6(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_LinkSend, phFriNfc_LlcpTransport_t *, phFriNfc_Llcp_sPacketHeader_t *, phFriNfc_Llcp_sPacketSequence_t *, phNfc_sData_t *, phFriNfc_Llcp_Send_CB_t, void *);
+#endif
 HYBRIS_IMPLEMENT_FUNCTION13(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_SendFrameReject, phFriNfc_LlcpTransport_t *, uint8_t, uint8_t, uint8_t, phFriNfc_Llcp_sPacketSequence_t *, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t);
 HYBRIS_IMPLEMENT_FUNCTION1(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_ConnectionOriented_Close, phFriNfc_LlcpTransport_Socket_t *);
 HYBRIS_IMPLEMENT_FUNCTION4(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_SendDisconnectMode, phFriNfc_LlcpTransport_t *, uint8_t, uint8_t, uint8_t);


### PR DESCRIPTION
Signed-off-by: Thomas Perl thomas.perl@jolla.com
