### PR TITLE
eglplatform: use unsigned long instead of 32-bit ints in generic platform

### DIFF
--- a/hybris/include/EGL/eglplatform.h
+++ b/hybris/include/EGL/eglplatform.h
@@ -113,8 +113,8 @@ typedef void                        *EGLNativeDisplayType;
 #ifdef MESA_EGL_NO_X11_HEADERS
 
 typedef void            *EGLNativeDisplayType;
-typedef khronos_uint32_t EGLNativePixmapType;
-typedef khronos_uint32_t EGLNativeWindowType;
+typedef khronos_uintptr_t EGLNativePixmapType;
+typedef khronos_uintptr_t EGLNativeWindowType;
 
 #else
 


### PR DESCRIPTION
In the generic Unix case use the "unsigned long" type instead of 32-bit
integers so that the type sizes are consistant on 64-bit machines between X11
and not-X11.

Signed-off-by: Ross Burton ross.burton@intel.com
Reviewed-by: Chad Versace chad.versace@linux.intel.com
Reviewed-by: Brian Paul brianp@vmware.com
