### PR TITLE
Add functions to allow buffer sharing between processes

### DIFF
--- a/hybris/egl/platforms/common/eglplatformcommon.cpp
+++ b/hybris/egl/platforms/common/eglplatformcommon.cpp
@@ -134,6 +134,42 @@ extern "C" EGLBoolean eglplatformcommon_eglQueryWaylandBufferWL(EGLDisplay dpy,
 
 #endif
 
+extern "C" void eglplatformcommon_eglHybrisGetNativeBufferInfo(EGLClientBuffer buffer, int *num_ints, int *num_fds)
+{
+	RemoteWindowBuffer *buf = static_cast<RemoteWindowBuffer *>((ANativeWindowBuffer *) buffer);
+	*num_ints = buf->handle->numInts;
+	*num_fds = buf->handle->numFds;
+}
+
+extern "C" void eglplatformcommon_eglHybrisSerializeNativeBuffer(EGLClientBuffer buffer, int *ints, int *fds)
+{
+	RemoteWindowBuffer *buf = static_cast<RemoteWindowBuffer *>((ANativeWindowBuffer *) buffer);
+	memcpy(ints, buf->handle->data + buf->handle->numFds, buf->handle->numInts * sizeof(int));
+	memcpy(fds, buf->handle->data, buf->handle->numFds * sizeof(int));
+}
+
+extern "C" EGLBoolean eglplatformcommon_eglHybrisCreateRemoteBuffer(EGLint width, EGLint height, EGLint usage, EGLint format, EGLint stride,
+                                                                    int num_ints, int *ints, int num_fds, int *fds, EGLClientBuffer *buffer)
+{
+	assert(my_gralloc != NULL);
+
+	native_handle_t *native = native_handle_create(num_fds, num_ints);
+	memcpy(&native->data[0], fds, num_fds * sizeof(int));
+	memcpy(&native->data[num_fds], ints, num_ints * sizeof(int));
+
+	int ret = my_gralloc->registerBuffer(my_gralloc, (buffer_handle_t)native);
+
+	if (ret == 0)
+	{
+		RemoteWindowBuffer *buf = new RemoteWindowBuffer(width, height, stride, format, usage, (buffer_handle_t)native, my_gralloc);
+		buf->common.incRef(&buf->common);
+		*buffer = (EGLClientBuffer) static_cast<ANativeWindowBuffer *>(buf);
+		return EGL_TRUE;
+	}
+	else
+		return EGL_FALSE;
+}
+
 extern "C" EGLBoolean eglplatformcommon_eglHybrisCreateNativeBuffer(EGLint width, EGLint height, EGLint usage, EGLint format, EGLint *stride, EGLClientBuffer *buffer)
 {
 	int ret;
@@ -260,6 +296,21 @@ extern "C" __eglMustCastToProperFunctionPointerType eglplatformcommon_eglGetProc
 	if (strcmp(procname, "eglHybrisReleaseNativeBuffer") == 0)
 	{
 		return (__eglMustCastToProperFunctionPointerType)eglplatformcommon_eglHybrisReleaseNativeBuffer;
+	}
+	else
+	if (strcmp(procname, "eglHybrisGetNativeBufferInfo") == 0)
+	{
+		return (__eglMustCastToProperFunctionPointerType)eglplatformcommon_eglHybrisGetNativeBufferInfo;
+	}
+	else
+	if (strcmp(procname, "eglHybrisSerializeNativeBuffer") == 0)
+	{
+		return (__eglMustCastToProperFunctionPointerType)eglplatformcommon_eglHybrisSerializeNativeBuffer;
+	}
+	else
+	if (strcmp(procname, "eglHybrisCreateRemoteBuffer") == 0)
+	{
+		return (__eglMustCastToProperFunctionPointerType)eglplatformcommon_eglHybrisCreateRemoteBuffer;
 	}
 	return NULL;
 }

--- a/hybris/egl/platforms/common/hybris_nativebufferext.h
+++ b/hybris/egl/platforms/common/hybris_nativebufferext.h
@@ -24,6 +24,12 @@ typedef EGLBoolean (EGLAPIENTRYP PFNEGLHYBRISLOCKNATIVEBUFFERPROC)(EGLClientBuff
 typedef EGLBoolean (EGLAPIENTRYP PFNEGLHYBRISUNLOCKNATIVEBUFFERPROC)(EGLClientBuffer buffer);
 typedef EGLBoolean (EGLAPIENTRYP PFNEGLHYBRISRELEASENATIVEBUFFERPROC)(EGLClientBuffer buffer);
 
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLHYBRISGETNATIVEBUFFERINFOPROC)(EGLClientBuffer buffer, int *num_ints, int *num_fds);
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLHYBRISSERIALIZENATIVEBUFFERPROC)(EGLClientBuffer buffer, int *ints, int *fds);
+
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLHYBRISCREATEREMOTEBUFFERPROC)(EGLint width, EGLint height, EGLint usage, EGLint format, EGLint stride,
+                                                                     int num_ints, int *ints, int num_fds, int *fds, EGLClientBuffer *buffer);
+
 enum {
     /* buffer is never read in software */
     HYBRIS_USAGE_SW_READ_NEVER         = 0x00000000,


### PR DESCRIPTION
This PR adds entry points to get the underlying ints and fds for a buffer so that they can be passed to another process which can use them to get the buffer, sharing it between both processes.
