### PR TITLE
egl: wayland: fix debug dump for first buffer sent to wayland compositor

### DIFF
--- a/hybris/egl/platforms/wayland/wayland_window.cpp
+++ b/hybris/egl/platforms/wayland/wayland_window.cpp
@@ -482,7 +482,8 @@ int WaylandNativeWindow::queueBuffer(BaseNativeWindowBuffer* buffer, int fenceFd
             debugenvchecked = 2;
         else
             debugenvchecked = 1;
-    } else if (debugenvchecked == 2)
+    }
+    if (debugenvchecked == 2)
     {
         HYBRIS_TRACE_BEGIN("wayland-platform", "queueBuffer_dumping_buffer", "-%p", wnb);
         hybris_dump_buffer_to_file(wnb->getNativeBuffer());


### PR DESCRIPTION
When evaluating debugenvchecked for the first time, we don't go into the actual dump code because of the "else", so let's remove it.

Signed-off-by: Christophe Chapuis chris.chapuis@gmail.com
