### PR TITLE
propcache: Remove one unnecessary strdup().

### DIFF
--- a/hybris/properties/cache.c
+++ b/hybris/properties/cache.c
@@ -73,7 +73,7 @@ char *hybris_propcache_find(const char *key)
 	/* then look up the key and do a copy if we get a result */
 	struct hybris_prop_value *prop = cache_find_internal(key);
 	if (prop)
-		ret = strdup(prop->value);
+		return prop->value;
 
 out:
 	return ret;

--- a/hybris/properties/properties.c
+++ b/hybris/properties/properties.c
@@ -175,7 +175,6 @@ int property_get(const char *key, char *value, const char *default_value)
 
 	if (ret) {
 		strcpy(value, ret);
-		free(ret);
 		return strlen(value);
 	} else if (default_value != NULL) {
 		strcpy(value, default_value);


### PR DESCRIPTION
By simply returning the already allocated value, we avoid an unnecessary
allocation, as the caller already copies the value anyway.
