### PR TITLE
hooks: search in librt too

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -1429,6 +1429,12 @@ void *get_hooked_symbol(char *sym)
         return rv;
     }
 
+    rv = hook_add_from_lib(sym, "librt.so");
+    if (rv != NULL) {
+        pthread_mutex_unlock(&hook_mutex);
+        return rv;
+    }
+
     rv = hook_add_from_lib(sym, "libc.so.6");
     if (rv != NULL) {
         pthread_mutex_unlock(&hook_mutex);


### PR DESCRIPTION
The clock_\* functions are provided by librt

Reported-By: Carsten Munk
Signed-off-by: Adrian Negreanu adrian.m.negreanu@intel.com
