### PR TITLE
extract bionic kernel headers

### DIFF
--- a/utils/extract-headers.sh
+++ b/utils/extract-headers.sh
@@ -157,10 +157,10 @@ extract_headers_to system \
 extract_headers_to android \
     system/core/include/android
 
-check_header_exists external/kernel-headers/original/linux/sync.h && \
+check_header_exists bionic/libc/kernel/common/linux/sync.h
     extract_headers_to linux \
-        external/kernel-headers/original/linux/sync.h \
-        external/kernel-headers/original/linux/sw_sync.h
+        bionic/libc/kernel/common/linux/sync.h \
+        bionic/libc/kernel/common/linux/sw_sync.h
 
 check_header_exists system/core/include/sync/sync.h && \
     extract_headers_to sync \
@@ -185,7 +185,6 @@ GIT_PROJECTS="
     hardware/libhardware
     hardware/libhardware_legacy
     system/core
-    external/kernel-headers
     external/libnfc-nxp
 "
 


### PR DESCRIPTION
This patch correctly extracts bionic kernel headers instead
of those under external/kernel-headers/original/.

From external/kernel-headers/original/README.txt:
  This directory contains the original kernel headers that are used to generate Bionic's "cleaned-up" user-land headers.
  They are mostly covered by the GPLv2 + exception, and thus cannot be distributed as part of the platform itself.
  (NOTE: The cleaned up headers do not contain copyrightable information and are distributed with Bionic)
