### PR TITLE
glesv1: parse DEFAULT_HYBRIS_LD_LIBRARY_NAME to find the correct (patched) version of libGLESv1_CM.so

### DIFF
--- a/hybris/glesv1/Makefile.am
+++ b/hybris/glesv1/Makefile.am
@@ -2,7 +2,9 @@ lib_LTLIBRARIES = \
 	libGLESv1_CM.la
 
 libGLESv1_CM_la_SOURCES = glesv1_cm.c
-libGLESv1_CM_la_CFLAGS = -I$(top_srcdir)/include $(ANDROID_HEADERS_CFLAGS)
+libGLESv1_CM_la_CFLAGS = \
+	-I$(top_srcdir)/include $(ANDROID_HEADERS_CFLAGS) \
+	-DDEFAULT_HYBRIS_LD_LIBRARY_PATH="\"@DEFAULT_HYBRIS_LD_LIBRARY_PATH@\""
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = glesv1_cm.pc

--- a/hybris/glesv1/glesv1_cm.c
+++ b/hybris/glesv1/glesv1_cm.c
@@ -26,9 +26,9 @@
 
 #include <hybris/common/binding.h>
 
-#define GLESV1_CM_LIBRARY_PATH "/system/lib/libGLESv1_CM.so"
+#define GLESV1_CM_LIBRARY_NAME "libGLESv1_CM.so"
 
-HYBRIS_LIBRARY_INITIALIZE(glesv1_cm, GLESV1_CM_LIBRARY_PATH);
+HYBRIS_LIBRARY_FIND_AND_INITIALIZE(glesv1_cm, DEFAULT_HYBRIS_LD_LIBRARY_PATH, "/", ":", GLESV1_CM_LIBRARY_NAME);
 
 /* Scripts to generate these bindings can be found in utils/generate_glesv1/ */
 HYBRIS_IMPLEMENT_VOID_FUNCTION2(glesv1_cm, glAlphaFunc, GLenum, GLclampf);


### PR DESCRIPTION
required for running glesv1 applications on sfos (jolla was not affected because there /system/lib/libGLESv1_CM.so is already patched) but on devices like nexus 5 this is required

don't know if it would be wiser to use getenv("LIBGLESV1") like the glesv2 wrapper does, please advice