### PR TITLE
Implement the EGL_WL_create_wayland_buffer_from_image extension

### DIFF
--- a/hybris/egl/eglhybris.h
+++ b/hybris/egl/eglhybris.h
@@ -35,6 +35,8 @@ void *hybris_android_egl_dlsym(const char *symbol);
 int hybris_egl_has_mapping(EGLSurface surface);
 EGLNativeWindowType hybris_egl_get_mapping(EGLSurface surface);
 
+struct _EGLDisplay *hybris_egl_display_get_mapping(EGLDisplay dpy);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hybris/egl/platforms/fbdev/eglplatform_fbdev.cpp
+++ b/hybris/egl/platforms/fbdev/eglplatform_fbdev.cpp
@@ -44,13 +44,23 @@ extern "C" void fbdevws_init_module(struct ws_egl_interface *egl_iface)
 	eglplatformcommon_init(egl_iface, gralloc, alloc);
 }
 
-extern "C" int fbdevws_IsValidDisplay(EGLNativeDisplayType display)
+extern "C" _EGLDisplay *fbdevws_GetDisplay(EGLNativeDisplayType display)
 {
 	assert (gralloc != NULL);
-	return display == EGL_DEFAULT_DISPLAY;
+
+	_EGLDisplay *dpy = 0;
+	if (display == EGL_DEFAULT_DISPLAY) {
+		dpy = new _EGLDisplay;
+	}
+	return dpy;
 }
 
-extern "C" EGLNativeWindowType fbdevws_CreateWindow(EGLNativeWindowType win, EGLNativeDisplayType display)
+extern "C" void fbdevws_Terminate(_EGLDisplay *dpy)
+{
+	delete dpy;
+}
+
+extern "C" EGLNativeWindowType fbdevws_CreateWindow(EGLNativeWindowType win, _EGLDisplay *display)
 {
 	assert (gralloc != NULL);
 	assert (_nativewindow == NULL);
@@ -88,7 +98,8 @@ extern "C" void fbdevws_setSwapInterval(EGLDisplay dpy, EGLNativeWindowType win,
 
 struct ws_module ws_module_info = {
 	fbdevws_init_module,
-	fbdevws_IsValidDisplay,
+	fbdevws_GetDisplay,
+	fbdevws_Terminate,
 	fbdevws_CreateWindow,
 	fbdevws_DestroyWindow,
 	fbdevws_eglGetProcAddress,

--- a/hybris/egl/platforms/hwcomposer/eglplatform_hwcomposer.cpp
+++ b/hybris/egl/platforms/hwcomposer/eglplatform_hwcomposer.cpp
@@ -36,13 +36,22 @@ extern "C" void hwcomposerws_init_module(struct ws_egl_interface *egl_iface)
 	eglplatformcommon_init(egl_iface, gralloc, alloc);
 }
 
-extern "C" int hwcomposerws_IsValidDisplay(EGLNativeDisplayType display)
+extern "C" _EGLDisplay *hwcomposerws_GetDisplay(EGLNativeDisplayType display)
 {
 	assert (gralloc != NULL);
-	return display == EGL_DEFAULT_DISPLAY;
+	_EGLDisplay *dpy = 0;
+	if (display == EGL_DEFAULT_DISPLAY) {
+		dpy = new _EGLDisplay;
+	}
+	return dpy;
 }
 
-extern "C" EGLNativeWindowType hwcomposerws_CreateWindow(EGLNativeWindowType win, EGLNativeDisplayType display)
+extern "C" void hwcomposerws_Terminate(_EGLDisplay *dpy)
+{
+	delete dpy;
+}
+
+extern "C" EGLNativeWindowType hwcomposerws_CreateWindow(EGLNativeWindowType win, _EGLDisplay *display)
 {
 	assert (gralloc != NULL);
 	assert (_nativewindow == NULL);
@@ -76,7 +85,8 @@ extern "C" void hwcomposerws_passthroughImageKHR(EGLContext *ctx, EGLenum *targe
 
 struct ws_module ws_module_info = {
 	hwcomposerws_init_module,
-	hwcomposerws_IsValidDisplay,
+	hwcomposerws_GetDisplay,
+	hwcomposerws_Terminate,
 	hwcomposerws_CreateWindow,
 	hwcomposerws_DestroyWindow,
 	hwcomposerws_eglGetProcAddress,

--- a/hybris/egl/platforms/null/eglplatform_null.c
+++ b/hybris/egl/platforms/null/eglplatform_null.c
@@ -38,12 +38,17 @@ static void nullws_init_module(struct ws_egl_interface *egl_iface)
 
 }
 
-static int nullws_IsValidDisplay(EGLNativeDisplayType display)
+static struct _EGLDisplay *nullws_GetDisplay(EGLNativeDisplayType display)
 {
-	return 1;
+	return malloc(sizeof(struct _EGLDisplay));
 }
 
-static EGLNativeWindowType nullws_CreateWindow(EGLNativeWindowType win, EGLNativeDisplayType display)
+static void nullws_Terminate(struct _EGLDisplay *dpy)
+{
+	free(dpy);
+}
+
+static EGLNativeWindowType nullws_CreateWindow(EGLNativeWindowType win, struct _EGLDisplay *display)
 {
 	if (win == 0)
 	{
@@ -60,7 +65,8 @@ static void nullws_DestroyWindow(EGLNativeWindowType win)
 
 struct ws_module ws_module_info = {
 	nullws_init_module,
-	nullws_IsValidDisplay,
+	nullws_GetDisplay,
+	nullws_Terminate,
 	nullws_CreateWindow,
 	nullws_DestroyWindow,
 	eglplatformcommon_eglGetProcAddress,

--- a/hybris/egl/platforms/wayland/wayland_window.cpp
+++ b/hybris/egl/platforms/wayland/wayland_window.cpp
@@ -107,51 +107,6 @@ void WaylandNativeWindow::unlock()
     pthread_mutex_unlock(&this->mutex);
 }
 
-    void
-WaylandNativeWindow::registry_handle_global(void *data, struct wl_registry *registry, uint32_t name,
-        const char *interface, uint32_t version)
-{
-    WaylandNativeWindow *nw = static_cast<WaylandNativeWindow *>(data);
-
-    if (strcmp(interface, "android_wlegl") == 0) {
-        nw->m_android_wlegl = static_cast<struct android_wlegl *>(wl_registry_bind(registry, name, &android_wlegl_interface, 1));
-    }
-}
-
-static const struct wl_registry_listener registry_listener = {
-    WaylandNativeWindow::registry_handle_global
-};
-
-
-    void
-WaylandNativeWindow::sync_callback(void *data, struct wl_callback *callback, uint32_t serial)
-{
-    int *done = static_cast<int *>(data);
-
-    *done = 1;
-    wl_callback_destroy(callback);
-}
-
-static const struct wl_callback_listener sync_listener = {
-    WaylandNativeWindow::sync_callback
-};
-
-    int
-WaylandNativeWindow::wayland_roundtrip(WaylandNativeWindow *display)
-{
-    struct wl_callback *callback;
-    int done = 0, ret = 0;
-    wl_display_dispatch_queue_pending(display->m_display, display->wl_queue);
-
-    callback = wl_display_sync(display->m_display);
-    wl_callback_add_listener(callback, &sync_listener, &done);
-    wl_proxy_set_queue((struct wl_proxy *) callback, display->wl_queue);
-    while (ret >= 0 && !done)
-        ret = wl_display_dispatch_queue(display->m_display, display->wl_queue);
-
-    return ret;
-}
-
 static void check_fatal_error(struct wl_display *display)
 {
     int error = wl_display_get_error(display);
@@ -180,11 +135,10 @@ static const struct wl_callback_listener frame_listener = {
     wayland_frame_callback
 };
 
-WaylandNativeWindow::WaylandNativeWindow(struct wl_egl_window *window, struct wl_display *display, alloc_device_t* alloc_device)
-                   : m_android_wlegl(NULL)
+WaylandNativeWindow::WaylandNativeWindow(struct wl_egl_window *window, struct wl_display *display, wl_event_queue *queue,
+                                         android_wlegl *wlegl, alloc_device_t* alloc_device)
+                   : m_android_wlegl(wlegl)
 {
-    int wayland_ok;
-
     HYBRIS_TRACE_BEGIN("wayland-platform", "create_window", "");
     this->m_window = window;
     this->m_window->nativewindow = (void *) this;
@@ -197,22 +151,11 @@ WaylandNativeWindow::WaylandNativeWindow(struct wl_egl_window *window, struct wl
     this->m_window->free_callback = free_callback;
     this->m_format = 1;
     this->frame_callback = NULL;
-    this->wl_queue = wl_display_create_queue(display);
-    this->registry = wl_display_get_registry(display);
-    this->m_android_wlegl = NULL;
-    wl_proxy_set_queue((struct wl_proxy *) this->registry,
-            this->wl_queue);
-    wl_registry_add_listener(this->registry, &registry_listener, this);
-
 	const_cast<int&>(ANativeWindow::minSwapInterval) = 0;
 	const_cast<int&>(ANativeWindow::maxSwapInterval) = 1;
     // This is the default as per the EGL documentation
     this->m_swap_interval = 1;
-
-    wayland_ok = wayland_roundtrip(this);
-    assert(wayland_ok >= 0);
-    assert(this->m_android_wlegl != NULL);
-
+    this->wl_queue = queue;
     this->m_alloc = alloc_device;
 
     m_usage=GRALLOC_USAGE_HW_RENDER | GRALLOC_USAGE_HW_TEXTURE;
@@ -233,9 +176,6 @@ WaylandNativeWindow::~WaylandNativeWindow()
     destroyBuffers();
     if (frame_callback)
         wl_callback_destroy(frame_callback);
-    wl_registry_destroy(registry);
-    wl_event_queue_destroy(wl_queue);
-    android_wlegl_destroy(m_android_wlegl);
     if (m_window) {
 	    m_window->nativewindow = NULL;
 	    m_window->resize_callback = NULL;

--- a/hybris/egl/platforms/wayland/wayland_window.h
+++ b/hybris/egl/platforms/wayland/wayland_window.h
@@ -67,6 +67,12 @@ protected:
         assert(alloc_ok == 0);
         this->youngest = 0;
     }
+
+protected:
+    void* vaddr;
+    alloc_device_t* m_alloc;
+
+public:
     WaylandNativeWindowBuffer(ANativeWindowBuffer *other)
     {
         ANativeWindowBuffer::width = other->width;
@@ -91,11 +97,6 @@ protected:
                                      struct wl_display *display,
                                      struct wl_event_queue *queue);
 
-protected:
-    void* vaddr;
-    alloc_device_t* m_alloc;
-
-public:
     struct wl_buffer *wlbuffer;
     struct wl_callback *creation_callback;
     int busy;
@@ -106,7 +107,8 @@ public:
 
 class WaylandNativeWindow : public BaseNativeWindow {
 public:
-    WaylandNativeWindow(struct wl_egl_window *win, struct wl_display *display, alloc_device_t* alloc_device);
+    WaylandNativeWindow(struct wl_egl_window *win, struct wl_display *display, wl_event_queue *queue,
+                        android_wlegl *wlegl, alloc_device_t* alloc_device);
     ~WaylandNativeWindow();
 
     void lock();
@@ -168,7 +170,6 @@ private:
     unsigned int m_usage;
     struct android_wlegl *m_android_wlegl;
     alloc_device_t* m_alloc;
-    struct wl_registry *registry;
     pthread_mutex_t mutex;
     pthread_cond_t cond;
     int m_queueReads;

--- a/hybris/egl/ws.c
+++ b/hybris/egl/ws.c
@@ -55,13 +55,19 @@ static void _init_ws()
 }
 
 
-int ws_IsValidDisplay(EGLNativeDisplayType display)
+struct _EGLDisplay *ws_GetDisplay(EGLNativeDisplayType display)
 {
 	_init_ws();
-	return ws->IsValidDisplay(display);
+	return ws->GetDisplay(display);
 }
 
-EGLNativeWindowType ws_CreateWindow(EGLNativeWindowType win, EGLNativeDisplayType display)
+void ws_Terminate(struct _EGLDisplay *dpy)
+{
+	_init_ws();
+	ws->Terminate(dpy);
+}
+
+EGLNativeWindowType ws_CreateWindow(EGLNativeWindowType win, struct _EGLDisplay *display)
 {
 	_init_ws();
 	return ws->CreateWindow(win, display);

--- a/hybris/egl/ws.h
+++ b/hybris/egl/ws.h
@@ -1,6 +1,7 @@
 #ifndef __LIBHYBRIS_WS_H
 #define __LIBHYBRIS_WS_H
 #include <EGL/egl.h>
+#include <EGL/eglext.h>
 
 struct ws_egl_interface {
 	void * (*android_egl_dlsym)(const char *symbol);
@@ -9,13 +10,26 @@ struct ws_egl_interface {
 	EGLNativeWindowType (*get_mapping)(EGLSurface surface);
 };
 
+struct egl_image
+{
+    EGLImageKHR egl_image;
+    EGLClientBuffer egl_buffer;
+    EGLenum target;
+};
+
 /* Defined in egl.c */
 extern struct ws_egl_interface hybris_egl_interface;
 
+struct _EGLDisplay {
+	EGLDisplay dpy;
+};
+
 struct ws_module {
 	void (*init_module)(struct ws_egl_interface *egl_interface);
-	int (*IsValidDisplay)(EGLNativeDisplayType display_id);
-	EGLNativeWindowType (*CreateWindow)(EGLNativeWindowType win, EGLNativeDisplayType display);
+
+	struct _EGLDisplay *(*GetDisplay)(EGLNativeDisplayType native);
+	void (*Terminate)(struct _EGLDisplay *display);
+	EGLNativeWindowType (*CreateWindow)(EGLNativeWindowType win, struct _EGLDisplay *display);
 	void (*DestroyWindow)(EGLNativeWindowType win);
 	__eglMustCastToProperFunctionPointerType (*eglGetProcAddress)(const char *procname);
 	void (*passthroughImageKHR)(EGLContext *ctx, EGLenum *target, EGLClientBuffer *buffer, const EGLint **attrib_list);
@@ -25,8 +39,9 @@ struct ws_module {
 	void (*setSwapInterval)(EGLDisplay dpy, EGLNativeWindowType win, EGLint interval);
 };
 
-int ws_IsValidDisplay(EGLNativeDisplayType display);
-EGLNativeWindowType ws_CreateWindow(EGLNativeWindowType win, EGLNativeDisplayType display);
+struct _EGLDisplay *ws_GetDisplay(EGLNativeDisplayType native);
+void ws_Terminate(struct _EGLDisplay *dpy);
+EGLNativeWindowType ws_CreateWindow(EGLNativeWindowType win, struct _EGLDisplay *display);
 void ws_DestroyWindow(EGLNativeWindowType win);
 __eglMustCastToProperFunctionPointerType ws_eglGetProcAddress(const char *procname);
 void ws_passthroughImageKHR(EGLContext *ctx, EGLenum *target, EGLClientBuffer *buffer, const EGLint **attrib_list);


### PR DESCRIPTION
This extension allows a nested compositor to create a client side
buffer for a server side buffer resource, and to post it to the parent
compositor on a subsurface, outsourcing compositing of the client surface
to the parent.
We also wrap EGLImageKHR with an internal struct to store the buffer that
image was created from, which we use later to create the wl_buffer.