### PR TITLE
[egl] Add missing android-config.h include.

### DIFF
--- a/hybris/egl/platforms/common/server_wlegl.cpp
+++ b/hybris/egl/platforms/common/server_wlegl.cpp
@@ -20,6 +20,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <android-config.h>
 #include <cstring>
 
 #include <EGL/egl.h>


### PR DESCRIPTION
Fixes #286 about server-side wayland buffers not working on devices using QCOM_BSP.