### PR TITLE
Propagate eglQueryString error back to the caller instead of crashing.

### DIFF
--- a/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
+++ b/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
@@ -250,9 +250,8 @@ extern "C" void waylandws_passthroughImageKHR(EGLContext *ctx, EGLenum *target, 
 extern "C" const char *waylandws_eglQueryString(EGLDisplay dpy, EGLint name, const char *(*real_eglQueryString)(EGLDisplay dpy, EGLint name))
 {
 	const char *ret = eglplatformcommon_eglQueryString(dpy, name, real_eglQueryString);
-	if (name == EGL_EXTENSIONS)
+	if (ret && name == EGL_EXTENSIONS)
 	{
-		assert(ret != NULL);
 		static char eglextensionsbuf[512];
 		snprintf(eglextensionsbuf, 510, "%s %s", ret,
 			"EGL_EXT_swap_buffers_with_damage EGL_WL_create_wayland_buffer_from_image"


### PR DESCRIPTION
The EGL spec defines the conditions in which the function can fail. Some
applications like chromium can actually cope with the fact that an early
eglQueryString function call failed and can retry it at a later time.
Unfortunately current implementation of EGL in libhybris simply aborts
exeution of the app in such case. This patch removes such bogus assert
propagating the NULL return value to the caller instead.