### PR TITLE
Fix build against API level >= 14

### DIFF
--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -181,6 +181,7 @@ AC_MSG_NOTICE("Android headers version is $android_headers_major.$android_header
 AM_CONDITIONAL([HAS_ANDROID_5_0_0], [test $android_headers_major -ge 5 -a $android_headers_minor -ge 0 ])
 AM_CONDITIONAL([HAS_ANDROID_4_2_0], [test $android_headers_major -ge 4 -a $android_headers_minor -ge 2 ])
 AM_CONDITIONAL([HAS_ANDROID_4_1_0], [test $android_headers_major -ge 4 -a $android_headers_minor -ge 1 ])
+AM_CONDITIONAL([HAS_ANDROID_4_0_3], [test $android_headers_major -ge 4 -a $android_headers_patch -ge 3 ])
 AM_CONDITIONAL([HAS_ANDROID_4_0_0], [test $android_headers_major -ge 4 -a $android_headers_minor -ge 0 ])
 AM_CONDITIONAL([HAS_ANDROID_2_3_0], [test $android_headers_major -ge 2 -a $android_headers_minor -ge 3 ])
 

--- a/hybris/libnfc_nxp/libnfc_nxp.c
+++ b/hybris/libnfc_nxp/libnfc_nxp.c
@@ -138,10 +138,17 @@ HYBRIS_IMPLEMENT_FUNCTION2(libnfc_so, NFCSTATUS, phLibNfc_Llcp_SocketGetLocalOpt
 HYBRIS_IMPLEMENT_FUNCTION2(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_SocketGetLocalOptions, phFriNfc_LlcpTransport_Socket_t *, phLibNfc_Llcp_sSocketOptions_t *);
 HYBRIS_IMPLEMENT_FUNCTION3(libnfc_so, NFCSTATUS, phLibNfc_Llcp_SocketGetRemoteOptions, phLibNfc_Handle, phLibNfc_Handle, phLibNfc_Llcp_sSocketOptions_t *);
 HYBRIS_IMPLEMENT_FUNCTION2(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_SocketGetRemoteOptions, phFriNfc_LlcpTransport_Socket_t *, phLibNfc_Llcp_sSocketOptions_t *);
+#if (ANDROID_VERSION_MAJOR == 4 && ANDROID_VERSION_MINOR >= 1) || (ANDROID_VERSION_MAJOR >= 5)
 HYBRIS_IMPLEMENT_FUNCTION3(libnfc_so, NFCSTATUS, phLibNfc_Llcp_Bind, phLibNfc_Handle, uint8_t, phNfc_sData_t *);
 HYBRIS_IMPLEMENT_FUNCTION3(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_Bind, phFriNfc_LlcpTransport_Socket_t *, uint8_t, phNfc_sData_t *);
 HYBRIS_IMPLEMENT_FUNCTION3(libnfc_so, NFCSTATUS, phLibNfc_Llcp_Listen, phLibNfc_Handle, pphLibNfc_LlcpSocketListenCb_t, void *);
 HYBRIS_IMPLEMENT_FUNCTION3(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_Listen, phFriNfc_LlcpTransport_Socket_t *, pphFriNfc_LlcpTransportSocketListenCb_t, void *);
+#else
+HYBRIS_IMPLEMENT_FUNCTION2(libnfc_so, NFCSTATUS, phLibNfc_Llcp_Bind, phLibNfc_Handle, uint8_t);
+HYBRIS_IMPLEMENT_FUNCTION2(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_Bind, phFriNfc_LlcpTransport_Socket_t *, uint8_t);
+HYBRIS_IMPLEMENT_FUNCTION4(libnfc_so, NFCSTATUS, phLibNfc_Llcp_Listen, phLibNfc_Handle, phNfc_sData_t *, pphLibNfc_LlcpSocketListenCb_t, void *);
+HYBRIS_IMPLEMENT_FUNCTION4(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_Listen, phFriNfc_LlcpTransport_Socket_t *, phNfc_sData_t *, pphFriNfc_LlcpTransportSocketListenCb_t, void *);
+#endif
 HYBRIS_IMPLEMENT_FUNCTION6(libnfc_so, NFCSTATUS, phLibNfc_Llcp_Accept, phLibNfc_Handle, phLibNfc_Llcp_sSocketOptions_t *, phNfc_sData_t *, pphLibNfc_LlcpSocketErrCb_t, pphLibNfc_LlcpSocketAcceptCb_t, void *);
 HYBRIS_IMPLEMENT_FUNCTION6(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_Accept, phFriNfc_LlcpTransport_Socket_t *, phFriNfc_LlcpTransport_sSocketOptions_t *, phNfc_sData_t *, pphFriNfc_LlcpTransportSocketErrCb_t, pphFriNfc_LlcpTransportSocketAcceptCb_t, void *);
 HYBRIS_IMPLEMENT_FUNCTION4(libnfc_so, NFCSTATUS, phLibNfc_Llcp_Reject, phLibNfc_Handle, phLibNfc_Handle, pphLibNfc_LlcpSocketRejectCb_t, void *);
@@ -184,7 +191,11 @@ HYBRIS_IMPLEMENT_FUNCTION4(libnfc_so, NFCSTATUS, phLibNfc_RemoteDev_FormatNdef, 
 HYBRIS_IMPLEMENT_FUNCTION6(libnfc_so, NFCSTATUS, phFriNfc_NdefSmtCrd_Reset, phFriNfc_sNdefSmtCrdFmt_t *, void *, phHal_sRemoteDevInformation_t *, phHal_sDevInputParam_t *, uint8_t *, uint16_t *);
 HYBRIS_IMPLEMENT_FUNCTION4(libnfc_so, NFCSTATUS, phFriNfc_NdefSmtCrd_SetCR, phFriNfc_sNdefSmtCrdFmt_t *, uint8_t, pphFriNfc_Cr_t, void *);
 HYBRIS_IMPLEMENT_FUNCTION2(libnfc_so, NFCSTATUS, phFriNfc_NdefSmtCrd_Format, phFriNfc_sNdefSmtCrdFmt_t *, const uint8_t *);
+#if (ANDROID_VERSION_MAJOR == 4 && ANDROID_VERSION_MINOR >= 1) || (ANDROID_VERSION_MAJOR >= 5)
 HYBRIS_IMPLEMENT_FUNCTION4(libnfc_so, NFCSTATUS, phLibNfc_ConvertToReadOnlyNdef, phLibNfc_Handle, phNfc_sData_t *, pphLibNfc_RspCb_t, void *);
+#else
+HYBRIS_IMPLEMENT_FUNCTION3(libnfc_so, NFCSTATUS, phLibNfc_ConvertToReadOnlyNdef, phLibNfc_Handle, pphLibNfc_RspCb_t, void *);
+#endif
 HYBRIS_IMPLEMENT_FUNCTION1(libnfc_so, NFCSTATUS, phFriNfc_NdefMap_ConvertToReadOnly, phFriNfc_NdefMap_t *);
 HYBRIS_IMPLEMENT_FUNCTION1(libnfc_so, NFCSTATUS, phFriNfc_NdefSmtCrd_ConvertToReadOnly, phFriNfc_sNdefSmtCrdFmt_t *);
 HYBRIS_IMPLEMENT_FUNCTION2(libnfc_so, NFCSTATUS, phFriNfc_MifareStdMap_ConvertToReadOnly, phFriNfc_NdefMap_t *, const uint8_t *);

--- a/hybris/tests/Makefile.am
+++ b/hybris/tests/Makefile.am
@@ -19,11 +19,7 @@ if HAS_LIBNFC_NXP_HEADERS
 bin_PROGRAMS += test_nfc
 endif
 
-# Please re-enable your test programs according to android
-# if HAS_ANDROID_X_Y_Z
-# bin_PROGRAMS += test_audio 
-# endif
-
+bin_PROGRAMS += test_audio
 test_audio_SOURCES = test_audio.c
 test_audio_CFLAGS = \
 	-I$(top_srcdir)/include

--- a/hybris/tests/Makefile.am
+++ b/hybris/tests/Makefile.am
@@ -16,7 +16,19 @@ endif
 
 
 if HAS_LIBNFC_NXP_HEADERS
+# test_nfc depends on NFC hardware HAL interface, which is only
+# available until Android API level 15 (v4.0.3, v4.0.4).
+if HAS_ANDROID_4_0_3
 bin_PROGRAMS += test_nfc
+else
+if HAS_ANDROID_4_1_0
+bin_PROGRAMS += test_nfc
+else
+if HAS_ANDROID_5_0_0
+bin_PROGRAMS += test_nfc
+endif
+endif
+endif
 endif
 
 bin_PROGRAMS += test_audio

--- a/hybris/tests/Makefile.am
+++ b/hybris/tests/Makefile.am
@@ -104,13 +104,6 @@ test_gps_SOURCES = test_gps.c
 test_gps_CFLAGS = -pthread \
 	-I$(top_srcdir)/include \
 	$(ANDROID_HEADERS_CFLAGS)
-
-if HAS_ANDROID_4_2_0
-test_gps_CFLAGS += -DHAS_ANDROID_4_2_0
-endif
-if HAS_ANDROID_5_0_0
-test_gps_CFLAGS += -DHAS_ANDROID_5_0_0
-endif
 test_gps_LDFLAGS = -pthread
 test_gps_LDADD =  \
 	$(top_builddir)/common/libhybris-common.la \

--- a/hybris/tests/test_audio.c
+++ b/hybris/tests/test_audio.c
@@ -31,7 +31,11 @@ int main(int argc, char **argv)
 	struct audio_hw_device *audiohw;
 
 	hw_get_module_by_class(AUDIO_HARDWARE_MODULE_ID,
+#if defined(AUDIO_HARDWARE_MODULE_ID_PRIMARY)
 					AUDIO_HARDWARE_MODULE_ID_PRIMARY,
+#else
+					"primary",
+#endif
 					(const hw_module_t**) &hwmod);
 	assert(hwmod != NULL);
 
@@ -39,17 +43,21 @@ int main(int argc, char **argv)
 	assert(audiohw->init_check(audiohw) == 0);
 	printf("Audio Hardware Interface initialized.\n");
 
+#if (ANDROID_VERSION_MAJOR == 4 && ANDROID_VERSION_MINOR >= 1) || (ANDROID_VERSION_MAJOR >= 5)
 	if (audiohw->get_master_volume) {
 		float volume;
 		audiohw->get_master_volume(audiohw, &volume);
 		printf("Master Volume: %f\n", volume);
 	}
+#endif
 
+#if (ANDROID_VERSION_MAJOR == 4 && ANDROID_VERSION_MINOR >= 2) || (ANDROID_VERSION_MAJOR >= 5)
 	if (audiohw->get_master_mute) {
 		bool mute;
 		audiohw->get_master_mute(audiohw, &mute);
 		printf("Master Mute: %d\n", mute);
 	}
+#endif
 
 	audio_hw_device_close(audiohw);
 

--- a/hybris/tests/test_gps.c
+++ b/hybris/tests/test_gps.c
@@ -288,19 +288,11 @@ static void agps_handle_status_callback(AGpsStatus *status)
   {
     case GPS_REQUEST_AGPS_DATA_CONN:
         fprintf(stdout, "*** data_conn_open\n");
-#if ! defined(HAS_ANDROID_4_2_0) && ! defined(HAS_ANDROID_5_0_0)
-        AGps->data_conn_open(AGPS_TYPE_SUPL, apn, AGPS_APN_BEARER_IPV4);
-#else
 	AGps->data_conn_open(apn);
-#endif
         break;
     case GPS_RELEASE_AGPS_DATA_CONN:
         fprintf(stdout, "*** data_conn_closed\n");
-#if ! defined(HAS_ANDROID_4_2_0) && ! defined(HAS_ANDROID_5_0_0)
-	AGps->data_conn_closed(AGPS_TYPE_SUPL);
-#else
         AGps->data_conn_closed();
-#endif
         break;
     case GPS_AGPS_DATA_CONNECTED:
         fprintf(stdout, "*** data_conn_established\n");

--- a/hybris/tests/test_nfc.c
+++ b/hybris/tests/test_nfc.c
@@ -227,7 +227,9 @@ void testNfc(int readNdefMessages)
 
         phLibNfc_sADD_Cfg_t discoveryConfig;
         discoveryConfig.NfcIP_Mode = phNfc_eP2P_ALL;
+#if (ANDROID_VERSION_MAJOR == 4 && ANDROID_VERSION_MINOR >= 1) || (ANDROID_VERSION_MAJOR >= 5)
         discoveryConfig.NfcIP_Target_Mode = 0x0E;
+#endif
         discoveryConfig.Duration = 300000;
         discoveryConfig.NfcIP_Tgt_Disable = 0;
         discoveryConfig.PollDevInfo.PollCfgInfo.EnableIso14443A = 1;

--- a/hybris/tests/test_sensors.c
+++ b/hybris/tests/test_sensors.c
@@ -80,11 +80,19 @@ int main(int argc, char **argv)
         printf("Hardware module ID: %s\n", hwmod->id);
         printf("Hardware module Name: %s\n", hwmod->name);
         printf("Hardware module Author: %s\n", hwmod->author);
+#ifdef HARDWARE_HAL_API_VERSION
         printf("Hardware module API version: 0x%x\n", hwmod->module_api_version);
         printf("Hardware HAL API version: 0x%x\n", hwmod->hal_api_version);
+#else
+        printf("Hardware module API version: 0x%x\n", hwmod->version_major);
+        printf("Hardware HAL API version: 0x%x\n", hwmod->version_minor);
+#endif
         printf("Poll device version: 0x%x\n", dev->common.version);
 
-        printf("API VERSION 0.1 (legacy): 0x%x\n", HARDWARE_MODULE_API_VERSION(0, 1));
+#ifndef SENSORS_MODULE_API_VERSION_0_1
+#define SENSORS_MODULE_API_VERSION_0_1 0x0001
+#endif
+        printf("API VERSION 0.1 (legacy): 0x%x\n", SENSORS_MODULE_API_VERSION_0_1);
 #ifdef SENSORS_DEVICE_API_VERSION_0_1
         printf("API VERSION 0.1: 0x%d\n", SENSORS_DEVICE_API_VERSION_0_1);
 #endif
@@ -93,6 +101,15 @@ int main(int argc, char **argv)
 #endif
 #ifdef SENSORS_DEVICE_API_VERSION_1_1
         printf("API VERSION 1.1: 0x%d\n", SENSORS_DEVICE_API_VERSION_1_1);
+#endif
+#ifdef SENSORS_DEVICE_API_VERSION_1_2
+        printf("API VERSION 1.2: 0x%d\n", SENSORS_DEVICE_API_VERSION_1_2);
+#endif
+#ifdef SENSORS_DEVICE_API_VERSION_1_3
+        printf("API VERSION 1.3: 0x%d\n", SENSORS_DEVICE_API_VERSION_1_3);
+#endif
+#ifdef SENSORS_DEVICE_API_VERSION_1_4
+        printf("API VERSION 1.4: 0x%d\n", SENSORS_DEVICE_API_VERSION_1_4);
 #endif
 
         struct sensors_module_t *smod = (struct sensors_module_t *)(hwmod);


### PR DESCRIPTION
This fix build against [Android API level](http://developer.android.com/guide/topics/manifest/uses-sdk-element.html) 14-23 using headers extracted in https://git.launchpad.net/~vicamo/android-headers/+git/android-headers/log/?h=clean .

Closes #298, #185.