### PR TITLE
egl: wayland: Print out also the actual error on fatal error

### DIFF
--- a/hybris/egl/platforms/wayland/wayland_window.cpp
+++ b/hybris/egl/platforms/wayland/wayland_window.cpp
@@ -133,12 +133,18 @@ WaylandNativeWindow::wayland_roundtrip(WaylandNativeWindow *display)
 
 static void check_fatal_error(struct wl_display *display)
 {
-    if (wl_display_get_error(display) != 0)
-    {
-        fprintf(stderr, "Wayland display got fatal error %i: %s\n", errno, strerror(errno));
-        fprintf(stderr, "The display is now unusable, aborting.\n");
-        abort();
-    }
+    int error = wl_display_get_error(display);
+
+    if (error == 0)
+        return;
+
+    fprintf(stderr, "Wayland display got fatal error %i: %s\n", error, strerror(error));
+
+    if (errno != 0)
+        fprintf(stderr, "Additionally, errno was set to %i: %s\n", errno, strerror(errno));
+
+    fprintf(stderr, "The display is now unusable, aborting.\n");
+    abort();
 }
 
     static void


### PR DESCRIPTION
Not everything sets errno when returning an error, but they do seem
to return strerror-compatible errors.

So let's try to print those out and also errno if it is set so we
see if there is additional info reported there.

Signed-off-by: Kalle Vahlman kalle.vahlman@movial.com
