### PR TITLE
wayland_window: Fix removed enum in Android 4.3

### DIFF
--- a/hybris/egl/platforms/wayland/wayland_window.cpp
+++ b/hybris/egl/platforms/wayland/wayland_window.cpp
@@ -588,7 +588,12 @@ unsigned int WaylandNativeWindow::queueLength() const {
 
 unsigned int WaylandNativeWindow::type() const {
     TRACE("");
+#if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=3
+    /* https://android.googlesource.com/platform/system/core/+/bcfa910611b42018db580b3459101c564f802552%5E!/ */
+    return NATIVE_WINDOW_SURFACE;
+#else
     return NATIVE_WINDOW_SURFACE_TEXTURE_CLIENT;
+#endif
 }
 
 unsigned int WaylandNativeWindow::transformHint() const {


### PR DESCRIPTION
The `NATIVE_WINDOW_SURFACE_TEXTURE_CLIENT` value has been removed in Android 4.3. Work around it by using `NATIVE_WINDOW_SURFACE` instead.

This is **untested**, but lets me at least build libhybris with Wayland support against Android 4.3 headers. You might not want to merge it at this point (until somebody actually tested it works), but keep it as a reminder that we'll need to fix this once 4.3 is more widespread.
