### PR TITLE
On destroying wl_egl_window, remove reference in WaylandNativeWindow

### DIFF
--- a/hybris/egl/platforms/common/wayland-egl-priv.h
+++ b/hybris/egl/platforms/common/wayland-egl-priv.h
@@ -27,6 +27,7 @@ struct wl_egl_window {
 
 	void *nativewindow;
 	void (*resize_callback)(struct wl_egl_window *, void *);
+	void (*free_callback)(struct wl_egl_window *, void *);
 };
 
 #ifdef  __cplusplus

--- a/hybris/egl/platforms/common/wayland-egl.c
+++ b/hybris/egl/platforms/common/wayland-egl.c
@@ -43,6 +43,8 @@ wl_egl_window_create(struct wl_surface *surface,
 WL_EGL_EXPORT void
 wl_egl_window_destroy(struct wl_egl_window *egl_window)
 {
+	if (egl_window->free_callback)
+		egl_window->free_callback(egl_window, NULL);
 	free(egl_window);
 }
 

--- a/hybris/egl/platforms/wayland/wayland_window.cpp
+++ b/hybris/egl/platforms/wayland/wayland_window.cpp
@@ -92,6 +92,11 @@ void WaylandNativeWindow::resize_callback(struct wl_egl_window *egl_window, void
         egl_window->width,egl_window->height);
 }
 
+void WaylandNativeWindow::free_callback(struct wl_egl_window *egl_window, void *)
+{
+    ((WaylandNativeWindow*)(egl_window->nativewindow))->m_window = 0;
+}
+
 void WaylandNativeWindow::lock()
 {
     pthread_mutex_lock(&this->mutex);
@@ -189,6 +194,7 @@ WaylandNativeWindow::WaylandNativeWindow(struct wl_egl_window *window, struct wl
     this->m_defaultWidth = window->width;
     this->m_defaultHeight = window->height;
     this->m_window->resize_callback = resize_callback;
+    this->m_window->free_callback = free_callback;
     this->m_format = 1;
     this->frame_callback = NULL;
     this->wl_queue = wl_display_create_queue(display);
@@ -230,8 +236,11 @@ WaylandNativeWindow::~WaylandNativeWindow()
     wl_registry_destroy(registry);
     wl_event_queue_destroy(wl_queue);
     android_wlegl_destroy(m_android_wlegl);
-    m_window->nativewindow = NULL;
-    m_window->resize_callback = NULL;
+    if (m_window) {
+	    m_window->nativewindow = NULL;
+	    m_window->resize_callback = NULL;
+	    m_window->free_callback = NULL;
+    }
 }
 
 void WaylandNativeWindow::frame() {

--- a/hybris/egl/platforms/wayland/wayland_window.h
+++ b/hybris/egl/platforms/wayland/wayland_window.h
@@ -123,6 +123,7 @@ public:
     static void registry_handle_global(void *data, struct wl_registry *registry, uint32_t name,
                        const char *interface, uint32_t version);
     static void resize_callback(struct wl_egl_window *egl_window, void *);
+    static void free_callback(struct wl_egl_window *egl_window, void *);
     struct wl_event_queue *wl_queue;
 
 protected:


### PR DESCRIPTION
On some cases, wl_egl_window could be destroyed when WaylandNativeWindow
had still alive references. In this case, the code in WaylandNativeWindow
that detachs the reference to wl_egl_window will access already freed
memory. This was reported by valgrind.
