### PR TITLE
For upstream/fix android 6.0 compilation

### DIFF
--- a/hybris/common/Makefile.am
+++ b/hybris/common/Makefile.am
@@ -10,11 +10,16 @@ if HAS_ANDROID_5_0_0
 SUBDIRS = jb
 libhybris_common_la_LIBADD= jb/libandroid-linker.la
 else
+if HAS_ANDROID_6_0_0
+SUBDIRS = jb
+libhybris_common_la_LIBADD= jb/libandroid-linker.la
+else
 if HAS_ANDROID_2_3_0
 SUBDIRS = gingerbread
 libhybris_common_la_LIBADD= gingerbread/libandroid-linker.la
 else
 $(error No Android Version is defined)
+endif
 endif
 endif
 endif

--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -178,6 +178,7 @@ AC_SUBST(ANDROID_VERSION_PATCH, [$android_headers_patch])
 AC_MSG_NOTICE("Android headers version is $android_headers_major.$android_headers_minor.$android_headers_patch")
 
 # Add automake tests for version/API needs here that you need in code, including test .am's
+AM_CONDITIONAL([HAS_ANDROID_6_0_0], [test $android_headers_major -ge 6 -a $android_headers_minor -ge 0 ])
 AM_CONDITIONAL([HAS_ANDROID_5_0_0], [test $android_headers_major -ge 5 -a $android_headers_minor -ge 0 ])
 AM_CONDITIONAL([HAS_ANDROID_4_2_0], [test $android_headers_major -ge 4 -a $android_headers_minor -ge 2 ])
 AM_CONDITIONAL([HAS_ANDROID_4_1_0], [test $android_headers_major -ge 4 -a $android_headers_minor -ge 1 ])

--- a/utils/extract-headers.sh
+++ b/utils/extract-headers.sh
@@ -183,6 +183,10 @@ if [ $MAJOR -ge 4 ]; then
     extract_headers_to system \
         system/core/include/system
 fi
+if [ $MAJOR -ge 6 ]; then
+    extract_headers_to system \
+        system/media/audio/include/system
+fi
 
 extract_headers_to android \
     system/core/include/android
@@ -194,7 +198,7 @@ if [ $MAJOR -eq 4 -a $MINOR -ge 1 ]; then
 
     extract_headers_to sync \
         system/core/include/sync
-elif [ $MAJOR -eq 5 ]; then
+elif [ $MAJOR -ge 5 ]; then
     extract_headers_to linux \
         bionic/libc/kernel/uapi/linux/sync.h \
         bionic/libc/kernel/uapi/linux/sw_sync.h


### PR DESCRIPTION
This is only an initial work for Android 6.0 adoption. No functional verification is ever done.

Headers extracted with:
`${topsrcdir}/utils/extract-headers.sh `pwd`/android-6.0.0_r1 `pwd`/extracted/android-23 6 0 0`
Configured with:
`./hybris/autogen.sh --with-android-headers=../extracted/android-23 --prefix=/usr --with-default-egl-platform=hwcomposer --enable-debug --enable-trace --with-default-hybris-ld-library-path=/system/lib:/vendor/lib`
