### PR TITLE
Hook __cxa_finalize as well.

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -1261,6 +1261,7 @@ FP_ATTRIB static double my_strtod(const char *nptr, char **endptr)
 }
 
 extern int __cxa_atexit(void (*)(void*), void*, void*);
+extern void __cxa_finalize(void * d);
 
 struct open_redirect {
 	const char *from;
@@ -1571,6 +1572,7 @@ static struct _hook hooks[] = {
     /* grp.h */
     {"getgrgid", getgrgid},
     {"__cxa_atexit", __cxa_atexit},
+    {"__cxa_finalize", __cxa_finalize},
     {NULL, NULL},
 };
 


### PR DESCRIPTION
We are already hooking up bionic __cxa_atexit to the glibc one.
Not hooking __cxa_finalize is a bug because the bionic one will go
and try to finalize stuff it did not manipulate causing a crash
upon unloading some shared objects