### PR TITLE
Revert "Fix calling gl* functions without loading them with eglGetProcAddress". Fixes NEMO#844

### DIFF
--- a/hybris/glesv2/glesv2.c
+++ b/hybris/glesv2/glesv2.c
@@ -60,8 +60,6 @@ This generates a function that when first called overwrites it's plt entry with 
 typeof(sym) * sym ## _dispatch (void) __asm__ (#sym);\
 typeof(sym) * sym ## _dispatch (void) \
 { \
-	if (!_libglesv2) \
-		_libglesv2 = (void *) android_dlopen(getenv("LIBGLESV2") ? getenv("LIBGLESV2") : "libGLESv2.so", RTLD_NOW); \
 	return (void *) android_dlsym(_libglesv2, #sym); \
 } 
 


### PR DESCRIPTION
This reverts commit 295d1598b500f9d7663a77d5ef458936b5bad24f.

In some cases this would crash during gnu_indirect_function relocation,
and always reproducable with LD_BIND_NOW=1.

==5550== Jump to the invalid address stated on the next line
==5550==    at 0x2C26: ???
==5550==    by 0xA1CB5C5: ??? (in /usr/libexec/droid-hybris/system/lib/libEGL.so)
==5550==    by 0x735A3BD: pthread_once (pthread_once.S:120)
==5550==    by 0xA1C8101: ??? (in /usr/libexec/droid-hybris/system/lib/libEGL.so)
==5550==    by 0x7FCD240: call_array (linker.c:1553)
==5550==    by 0x7FD446C: call_constructors_recursive (linker.c:1618)
==5550==    by 0x7FD4347: call_constructors_recursive (linker.c:1602)
==5550==    by 0x7FCCF3A: android_dlopen (dlfcn.c:64)
==5550==    by 0x73487E9: glIsFramebuffer (glesv2.c:246)
==5550==    by 0x400D962: elf_machine_rel (dl-machine.h:345)
==5550==    by 0x400D962: elf_dynamic_do_Rel (do-rel.h:137)
==5550==    by 0x400D962: _dl_relocate_object (dl-reloc.c:264)
==5550==    by 0x4003E9F: dl_main (rtld.c:2236)
==5550==    by 0x401771A: _dl_sysdep_start (dl-sysdep.c:249)
==5550==  Address 0x2c26 is not stack'd, malloc'd or (recently) freed