### PR TITLE
Cleanup the buffers from the list once destroyed

### DIFF
--- a/hybris/egl/platforms/wayland/wayland_window.cpp
+++ b/hybris/egl/platforms/wayland/wayland_window.cpp
@@ -224,11 +224,7 @@ WaylandNativeWindow::WaylandNativeWindow(struct wl_egl_window *window, struct wl
 WaylandNativeWindow::~WaylandNativeWindow()
 {
     std::list<WaylandNativeWindowBuffer *>::iterator it = m_bufList.begin();
-    for (; it != m_bufList.end(); it++)
-    {
-        WaylandNativeWindowBuffer* buf=*it;
-        destroyBuffer(buf);
-    }
+    destroyBuffers();
     if (frame_callback)
         wl_callback_destroy(frame_callback);
     wl_registry_destroy(registry);
@@ -751,6 +747,7 @@ void WaylandNativeWindow::destroyBuffers()
     for (; it!=m_bufList.end(); ++it)
     {
         destroyBuffer(*it);
+        it = m_bufList.erase(it);
     }
     m_bufList.clear();
     m_freeBufs = 0;


### PR DESCRIPTION
Since we dispatch the wayland queue in destroyBuffer() a wl_buffer.release
event may come while we're still mid-through deleting all the buffers.
When getting a release event we go through the list of the buffers, and so
we risk of accessing a deleted buffer object. To fix this remove the deleted
buffers from the list as soon as possible.
