### PR TITLE
hooks.c: adding hooks for asprintf and vasprintf (both use malloc/realloc internally)

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -1368,6 +1368,8 @@ static struct _hook hooks[] = {
     {"popen", popen},
     {"puts", puts},
     {"sprintf", sprintf},
+    {"asprintf", asprintf},
+    {"vasprintf", vasprintf},
     {"snprintf", snprintf},
     {"vsprintf", vsprintf},
     {"vsnprintf", vsnprintf},


### PR DESCRIPTION
Signed-off-by: Ricardo Salveti de Araujo ricardo.salveti@canonical.com
