### PR TITLE
[test_gps] Allow to specify custom SUPL server on the command line

### DIFF
--- a/hybris/tests/test_gps.c
+++ b/hybris/tests/test_gps.c
@@ -38,6 +38,7 @@ const UlpNetworkInterface *UlpNetwork = NULL;
 const UlpPhoneContextInterface *UlpPhoneContext = NULL;
 #endif /* HAVE_ULP */
 char *apn = 0;
+char *agps_server = 0;
 
 static const GpsInterface* get_gps_interface()
 {
@@ -436,7 +437,7 @@ int main(int argc, char *argv[])
   char *location = 0, *longitude, *latitude;
   float accuracy = 100; /* Use 100m as location accuracy by default */
 
-  while ((opt = getopt(argc, argv, "acl:p:rtux")) != -1)
+  while ((opt = getopt(argc, argv, "acl:p:s:rtux")) != -1)
   {
 	switch (opt) {
 		case 'a':
@@ -463,6 +464,9 @@ int main(int argc, char *argv[])
 		case 'p':
 		   apn = optarg;
 		   break;
+		case 's':
+		   agps_server = optarg;
+		   break;
 		case 'u':
 		   ulp = 1;
 		   break;
@@ -475,6 +479,7 @@ int main(int argc, char *argv[])
 			   \t-a for agps,\n \
 			   \t-c for coldstarting the gps,\n \
 			   \t-p <apn name> to specify an apn name,\n \
+			   \t-s <agps_server:port> to specify a different supls server.\n \
 		           \t-r for agpsril,\n \
 			   \t-t to inject time,\n \
 			   \t-u to use ULP (if available,\n \
@@ -514,7 +519,19 @@ int main(int argc, char *argv[])
 	fprintf(stdout, "*** set up agps interface\n");
 	AGps->init(&callbacks2);
 	fprintf(stdout, "*** set up agps server\n");
-	AGps->set_server(AGPS_TYPE_SUPL, "supl.google.com", 7276);
+	if(agps_server)
+	{
+		char *server,*port = 0;
+
+		server =  strdup(agps_server);
+		strtok_r (server, ":", &port);
+
+		fprintf(stdout, "SUPL server: %s at port number: %s\n", server, port);
+		AGps->set_server(AGPS_TYPE_SUPL, server, atoi(port));
+		free(server);
+	}
+	else
+		AGps->set_server(AGPS_TYPE_SUPL, "supl.google.com", 7276);
     }
 
     if(agpsril)


### PR DESCRIPTION
For testing purposes it might be useful to specify another
SUPL server than the google default one.

Signed-off-by: Philippe De Swert philippe.deswert@jollamobile.com
