### PR TITLE
Add wayland-server support to nullws

### DIFF
--- a/hybris/egl/platforms/null/Makefile.am
+++ b/hybris/egl/platforms/null/Makefile.am
@@ -2,8 +2,25 @@ pkglib_LTLIBRARIES = eglplatform_null.la
 
 
 eglplatform_null_la_SOURCES = eglplatform_null.c
-eglplatform_null_la_CFLAGS = -I$(top_srcdir)/include $(ANDROID_HEADERS_CFLAGS) -I$(top_srcdir)/egl
+eglplatform_null_la_CFLAGS = \
+	-I$(top_srcdir)/include \
+	-I$(top_srcdir)/common \
+	-I$(top_srcdir)/include \
+	-I$(top_srcdir)/egl \
+	-I$(top_srcdir)/egl/platforms/common \
+	$(ANDROID_HEADERS_CFLAGS) \
+	$(WAYLAND_SERVER_CFLAGS)
 
-eglplatform_null_la_LDFLAGS = -avoid-version -module -shared -export-dynamic
+eglplatform_null_la_LDFLAGS = \
+	-avoid-version -module -shared -export-dynamic \
+	$(top_builddir)/egl/platforms/common/libhybris-eglplatformcommon.la \
+	$(top_builddir)/hardware/libhardware.la \
+	$(WAYLAND_SERVER_LIBS)
 
+if WANT_DEBUG
+eglplatform_null_la_CFLAGS += -I$(top_srcdir)/common -ggdb -O0
+endif
 
+if WANT_TRACE
+eglplatform_null_la_CFLAGS += -DDEBUG
+endif


### PR DESCRIPTION
Adds support for running a wayland compositor off of nullws.
This allows for platforms that have trouble bringing up fbdev and
hwcomposer to run a wayland compositor using null EGL platform for the
compositor.

tested using nexus5, qml-compositor and hellogl_es2 client.
