### PR TITLE
set libdl soinfo refcnt to 1

### DIFF
--- a/hybris/common/jb/dlfcn.c
+++ b/hybris/common/jb/dlfcn.c
@@ -274,6 +274,7 @@ soinfo libdl_info = {
     strtab: ANDROID_LIBDL_STRTAB,
     symtab: libdl_symtab,
 
+    refcount: 1,
     nbucket: 1,
     nchain: 7,
     bucket: libdl_buckets,


### PR DESCRIPTION
We need that to prevent hybris from wrongly
unloading libdl.so when an application exits.