### PR TITLE
Rely solely on "buffer release" to recycle buffers.

### DIFF
--- a/hybris/egl/platforms/wayland/wayland_window.h
+++ b/hybris/egl/platforms/wayland/wayland_window.h
@@ -105,7 +105,6 @@ public:
 
     void lock();
     void unlock();
-    void frame();
     void releaseBuffer(struct wl_buffer *buffer);
     int postBuffer(ANativeWindowBuffer *buffer);
 


### PR DESCRIPTION
The frame signal is tied to a surface, not a buffer so using frame to recycle buffers on makes the code more complicated and block-prone.

Signed-off-by: Gunnar Sletta gunnar.sletta@jollamobile.com
