### PR TITLE
egl: Fix calling down to eglCreateImageKHR() with proper arguments

### DIFF
--- a/hybris/egl/egl.c
+++ b/hybris/egl/egl.c
@@ -421,18 +421,13 @@ EGLBoolean eglCopyBuffers(EGLDisplay dpy, EGLSurface surface,
 static EGLImageKHR _my_eglCreateImageKHR(EGLDisplay dpy, EGLContext ctx, EGLenum target, EGLClientBuffer buffer, const EGLint *attrib_list)
 {
 	EGL_DLSYM(&_eglCreateImageKHR, "eglCreateImageKHR");
+	EGLContext newctx = ctx;
 	EGLenum newtarget = target;
 	EGLClientBuffer newbuffer = buffer;
+	const EGLint *newattrib_list = attrib_list;
 
-	ws_passthroughImageKHR(&newtarget, &newbuffer);
-	if (newtarget == EGL_NATIVE_BUFFER_ANDROID)
-	{
-		assert(((struct ANativeWindowBuffer *) newbuffer)->common.magic == ANDROID_NATIVE_BUFFER_MAGIC);
-		attrib_list=NULL;
-	}
-
-	EGLImageKHR ret = (*_eglCreateImageKHR)(dpy, EGL_NO_CONTEXT, newtarget, newbuffer, attrib_list);
-	return ret;
+	ws_passthroughImageKHR(&newctx, &newtarget, &newbuffer, &newattrib_list);
+	return (*_eglCreateImageKHR)(dpy, newctx, newtarget, newbuffer, newattrib_list);
 }
 
 static void _my_glEGLImageTargetTexture2DOES(GLenum target, GLeglImageOES image)

--- a/hybris/egl/platforms/common/eglplatformcommon.cpp
+++ b/hybris/egl/platforms/common/eglplatformcommon.cpp
@@ -179,7 +179,7 @@ extern "C" EGLBoolean eglplatformcommon_eglHybrisReleaseNativeBuffer(EGLClientBu
 
 
 extern "C" void
-eglplatformcommon_passthroughImageKHR(EGLenum *target, EGLClientBuffer *buffer)
+eglplatformcommon_passthroughImageKHR(EGLContext *ctx, EGLenum *target, EGLClientBuffer *buffer, const EGLint **attrib_list)
 {
 #ifdef WANT_WAYLAND
 	static int debugenvchecked = 0;
@@ -200,6 +200,8 @@ eglplatformcommon_passthroughImageKHR(EGLenum *target, EGLClientBuffer *buffer)
 		}
 		*buffer = (EGLClientBuffer) (ANativeWindowBuffer *) buf->buf;
 		*target = EGL_NATIVE_BUFFER_ANDROID;
+		*ctx = EGL_NO_CONTEXT;
+		*attrib_list = NULL;
 	}
 #endif
 }

--- a/hybris/egl/platforms/common/eglplatformcommon.h
+++ b/hybris/egl/platforms/common/eglplatformcommon.h
@@ -6,6 +6,6 @@
 
 void eglplatformcommon_init(gralloc_module_t *gralloc, alloc_device_t *allocdevice);
 __eglMustCastToProperFunctionPointerType eglplatformcommon_eglGetProcAddress(const char *procname);
-void eglplatformcommon_passthroughImageKHR(EGLenum *target, EGLClientBuffer *buffer);
+void eglplatformcommon_passthroughImageKHR(EGLContext *ctx, EGLenum *target, EGLClientBuffer *buffer, const EGLint **attrib_list);
 const char *eglplatformcommon_eglQueryString(EGLDisplay dpy, EGLint name, const char *(*real_eglQueryString)(EGLDisplay dpy, EGLint name));
 #endif

--- a/hybris/egl/platforms/fbdev/eglplatform_fbdev.cpp
+++ b/hybris/egl/platforms/fbdev/eglplatform_fbdev.cpp
@@ -74,9 +74,9 @@ extern "C" __eglMustCastToProperFunctionPointerType fbdevws_eglGetProcAddress(co
 	return eglplatformcommon_eglGetProcAddress(procname);
 }
 
-extern "C" void fbdevws_passthroughImageKHR(EGLenum *target, EGLClientBuffer *buffer)
+extern "C" void fbdevws_passthroughImageKHR(EGLContext *ctx, EGLenum *target, EGLClientBuffer *buffer, const EGLint **attrib_list)
 {
-	eglplatformcommon_passthroughImageKHR(target, buffer);
+	eglplatformcommon_passthroughImageKHR(ctx, target, buffer, attrib_list);
 }
 
 struct ws_module ws_module_info = {

--- a/hybris/egl/platforms/hwcomposer/eglplatform_hwcomposer.cpp
+++ b/hybris/egl/platforms/hwcomposer/eglplatform_hwcomposer.cpp
@@ -68,9 +68,9 @@ extern "C" __eglMustCastToProperFunctionPointerType hwcomposerws_eglGetProcAddre
 	return eglplatformcommon_eglGetProcAddress(procname);
 }
 
-extern "C" void hwcomposerws_passthroughImageKHR(EGLenum *target, EGLClientBuffer *buffer)
+extern "C" void hwcomposerws_passthroughImageKHR(EGLContext *ctx, EGLenum *target, EGLClientBuffer *buffer, const EGLint **attrib_list)
 {
-	eglplatformcommon_passthroughImageKHR(target, buffer);
+	eglplatformcommon_passthroughImageKHR(ctx, target, buffer, attrib_list);
 }
 
 struct ws_module ws_module_info = {

--- a/hybris/egl/platforms/null/eglplatform_null.c
+++ b/hybris/egl/platforms/null/eglplatform_null.c
@@ -48,7 +48,7 @@ static __eglMustCastToProperFunctionPointerType nullws_eglGetProcAddress(const c
 	return NULL;
 }
 
-static void nullws_passthroughImageKHR(EGLenum *target, EGLClientBuffer *buffer)
+static void nullws_passthroughImageKHR(EGLContext *ctx, EGLenum *target, EGLClientBuffer *buffer, const EGLint **attrib_list)
 {
 }
 

--- a/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
+++ b/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
@@ -93,9 +93,9 @@ extern "C" __eglMustCastToProperFunctionPointerType waylandws_eglGetProcAddress(
 	return eglplatformcommon_eglGetProcAddress(procname);
 }
 
-extern "C" void waylandws_passthroughImageKHR(EGLenum *target, EGLClientBuffer *buffer)
+extern "C" void waylandws_passthroughImageKHR(EGLContext *ctx, EGLenum *target, EGLClientBuffer *buffer, const EGLint **attrib_list)
 {
-	eglplatformcommon_passthroughImageKHR(target, buffer);
+	eglplatformcommon_passthroughImageKHR(ctx, target, buffer, attrib_list);
 }
 
 struct ws_module ws_module_info = {

--- a/hybris/egl/ws.c
+++ b/hybris/egl/ws.c
@@ -78,10 +78,10 @@ __eglMustCastToProperFunctionPointerType ws_eglGetProcAddress(const char *procna
 	return ws->eglGetProcAddress(procname);
 }
 
-void ws_passthroughImageKHR(EGLenum *target, EGLClientBuffer *buffer)
+void ws_passthroughImageKHR(EGLContext *ctx, EGLenum *target, EGLClientBuffer *buffer, const EGLint **attrib_list)
 {
 	_init_ws();
-	return ws->passthroughImageKHR(target, buffer);
+	return ws->passthroughImageKHR(ctx, target, buffer, attrib_list);
 }
 
 const char *ws_eglQueryString(EGLDisplay dpy, EGLint name, const char *(*real_eglQueryString)(EGLDisplay dpy, EGLint name))

--- a/hybris/egl/ws.h
+++ b/hybris/egl/ws.h
@@ -7,7 +7,7 @@ struct ws_module {
 	EGLNativeWindowType (*CreateWindow)(EGLNativeWindowType win, EGLNativeDisplayType display);
 	void (*DestroyWindow)(EGLNativeWindowType win);
 	__eglMustCastToProperFunctionPointerType (*eglGetProcAddress)(const char *procname);
-	void (*passthroughImageKHR)(EGLenum *target, EGLClientBuffer *buffer);
+	void (*passthroughImageKHR)(EGLContext *ctx, EGLenum *target, EGLClientBuffer *buffer, const EGLint **attrib_list);
 	const char *(*eglQueryString)(EGLDisplay dpy, EGLint name, const char *(*real_eglQueryString)(EGLDisplay dpy, EGLint name));
 };
 
@@ -15,7 +15,7 @@ int ws_IsValidDisplay(EGLNativeDisplayType display);
 EGLNativeWindowType ws_CreateWindow(EGLNativeWindowType win, EGLNativeDisplayType display);
 void ws_DestroyWindow(EGLNativeWindowType win);
 __eglMustCastToProperFunctionPointerType ws_eglGetProcAddress(const char *procname);
-void ws_passthroughImageKHR(EGLenum *target, EGLClientBuffer *buffer);
+void ws_passthroughImageKHR(EGLContext *ctx, EGLenum *target, EGLClientBuffer *buffer, const EGLint **attrib_list);
 const char *ws_eglQueryString(EGLDisplay dpy, EGLint name, const char *(*real_eglQueryString)(EGLDisplay dpy, EGLint name));
 
 #endif


### PR DESCRIPTION
We do want to call eglCreateImageKHR() with EGL_NO_CONTEXT, but ONLY
when the render target is EGL_NATIVE_BUFFER_ANDROID. Otherwise we'll
either not get a valid image even if we should or worse, end up crashing
if the drivers don't handle it properly.

While we are touching the code, change it so the ws has an opportunity to
change all the parameters should it have specific needs for things like this.

Signed-off-by: Kalle Vahlman kalle.vahlman@movial.com
