### PR TITLE
Get rid of workaround allowing gecko to pass invalid pointers to EGL.

### DIFF
--- a/hybris/egl/egl.c
+++ b/hybris/egl/egl.c
@@ -494,7 +494,8 @@ static EGLImageKHR _my_eglCreateImageKHR(EGLDisplay dpy, EGLContext ctx, EGLenum
 		return EGL_NO_IMAGE_KHR;
 	}
 
-	struct egl_image *image = egl_image_create();
+	struct egl_image *image;
+	image = malloc(sizeof *image);
 	image->egl_image = eik;
 	image->egl_buffer = buffer;
 	image->target = target;
@@ -506,8 +507,6 @@ static void _my_glEGLImageTargetTexture2DOES(GLenum target, GLeglImageOES image)
 {
 	GLESv2_DLSYM(&_glEGLImageTargetTexture2DOES, "glEGLImageTargetTexture2DOES");
 	struct egl_image *img = image;
-	if (!egl_image_sanitycheck(img))
-		img = 0;
 	(*_glEGLImageTargetTexture2DOES)(target, img ? img->egl_image : NULL);
 }
 

--- a/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
+++ b/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
@@ -210,7 +210,7 @@ extern "C" int waylandws_post(EGLNativeWindowType win, void *buffer)
 extern "C" wl_buffer *waylandws_createWlBuffer(EGLDisplay dpy, EGLImageKHR image)
 {
 	egl_image *img = reinterpret_cast<egl_image *>(image);
-	if (!img || !egl_image_sanitycheck(img)) {
+	if (!img) {
 	    // The spec says we should send a EGL_BAD_PARAMETER error here, but we don't have the
 	    // means, as of now.
 	    return NULL;

--- a/hybris/egl/ws.c
+++ b/hybris/egl/ws.c
@@ -118,26 +118,4 @@ void ws_setSwapInterval(EGLDisplay dpy, EGLNativeWindowType win, EGLint interval
 		ws->setSwapInterval(dpy, win, interval);
 }
 
-#define HYBRIS_MAKE_TOKEN(a, b, c, d) ((((unsigned int) a) << 24) \
-                                      | (((unsigned int) b) << 16) \
-                                      | (((unsigned int) c) << 8) \
-                                      | ((unsigned int) d))
-
-#define HYBRIS_EGL_IMAGE_ID HYBRIS_MAKE_TOKEN('H', 'I', 'M', 'G')
-
-struct egl_image *egl_image_create()
-{
-    struct egl_image *img = (struct egl_image *) malloc(sizeof(struct egl_image));
-    img->__type_token = HYBRIS_EGL_IMAGE_ID;
-    return img;
-}
-
-int egl_image_sanitycheck(struct egl_image *image)
-{
-    if (image && image->__type_token == HYBRIS_EGL_IMAGE_ID)
-        return 1;
-    return 0;
-}
-
-
 // vim:ts=4:sw=4:noexpandtab

--- a/hybris/egl/ws.h
+++ b/hybris/egl/ws.h
@@ -12,21 +12,10 @@ struct ws_egl_interface {
 
 struct egl_image
 {
-    // We experience that some client API's may pass invalid pointers for
-    // EGLImages and the blob survives this, so we have this token to try to
-    // acheive the same.
-    int __type_token;
     EGLImageKHR egl_image;
     EGLClientBuffer egl_buffer;
     EGLenum target;
 };
-
-/* Used to allocate egl_image with the __type_token safeguard initialized. */
-struct egl_image *egl_image_create();
-
-/* Returns 1 if the input image is NULL or a valid pointer with the
-   __internal_id set to the right value */
-int egl_image_sanitycheck(struct egl_image *image);
 
 /* Defined in egl.c */
 extern struct ws_egl_interface hybris_egl_interface;


### PR DESCRIPTION
This basically reverts 4c6d9966187e561a2e6b821aee0e90c11f413e9a.
Acording to Gunnar Sletta the patch was a workaround for a bug in gecko.
Since the problem was fixed there is no point in keeping it around.
Passing invalid pointers to EGL functions should not be an acceptable
behaviour.