### PR TITLE
[hybris] Don't leak gralloc buffers created by eglHybrisCreateNativeBuff...

### DIFF
--- a/hybris/egl/platforms/common/eglplatformcommon.cpp
+++ b/hybris/egl/platforms/common/eglplatformcommon.cpp
@@ -161,7 +161,7 @@ extern "C" EGLBoolean eglplatformcommon_eglHybrisCreateRemoteBuffer(EGLint width
 
 	if (ret == 0)
 	{
-		RemoteWindowBuffer *buf = new RemoteWindowBuffer(width, height, stride, format, usage, (buffer_handle_t)native, my_gralloc);
+	        RemoteWindowBuffer *buf = new RemoteWindowBuffer(width, height, stride, format, usage, (buffer_handle_t)native, my_gralloc, my_alloc);
 		buf->common.incRef(&buf->common);
 		*buffer = (EGLClientBuffer) static_cast<ANativeWindowBuffer *>(buf);
 		return EGL_TRUE;
@@ -183,8 +183,9 @@ extern "C" EGLBoolean eglplatformcommon_eglHybrisCreateNativeBuffer(EGLint width
 
 	if (ret == 0)
 	{
-		RemoteWindowBuffer *buf = new RemoteWindowBuffer(width, height, _stride, format, usage, _handle, my_gralloc);
+	        RemoteWindowBuffer *buf = new RemoteWindowBuffer(width, height, _stride, format, usage, _handle, my_gralloc, my_alloc);
 		buf->common.incRef(&buf->common);
+		buf->setAllocated(true);
 		*buffer = (EGLClientBuffer) static_cast<ANativeWindowBuffer *>(buf);
 		*stride = _stride;
 		return EGL_TRUE;

--- a/hybris/egl/platforms/common/server_wlegl_buffer.cpp
+++ b/hybris/egl/platforms/common/server_wlegl_buffer.cpp
@@ -92,7 +92,7 @@ server_wlegl_buffer_create(uint32_t id,
 	}
         
 	buffer->buf = new RemoteWindowBuffer(
-		width, height, stride, format, usage, handle, wlegl->gralloc);
+	        width, height, stride, format, usage, handle, wlegl->gralloc, NULL);
 	buffer->buf->common.incRef(&buffer->buf->common);
 	return buffer;
 }

--- a/hybris/egl/platforms/common/windowbuffer.cpp
+++ b/hybris/egl/platforms/common/windowbuffer.cpp
@@ -27,7 +27,11 @@
 
 RemoteWindowBuffer::~RemoteWindowBuffer()
 {
+    if (!m_allocated) {
 	this->m_gralloc->unregisterBuffer(this->m_gralloc, this->handle);
 	native_handle_close(this->handle);
 	native_handle_delete(const_cast<native_handle_t*>(this->handle)); 
+    } else if (this->m_alloc) {
+      this->m_alloc->free((alloc_device_t *)this->m_alloc, this->handle);
+    }
 }

--- a/hybris/egl/platforms/common/windowbuffer.h
+++ b/hybris/egl/platforms/common/windowbuffer.h
@@ -38,7 +38,8 @@ class RemoteWindowBuffer : public BaseNativeWindowBuffer
 				unsigned int format,
 				unsigned int usage,
 				buffer_handle_t handle,
-				const gralloc_module_t *gralloc	
+				const gralloc_module_t *gralloc,
+				const alloc_device_t *alloc = NULL
 				) {
 			// Base members
 			ANativeWindowBuffer::width = width;
@@ -48,9 +49,16 @@ class RemoteWindowBuffer : public BaseNativeWindowBuffer
 			ANativeWindowBuffer::stride = stride;
 			ANativeWindowBuffer::handle = handle;
 			this->m_gralloc = gralloc;
+			this->m_alloc = alloc;
+			this->m_allocated = false;
 		};
 		~RemoteWindowBuffer();
+
+		void setAllocated(bool allocated) { m_allocated = allocated; }
+
 	private:
 		const gralloc_module_t *m_gralloc;
+		const alloc_device_t *m_alloc;
+                bool m_allocated;
 };
 #endif /* WINDOWBUFFER_H */


### PR DESCRIPTION
...er()

The same class is used to wrap buffers created by eglHybrisCreateNativeBuffer()
and eglHybrisCreateRemoteBuffer() but the difference is that a native buffer
is allocated (and needs to be free'd) while a remote buffer is registered and
needs to be unregistered only.

Since major changes in that code is not a wise idea, A flag has ben added to
RemoteWindowBuffer (m_allocated) so it can detect both cases and free the allocated
buffer and unregister the registered buffer.
