### PR TITLE
Extract headers improvements

### DIFF
--- a/utils/extract-headers.sh
+++ b/utils/extract-headers.sh
@@ -53,11 +53,60 @@ if [ x$MAJOR = x -o x$MINOR = x -o x$PATCH = x ]; then
     fi
 fi
 
+require_sources() {
+    # require_sources [FILE|DIR] ...
+    # Check if the given paths exist in the Android source
+    while [ $# -gt 0 ]; do
+        SOURCE_PATH=$ANDROID_ROOT/$1
+        shift
+
+        if [ ! -e "$SOURCE_PATH" ]; then
+            echo "Cannot extract headers: '$SOURCE_PATH' does not exist."
+            exit 1
+        fi
+    done
+}
+
+extract_headers_to() {
+    # extract_headers_to <TARGET> [FILE|DIR] ...
+    # For each FILE argument, copy it to TARGET
+    # For each DIR argument, copy all its contents to TARGET
+    TARGET_DIRECTORY=$HEADERPATH/$1
+    if [ ! -d "$TARGET_DIRECTORY" ]; then
+        mkdir -p "$TARGET_DIRECTORY"
+    fi
+    echo "  $1"
+    shift
+
+    while [ $# -gt 0 ]; do
+        SOURCE_PATH=$ANDROID_ROOT/$1
+        if [ -d $SOURCE_PATH ]; then
+            for file in $SOURCE_PATH/*; do
+                echo "    $1/$(basename $file)"
+                cp $file $TARGET_DIRECTORY/
+            done
+        else
+            echo "    $1"
+            cp $SOURCE_PATH $TARGET_DIRECTORY/
+        fi
+        shift
+    done
+}
+
+check_header_exists() {
+    # check_header_exists <FILENAME>
+    HEADER_FILE=$ANDROID_ROOT/$1
+    if [ ! -e "$HEADER_FILE" ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+
 # Make sure that the dir given contains at least some of the assumed structures.
-if [ ! -d "$ANDROID_ROOT/hardware/libhardware/include/hardware/" ]; then
-    echo "Given Android root dir '$ANDROID_ROOT/hardware/libhardware/include/hardware/' doesn't exist."
-    exit 1
-fi
+require_sources \
+    hardware/libhardware/include/hardware
 
 mkdir -p $HEADERPATH
 
@@ -82,40 +131,37 @@ cat > $HEADERPATH/android-version.h << EOF
 #endif
 EOF
 
-mkdir -p $HEADERPATH/hardware/
-cp $ANDROID_ROOT/hardware/libhardware/include/hardware/* $HEADERPATH/hardware/
+extract_headers_to hardware \
+    hardware/libhardware/include/hardware
 
-mkdir -p $HEADERPATH/hardware_legacy/
-cp $ANDROID_ROOT/hardware/libhardware_legacy/include/hardware_legacy/audio_policy_conf.h $HEADERPATH/hardware_legacy/
+extract_headers_to hardware_legacy \
+    hardware/libhardware_legacy/include/hardware_legacy/audio_policy_conf.h
 
-mkdir -p $HEADERPATH/cutils/
-cp $ANDROID_ROOT/system/core/include/cutils/* $HEADERPATH/cutils/
+extract_headers_to cutils \
+    system/core/include/cutils
 
-mkdir -p $HEADERPATH/system/
-cp $ANDROID_ROOT/system/core/include/system/* $HEADERPATH/system/
+extract_headers_to system \
+    system/core/include/system
 
-mkdir -p $HEADERPATH/android/
-cp $ANDROID_ROOT/system/core/include/android/* $HEADERPATH/android/
+extract_headers_to android \
+    system/core/include/android
 
-if [ -e $ANDROID_ROOT/external/kernel-headers/original/linux/sync.h ]; then
-	mkdir -p $HEADERPATH/linux
-	cp $ANDROID_ROOT/external/kernel-headers/original/linux/sync.h $HEADERPATH/linux
-	cp $ANDROID_ROOT/external/kernel-headers/original/linux/sw_sync.h $HEADERPATH/linux
-fi
+check_header_exists external/kernel-headers/original/linux/sync.h && \
+    extract_headers_to linux \
+        external/kernel-headers/original/linux/sync.h \
+        external/kernel-headers/original/linux/sw_sync.h
 
-if [ -e $ANDROID_ROOT/system/core/include/sync/sync.h ]; then
-	mkdir -p $HEADERPATH/sync/
-	cp $ANDROID_ROOT/system/core/include/sync/* $HEADERPATH/sync/
-fi
+check_header_exists system/core/include/sync/sync.h && \
+    extract_headers_to sync \
+        system/core/include/sync
 
-if [ -e $ANDROID_ROOT/external/libnfc-nxp/inc/phNfcConfig.h ]; then
-	mkdir -p $HEADERPATH/libnfc-nxp/
-	cp $ANDROID_ROOT/external/libnfc-nxp/inc/*.h $HEADERPATH/libnfc-nxp/
-	cp $ANDROID_ROOT/external/libnfc-nxp/src/*.h $HEADERPATH/libnfc-nxp/
-fi
+check_header_exists external/libnfc-nxp/inc/phNfcConfig.h && \
+    extract_headers_to libnfc-nxp \
+        external/libnfc-nxp/inc \
+        external/libnfc-nxp/src
 
-mkdir -p $HEADERPATH/private
-cp $ANDROID_ROOT/system/core/include/private/android_filesystem_config.h $HEADERPATH/private
+extract_headers_to private \
+    system/core/include/private/android_filesystem_config.h
 
 
 # In order to make it easier to trace back the origins of headers, fetch
@@ -132,6 +178,7 @@ GIT_PROJECTS="
     external/libnfc-nxp
 "
 
+echo "Extracting Git revision information"
 rm -f $HEADERPATH/SOURCE_GIT_REVISION_INFO
 (for GIT_PROJECT in $GIT_PROJECTS; do
     TARGET_DIR=$ANDROID_ROOT/$GIT_PROJECT
@@ -141,6 +188,7 @@ rm -f $HEADERPATH/SOURCE_GIT_REVISION_INFO
     if [ -e $TARGET_DIR/.git ]; then
         (
         set -x
+        cd $ANDROID_ROOT
         repo status $GIT_PROJECT
         cd $TARGET_DIR
         git show-ref --head


### PR DESCRIPTION
Add additional metadata (Git/repo) from Android sources to make it easier to trace back from where a set of extracted headers comes from.

Also simplify extract-headers.sh so that it prints out which headers are extracted, which is useful in case the script is used in some automated build/deployment scripts (for later checking which files were copied).
