### PR TITLE
Zero call overhead glesv2 wrapper

### DIFF
--- a/hybris/glesv2/glesv2.c
+++ b/hybris/glesv2/glesv2.c
@@ -21,7 +21,6 @@
 #include <dlfcn.h>
 #include <stddef.h>
 #include <stdlib.h>
-#include <stdio.h>
 
 #include <hybris/internal/binding.h>
 #include <hybris/internal/floating_point_abi.h>
@@ -49,6 +48,10 @@ static void         (*_glVertexAttrib4f)(GLuint indx, GLfloat x, GLfloat y, GLfl
 
 
 #define GLES2_LOAD(sym)  { *(&_ ## sym) = (void *) android_dlsym(_libglesv2, #sym);  } 
+
+/*
+This generates a function that when first called overwrites it's plt entry with new address. Subsequent calls jump directly at the target function in the android library. This means effectively 0 call overhead after the first call.
+*/
 
 #define GLES2_IDLOAD(sym) \
  __asm__ (".type " #sym ", %gnu_indirect_function"); \


### PR DESCRIPTION
A new optimization using Gnu indirect dispatch symbols.

Based on insight from http://www.agner.org/optimize/blog/read.php?i=167
A modified version of that was made consisting of 2 libraries and a.out to test the actual call overhead.
using gdb every single executed instruction was saved into a text file. From this file that was larger than a small country the following was dug out (on C code they are simply: myfunc();myfunc();myfunc()):
http://pastebin.com/YRscAuSs

The executable was linked against libbar.so that provided the bridge, it had no idea about libfoo.so which was opened via dlopen from the libbar.so. And after the first call not a single instruction from that library is executed. Therefore after the first call there is no additional overhead from the wrapper, it's as if the function was linked there directly.

Therefore this new version of libGLESv2.so has exactly 0 call overhead after the first call. The function rewrites it's PLT entry, thus all subsequent calls go directly into android lib!

Highly biased benchmark on device that simply called glEnableVertexAttribArray on loop:
Newly optimized: mean 0.85s user time
Currently on Jolla: mean 1.14s user time
standard deviation for 12 repeats was on order of 0.1s so the result is significant.

While this version produces somewhat bigger library (28k, vs 19k in device). However most of the time nothing is done with this library, as all the calls go directly to the android library, with exception of the functions with floating point arguments. Those are placed together as gcc places functions that are close in c file also close in the resulting library. Therefore only 1 (2 in worst case, boundaries schmoundaries) page is kept hot. Rest of the library will be swapped out and left to anguish.
