### PR TITLE
utils: fix android headers extraction

### DIFF
--- a/utils/extract-headers.sh
+++ b/utils/extract-headers.sh
@@ -162,27 +162,43 @@ extract_headers_to hardware \
     hardware/libhardware/include/hardware
 
 extract_headers_to hardware_legacy \
-    hardware/libhardware_legacy/include/hardware_legacy/vibrator.h \
-    hardware/libhardware_legacy/include/hardware_legacy/audio_policy_conf.h
+    hardware/libhardware_legacy/include/hardware_legacy/vibrator.h
+if [ $MAJOR -ge 4 -a $MINOR -ge 1 -o $MAJOR -ge 5 ]; then
+    extract_headers_to hardware_legacy \
+        hardware/libhardware_legacy/include/hardware_legacy/audio_policy_conf.h
+fi
 
 extract_headers_to cutils \
     system/core/include/cutils
 
-extract_headers_to log \
-    system/core/include/log
+if [ $MAJOR -eq 4 -a $MINOR -ge 4 -o $MAJOR -ge 5 ]; then
+    extract_headers_to log \
+        system/core/include/log
+fi
 
-extract_headers_to system \
-    system/core/include/system
+if [ $MAJOR -ge 4 ]; then
+    extract_headers_to system \
+        system/core/include/system
+fi
 
 extract_headers_to android \
     system/core/include/android
 
-extract_headers_to linux \
-    bionic/libc/kernel/common/linux/sync.h \
-    bionic/libc/kernel/common/linux/sw_sync.h
+if [ $MAJOR -eq 4 -a $MINOR -ge 1 ]; then
+    extract_headers_to linux \
+        bionic/libc/kernel/common/linux/sync.h \
+        bionic/libc/kernel/common/linux/sw_sync.h
 
-extract_headers_to sync \
-    system/core/include/sync
+    extract_headers_to sync \
+        system/core/include/sync
+elif [ $MAJOR -eq 5 ]; then
+    extract_headers_to linux \
+        bionic/libc/kernel/uapi/linux/sync.h \
+        bionic/libc/kernel/uapi/linux/sw_sync.h
+
+    extract_headers_to sync \
+        system/core/libsync/include/sync
+fi
 
 extract_headers_to libnfc-nxp \
     external/libnfc-nxp/inc \
@@ -191,9 +207,15 @@ extract_headers_to libnfc-nxp \
 extract_headers_to private \
     system/core/include/private/android_filesystem_config.h
 
-extract_headers_to linux \
-    external/kernel-headers/original/linux/android_alarm.h \
-    external/kernel-headers/original/linux/binder.h
+if [ $MAJOR -ge 5 ]; then
+    extract_headers_to linux \
+        bionic/libc/kernel/uapi/linux/android_alarm.h \
+        bionic/libc/kernel/uapi/linux/binder.h
+else
+    extract_headers_to linux \
+        external/kernel-headers/original/linux/android_alarm.h \
+        external/kernel-headers/original/linux/binder.h
+fi
 
 # In order to make it easier to trace back the origins of headers, fetch
 # some repository information from the Git source tree (if available).


### PR DESCRIPTION
Header extraction passed on following tags:
* android-2.3.7_r1
* android-4.0.4_r2.1
* android-4.1.2_r2.1
* android-4.2.2_r1.2
* android-4.3_r3.1 [1]
* android-4.4.4_r2.0.1
* android-5.0.2_r3
* android-5.1.1_r13

Build [2] passed on:
* android-4.2.2_r1.2
* android-4.3_r3.1
* android-4.4.4_r2.0.1
* android-5.0.2_r3
* android-5.1.1_r13

Note 1: specify __MAJOR__, __MINOR__, and __PATCH__ as `./utils/extract-headers.sh aosp/android-4.3_r3.1 android-headers 4 3 0` because AOSP 4.3 has a 2-digit PLATFORM_VERSION "4.3" rather than "4.3.0".
Note 2: configured by `hybris/autogen.sh --with-android-headers=`pwd`/android-headers --prefix=/usr --with-default-egl-platform=hwcomposer --enable-debug --enable-trace --with-default-hybris-ld-library-path=/system/lib:/vendor/lib`