### PR TITLE
Guard against too fast deletion of wl_buffers

### DIFF
--- a/hybris/egl/platforms/wayland/wayland_window.h
+++ b/hybris/egl/platforms/wayland/wayland_window.h
@@ -56,6 +56,7 @@ protected:
         ANativeWindowBuffer::format = format;
         ANativeWindowBuffer::usage = usage;
         this->wlbuffer = NULL;
+        this->creation_callback = NULL;
         this->busy = 0;
         this->other = NULL;
         this->m_alloc = alloc_device;
@@ -75,6 +76,7 @@ protected:
         ANativeWindowBuffer::handle = other->handle;
         ANativeWindowBuffer::stride = other->stride;
         this->wlbuffer = NULL;
+        this->creation_callback = NULL;
         this->busy = 0;
         this->other = other;
         this->m_alloc = NULL;
@@ -85,7 +87,9 @@ protected:
         if (this->m_alloc)
              m_alloc->free(m_alloc, this->handle);
     }
-    void wlbuffer_from_native_handle(struct android_wlegl *android_wlegl);
+    void wlbuffer_from_native_handle(struct android_wlegl *android_wlegl,
+                                     struct wl_display *display,
+                                     struct wl_event_queue *queue);
 
 protected:
     void* vaddr;
@@ -93,6 +97,7 @@ protected:
 
 public:
     struct wl_buffer *wlbuffer;
+    struct wl_callback *creation_callback;
     int busy;
     int youngest;
     ANativeWindowBuffer *other;


### PR DESCRIPTION
When creating a wl_buffer using the android_wlegl protocol the server
registers with the native handle only when it processes the request later.
If the client destroys the wl_buffer and the native handle before the server
registers with it, the native handle will be gone and trying to register it
will fail. The server will then send a protocol error because it cannot know
the handle was valid when the client issued the request.
To solve it, register a wl_callback after creating the wl_buffer, which
will be used to block before destroying a buffer if the done event was not
fired yet.

Done-with: Jonas Ådahl jadahl@gmail.com
