### PR TITLE
hybris/common/jb: Making libhybris buildable x86 64

### DIFF
--- a/hybris/common/jb/dlfcn.c
+++ b/hybris/common/jb/dlfcn.c
@@ -78,7 +78,7 @@ const char *android_dlerror(void)
 void *android_dlsym(void *handle, const char *symbol)
 {
     soinfo *found;
-    Elf32_Sym *sym;
+    Elf_Sym *sym;
     unsigned bind;
 
     pthread_mutex_lock(&dl_lock);
@@ -142,7 +142,7 @@ int android_dladdr(const void *addr, Dl_info *info)
         info->dli_fbase = (void*)si->base;
 
         /* Determine if any symbol in the library contains the specified address */
-        Elf32_Sym *sym = find_containing_symbol(addr, si);
+        Elf_Sym *sym = find_containing_symbol(addr, si);
 
         if(sym != NULL) {
             info->dli_sname = si->strtab + sym->st_name;
@@ -191,7 +191,7 @@ _Unwind_Ptr android_dl_unwind_find_exidx(_Unwind_Ptr pc, int *pcount);
 #endif
 
 
-static Elf32_Sym libdl_symtab[] = {
+static Elf_Sym libdl_symtab[] = {
       // total length of libdl_info.strtab, including trailing 0
       // This is actually the the STH_UNDEF entry. Technically, it's
       // supposed to have st_name == 0, but instead, it points to an index
@@ -199,33 +199,33 @@ static Elf32_Sym libdl_symtab[] = {
     { st_name: sizeof(ANDROID_LIBDL_STRTAB) - 1,
     },
     { st_name: 0,   // starting index of the name in libdl_info.strtab
-      st_value: (Elf32_Addr) &android_dlopen,
+      st_value: (Elf_Addr) &android_dlopen,
       st_info: STB_GLOBAL << 4,
       st_shndx: 1,
     },
     { st_name: 7,
-      st_value: (Elf32_Addr) &android_dlclose,
+      st_value: (Elf_Addr) &android_dlclose,
       st_info: STB_GLOBAL << 4,
       st_shndx: 1,
     },
     { st_name: 15,
-      st_value: (Elf32_Addr) &android_dlsym,
+      st_value: (Elf_Addr) &android_dlsym,
       st_info: STB_GLOBAL << 4,
       st_shndx: 1,
     },
     { st_name: 21,
-      st_value: (Elf32_Addr) &android_dlerror,
+      st_value: (Elf_Addr) &android_dlerror,
       st_info: STB_GLOBAL << 4,
       st_shndx: 1,
     },
     { st_name: 29,
-      st_value: (Elf32_Addr) &android_dladdr,
+      st_value: (Elf_Addr) &android_dladdr,
       st_info: STB_GLOBAL << 4,
       st_shndx: 1,
     },
 #ifdef ANDROID_ARM_LINKER
     { st_name: 36,
-      st_value: (Elf32_Addr) &android_dl_unwind_find_exidx,
+      st_value: (Elf_Addr) &android_dl_unwind_find_exidx,
       st_info: STB_GLOBAL << 4,
       st_shndx: 1,
     },
@@ -233,7 +233,7 @@ static Elf32_Sym libdl_symtab[] = {
 #else
     { st_name: 36,
 #endif
-      st_value: (Elf32_Addr) &android_dl_iterate_phdr,
+      st_value: (Elf_Addr) &android_dl_iterate_phdr,
       st_info: STB_GLOBAL << 4,
       st_shndx: 1,
     },

--- a/hybris/common/jb/linker.c
+++ b/hybris/common/jb/linker.c
@@ -380,10 +380,10 @@ android_dl_iterate_phdr(int (*cb)(struct dl_phdr_info *info, size_t size, void *
     return rv;
 }
 
-static Elf32_Sym *_elf_lookup(soinfo *si, unsigned hash, const char *name)
+static Elf_Sym *_elf_lookup(soinfo *si, unsigned hash, const char *name)
 {
-    Elf32_Sym *s;
-    Elf32_Sym *symtab = si->symtab;
+    Elf_Sym *s;
+    Elf_Sym *symtab = si->symtab;
     const char *strtab = si->strtab;
     unsigned n;
 
@@ -425,11 +425,11 @@ static unsigned elfhash(const char *_name)
     return h;
 }
 
-static Elf32_Sym *
+static Elf_Sym *
 _do_lookup(soinfo *si, const char *name, unsigned *base)
 {
     unsigned elf_hash = elfhash(name);
-    Elf32_Sym *s;
+    Elf_Sym *s;
     unsigned *d;
     soinfo *lsi = si;
     int i;
@@ -501,17 +501,17 @@ done:
 /* This is used by dl_sym().  It performs symbol lookup only within the
    specified soinfo object and not in any of its dependencies.
  */
-Elf32_Sym *lookup_in_library(soinfo *si, const char *name)
+Elf_Sym *lookup_in_library(soinfo *si, const char *name)
 {
     return _elf_lookup(si, elfhash(name), name);
 }
 
 /* This is used by dl_sym().  It performs a global symbol lookup.
  */
-Elf32_Sym *lookup(const char *name, soinfo **found, soinfo *start)
+Elf_Sym *lookup(const char *name, soinfo **found, soinfo *start)
 {
     unsigned elf_hash = elfhash(name);
-    Elf32_Sym *s = NULL;
+    Elf_Sym *s = NULL;
     soinfo *si;
 
     if(start == NULL) {
@@ -552,7 +552,7 @@ soinfo *find_containing_library(const void *addr)
     return NULL;
 }
 
-Elf32_Sym *find_containing_symbol(const void *addr, soinfo *si)
+Elf_Sym *find_containing_symbol(const void *addr, soinfo *si)
 {
     unsigned int i;
     unsigned soaddr = (unsigned)addr - si->base;
@@ -560,7 +560,7 @@ Elf32_Sym *find_containing_symbol(const void *addr, soinfo *si)
     /* Search the library's symbol table for any defined symbol which
      * contains this address */
     for(i=0; i<si->nchain; i++) {
-        Elf32_Sym *sym = &si->symtab[i];
+        Elf_Sym *sym = &si->symtab[i];
 
         if(sym->st_shndx != SHN_UNDEF &&
            soaddr >= sym->st_value &&
@@ -575,7 +575,7 @@ Elf32_Sym *find_containing_symbol(const void *addr, soinfo *si)
 #if 0
 static void dump(soinfo *si)
 {
-    Elf32_Sym *s = si->symtab;
+    Elf_Sym *s = si->symtab;
     unsigned n;
 
     for(n = 0; n < si->nchain; n++) {
@@ -704,7 +704,7 @@ is_prelinked(int fd, const char *name)
 static int
 verify_elf_object(void *base, const char *name)
 {
-    Elf32_Ehdr *hdr = (Elf32_Ehdr *) base;
+    Elf_Ehdr *hdr = (Elf_Ehdr *) base;
 
     if (hdr->e_ident[EI_MAG0] != ELFMAG0) return -1;
     if (hdr->e_ident[EI_MAG1] != ELFMAG1) return -1;
@@ -749,8 +749,8 @@ get_lib_extents(int fd, const char *name, void *__hdr, unsigned *total_sz)
     unsigned min_vaddr = 0xffffffff;
     unsigned max_vaddr = 0;
     unsigned char *_hdr = (unsigned char *)__hdr;
-    Elf32_Ehdr *ehdr = (Elf32_Ehdr *)_hdr;
-    Elf32_Phdr *phdr;
+    Elf_Ehdr *ehdr = (Elf_Ehdr *)_hdr;
+    Elf_Phdr *phdr;
     int cnt;
 
     TRACE("[ %5d Computing extents for '%s'. ]\n", pid, name);
@@ -769,7 +769,7 @@ get_lib_extents(int fd, const char *name, void *__hdr, unsigned *total_sz)
         TRACE("[ %5d - Non-prelinked library '%s' found. ]\n", pid, name);
     }
 
-    phdr = (Elf32_Phdr *)(_hdr + ehdr->e_phoff);
+    phdr = (Elf_Phdr *)(_hdr + ehdr->e_phoff);
 
     /* find the min/max p_vaddrs from all the PT_LOAD segments so we can
      * get the range. */
@@ -884,12 +884,12 @@ err:
 static int
 load_segments(int fd, void *header, soinfo *si)
 {
-    Elf32_Ehdr *ehdr = (Elf32_Ehdr *)header;
-    Elf32_Phdr *phdr = (Elf32_Phdr *)((unsigned char *)header + ehdr->e_phoff);
-    Elf32_Addr base = (Elf32_Addr) si->base;
+    Elf_Ehdr *ehdr = (Elf_Ehdr *)header;
+    Elf_Phdr *phdr = (Elf_Phdr *)((unsigned char *)header + ehdr->e_phoff);
+    Elf_Addr base = (Elf_Addr) si->base;
     int cnt;
     unsigned len;
-    Elf32_Addr tmp;
+    Elf_Addr tmp;
     unsigned char *pbase;
     unsigned char *extra_base;
     unsigned extra_len;
@@ -955,7 +955,7 @@ load_segments(int fd, void *header, soinfo *si)
              *                  |                     |
              *                 _+---------------------+  page boundary
              */
-            tmp = (Elf32_Addr)(((unsigned)pbase + len + PAGE_SIZE - 1) &
+            tmp = (Elf_Addr)(((unsigned)pbase + len + PAGE_SIZE - 1) &
                                     (~PAGE_MASK));
             if (tmp < (base + phdr->p_vaddr + phdr->p_memsz)) {
                 extra_len = base + phdr->p_vaddr + phdr->p_memsz - tmp;
@@ -1019,7 +1019,7 @@ load_segments(int fd, void *header, soinfo *si)
                        phdr->p_vaddr, phdr->p_memsz);
                 goto fail;
             }
-            si->gnu_relro_start = (Elf32_Addr) (base + phdr->p_vaddr);
+            si->gnu_relro_start = (Elf_Addr) (base + phdr->p_vaddr);
             si->gnu_relro_len = (unsigned) phdr->p_memsz;
         } else {
 #ifdef ANDROID_ARM_LINKER
@@ -1066,11 +1066,11 @@ fail:
  */
 #if 0
 static unsigned
-get_wr_offset(int fd, const char *name, Elf32_Ehdr *ehdr)
+get_wr_offset(int fd, const char *name, Elf_Ehdr *ehdr)
 {
-    Elf32_Shdr *shdr_start;
-    Elf32_Shdr *shdr;
-    int shdr_sz = ehdr->e_shnum * sizeof(Elf32_Shdr);
+    Elf_Shdr *shdr_start;
+    Elf_Shdr *shdr;
+    int shdr_sz = ehdr->e_shnum * sizeof(Elf_Shdr);
     int cnt;
     unsigned wr_offset = 0xffffffff;
 
@@ -1103,7 +1103,7 @@ load_library(const char *name)
     unsigned req_base;
     const char *bname;
     soinfo *si = NULL;
-    Elf32_Ehdr *hdr;
+    Elf_Ehdr *hdr;
 
     if(fd == -1) {
         DL_ERR("Library '%s' not found", name);
@@ -1160,8 +1160,8 @@ load_library(const char *name)
 
     /* this might not be right. Technically, we don't even need this info
      * once we go through 'load_segments'. */
-    hdr = (Elf32_Ehdr *)si->base;
-    si->phdr = (Elf32_Phdr *)((unsigned char *)si->base + hdr->e_phoff);
+    hdr = (Elf_Ehdr *)si->base;
+    si->phdr = (Elf_Phdr *)((unsigned char *)si->base + hdr->e_phoff);
     si->phnum = hdr->e_phnum;
     /**/
 
@@ -1260,7 +1260,7 @@ unsigned unload_library(soinfo *si)
          * in link_image. This is needed to undo the DT_NEEDED hack below.
          */
         if ((si->gnu_relro_start != 0) && (si->gnu_relro_len != 0)) {
-            Elf32_Addr start = (si->gnu_relro_start & ~PAGE_MASK);
+            Elf_Addr start = (si->gnu_relro_start & ~PAGE_MASK);
             unsigned len = (si->gnu_relro_start - start) + si->gnu_relro_len;
             if (mprotect((void *) start, len, PROT_READ | PROT_WRITE) < 0)
                 DL_ERR("%5d %s: could not undo GNU_RELRO protections. "
@@ -1303,16 +1303,16 @@ unsigned unload_library(soinfo *si)
 }
 
 /* TODO: don't use unsigned for addrs below. It works, but is not
- * ideal. They should probably be either uint32_t, Elf32_Addr, or unsigned
+ * ideal. They should probably be either uint32_t, Elf_Addr, or unsigned
  * long.
  */
-static int reloc_library(soinfo *si, Elf32_Rel *rel, unsigned count)
+static int reloc_library(soinfo *si, Elf_Rel *rel, unsigned count)
 {
-    Elf32_Sym *symtab = si->symtab;
+    Elf_Sym *symtab = si->symtab;
     const char *strtab = si->strtab;
-    Elf32_Sym *s;
+    Elf_Sym *s;
     unsigned base;
-    Elf32_Rel *start = rel;
+    Elf_Rel *start = rel;
     unsigned idx;
 
     for (idx = 0; idx < count; ++idx) {
@@ -1711,7 +1711,7 @@ static int nullify_closed_stdio (void)
 static int link_image(soinfo *si, unsigned wr_offset)
 {
     unsigned *d;
-    Elf32_Phdr *phdr = si->phdr;
+    Elf_Phdr *phdr = si->phdr;
     int phnum = si->phnum;
 
     INFO("[ %5d linking %s ]\n", pid, si->name);
@@ -1794,7 +1794,7 @@ static int link_image(soinfo *si, unsigned wr_offset)
                            phdr->p_vaddr, phdr->p_memsz);
                     goto fail;
                 }
-                si->gnu_relro_start = (Elf32_Addr) (si->base + phdr->p_vaddr);
+                si->gnu_relro_start = (Elf_Addr) (si->base + phdr->p_vaddr);
                 si->gnu_relro_len = (unsigned) phdr->p_memsz;
             }
         }
@@ -1821,7 +1821,7 @@ static int link_image(soinfo *si, unsigned wr_offset)
             si->strtab = (const char *) (si->base + *d);
             break;
         case DT_SYMTAB:
-            si->symtab = (Elf32_Sym *) (si->base + *d);
+            si->symtab = (Elf_Sym *) (si->base + *d);
             break;
         case DT_PLTREL:
             if(*d != DT_REL) {
@@ -1830,13 +1830,13 @@ static int link_image(soinfo *si, unsigned wr_offset)
             }
             break;
         case DT_JMPREL:
-            si->plt_rel = (Elf32_Rel*) (si->base + *d);
+            si->plt_rel = (Elf_Rel*) (si->base + *d);
             break;
         case DT_PLTRELSZ:
             si->plt_rel_count = *d / 8;
             break;
         case DT_REL:
-            si->rel = (Elf32_Rel*) (si->base + *d);
+            si->rel = (Elf_Rel*) (si->base + *d);
             break;
         case DT_RELSZ:
             si->rel_count = *d / 8;
@@ -1868,7 +1868,7 @@ static int link_image(soinfo *si, unsigned wr_offset)
                   pid, si->name, si->init_array);
             break;
         case DT_INIT_ARRAYSZ:
-            si->init_array_count = ((unsigned)*d) / sizeof(Elf32_Addr);
+            si->init_array_count = ((unsigned)*d) / sizeof(Elf_Addr);
             break;
         case DT_FINI_ARRAY:
             si->fini_array = (unsigned *)(si->base + *d);
@@ -1876,7 +1876,7 @@ static int link_image(soinfo *si, unsigned wr_offset)
                   pid, si->name, si->fini_array);
             break;
         case DT_FINI_ARRAYSZ:
-            si->fini_array_count = ((unsigned)*d) / sizeof(Elf32_Addr);
+            si->fini_array_count = ((unsigned)*d) / sizeof(Elf_Addr);
             break;
         case DT_PREINIT_ARRAY:
             si->preinit_array = (unsigned *)(si->base + *d);
@@ -1884,7 +1884,7 @@ static int link_image(soinfo *si, unsigned wr_offset)
                   pid, si->name, si->preinit_array);
             break;
         case DT_PREINIT_ARRAYSZ:
-            si->preinit_array_count = ((unsigned)*d) / sizeof(Elf32_Addr);
+            si->preinit_array_count = ((unsigned)*d) / sizeof(Elf_Addr);
             break;
         case DT_TEXTREL:
             /* TODO: make use of this. */
@@ -1986,7 +1986,7 @@ static int link_image(soinfo *si, unsigned wr_offset)
 #endif
 
     if (si->gnu_relro_start != 0 && si->gnu_relro_len != 0) {
-        Elf32_Addr start = (si->gnu_relro_start & ~PAGE_MASK);
+        Elf_Addr start = (si->gnu_relro_start & ~PAGE_MASK);
         unsigned len = (si->gnu_relro_start - start) + si->gnu_relro_len;
         if (mprotect((void *) start, len, PROT_READ) < 0) {
             DL_ERR("%5d GNU_RELRO mprotect of library '%s' failed: %d (%s)\n",
@@ -2169,7 +2169,7 @@ sanitize:
     while(vecs[0] != 0){
         switch(vecs[0]){
         case AT_PHDR:
-            si->phdr = (Elf32_Phdr*) vecs[1];
+            si->phdr = (Elf_Phdr*) vecs[1];
             break;
         case AT_PHNUM:
             si->phnum = (int) vecs[1];
@@ -2189,7 +2189,7 @@ sanitize:
     si->base = 0;
     for ( nn = 0; nn < si->phnum; nn++ ) {
         if (si->phdr[nn].p_type == PT_PHDR) {
-            si->base = (Elf32_Addr) si->phdr - si->phdr[nn].p_vaddr;
+            si->base = (Elf_Addr) si->phdr - si->phdr[nn].p_vaddr;
             break;
         }
     }
@@ -2302,9 +2302,9 @@ static unsigned find_linker_base(unsigned **elfdata) {
  */
 unsigned __linker_init(unsigned **elfdata) {
     unsigned linker_addr = find_linker_base(elfdata);
-    Elf32_Ehdr *elf_hdr = (Elf32_Ehdr *) linker_addr;
-    Elf32_Phdr *phdr =
-        (Elf32_Phdr *)((unsigned char *) linker_addr + elf_hdr->e_phoff);
+    Elf_Ehdr *elf_hdr = (Elf_Ehdr *) linker_addr;
+    Elf_Phdr *phdr =
+        (Elf_Phdr *)((unsigned char *) linker_addr + elf_hdr->e_phoff);
 
     soinfo linker_so;
     memset(&linker_so, 0, sizeof(soinfo));

--- a/hybris/common/jb/linker.h
+++ b/hybris/common/jb/linker.h
@@ -38,6 +38,26 @@
 #define PAGE_SIZE 4096
 #define PAGE_MASK 4095
 
+#if defined(__x86_64__)
+typedef Elf64_Ehdr Elf_Ehdr;
+typedef Elf64_Shdr Elf_Shdr;
+typedef Elf64_Sym  Elf_Sym;
+typedef Elf64_Addr Elf_Addr;
+typedef Elf64_Phdr Elf_Phdr;
+typedef Elf64_Half Elf_Half;
+typedef Elf64_Rel  Elf_Rel;
+typedef Elf64_Rela Elf_Rela;
+#else
+typedef Elf32_Ehdr Elf_Ehdr;
+typedef Elf32_Shdr Elf_Shdr;
+typedef Elf32_Sym  Elf_Sym;
+typedef Elf32_Addr Elf_Addr;
+typedef Elf32_Phdr Elf_Phdr;
+typedef Elf32_Half Elf_Half;
+typedef Elf32_Rel  Elf_Rel;
+typedef Elf32_Rela Elf_Rela;
+#endif
+
 void debugger_init();
 const char *addr_to_name(unsigned addr);
 
@@ -55,10 +75,10 @@ struct link_map
 /* needed for dl_iterate_phdr to be passed to the callbacks provided */
 struct dl_phdr_info
 {
-    Elf32_Addr dlpi_addr;
+    Elf_Addr dlpi_addr;
     const char *dlpi_name;
-    const Elf32_Phdr *dlpi_phdr;
-    Elf32_Half dlpi_phnum;
+    const Elf_Phdr *dlpi_phdr;
+    Elf_Half dlpi_phnum;
 };
 
 
@@ -90,7 +110,7 @@ typedef struct soinfo soinfo;
 struct soinfo
 {
     const char name[SOINFO_NAME_LEN];
-    Elf32_Phdr *phdr;
+    Elf_Phdr *phdr;
     int phnum;
     unsigned entry;
     unsigned base;
@@ -107,7 +127,7 @@ struct soinfo
     unsigned flags;
 
     const char *strtab;
-    Elf32_Sym *symtab;
+    Elf_Sym *symtab;
 
     unsigned nbucket;
     unsigned nchain;
@@ -116,10 +136,10 @@ struct soinfo
 
     unsigned *plt_got;
 
-    Elf32_Rel *plt_rel;
+    Elf_Rel *plt_rel;
     unsigned plt_rel_count;
 
-    Elf32_Rel *rel;
+    Elf_Rel *rel;
     unsigned rel_count;
 
     unsigned *preinit_array;
@@ -144,7 +164,7 @@ struct soinfo
 
     int constructors_called;
 
-    Elf32_Addr gnu_relro_start;
+    Elf_Addr gnu_relro_start;
     unsigned gnu_relro_len;
 
 };
@@ -202,10 +222,10 @@ extern soinfo libdl_info;
 
 soinfo *find_library(const char *name);
 unsigned unload_library(soinfo *si);
-Elf32_Sym *lookup_in_library(soinfo *si, const char *name);
-Elf32_Sym *lookup(const char *name, soinfo **found, soinfo *start);
+Elf_Sym *lookup_in_library(soinfo *si, const char *name);
+Elf_Sym *lookup(const char *name, soinfo **found, soinfo *start);
 soinfo *find_containing_library(const void *addr);
-Elf32_Sym *find_containing_symbol(const void *addr, soinfo *si);
+Elf_Sym *find_containing_symbol(const void *addr, soinfo *si);
 const char *linker_get_error(void);
 void call_constructors_recursive(soinfo *si);
 


### PR DESCRIPTION
Fails with

dlfcn.c:202:17: error: initializer element is not constant
dlfcn.c:202:17: note: (near initialization for 'libdl_symtab[1].st_value')
dlfcn.c:207:17: warning: cast from pointer to integer of different size
[-Wpointer-to-int-cast]
       st_value: (Elf32_Addr) &android_dlclose,