### PR TITLE
use api level for version comparison

### DIFF
--- a/hybris/Makefile.am
+++ b/hybris/Makefile.am
@@ -1,14 +1,11 @@
 SUBDIRS = include properties common hardware
 
-if HAS_ANDROID_4_2_0
-SUBDIRS += libsync
-endif
-if HAS_ANDROID_5_0_0
+if HAS_ANDROID_LIBSYNC
 SUBDIRS += libsync
 endif
 SUBDIRS += egl glesv1 glesv2 vibrator
 
-if HAS_LIBNFC_NXP_HEADERS
+if HAS_ANDROID_LIBNFC_NXP
 SUBDIRS += libnfc_nxp libnfc_ndef_nxp
 endif
 SUBDIRS += utils tests

--- a/hybris/common/Makefile.am
+++ b/hybris/common/Makefile.am
@@ -2,20 +2,15 @@ lib_LTLIBRARIES = \
 	libhybris-common.la
 
 # JB linker works fine for ICS
-if HAS_ANDROID_4_0_0
+if HAS_ANDROID_14_OR_NEWER
 SUBDIRS = jb
 libhybris_common_la_LIBADD= jb/libandroid-linker.la
 else
-if HAS_ANDROID_5_0_0
-SUBDIRS = jb
-libhybris_common_la_LIBADD= jb/libandroid-linker.la
-else
-if HAS_ANDROID_2_3_0
+if HAS_ANDROID_9_OR_NEWER
 SUBDIRS = gingerbread
 libhybris_common_la_LIBADD= gingerbread/libandroid-linker.la
 else
 $(error No Android Version is defined)
-endif
 endif
 endif
 

--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -117,8 +117,12 @@ AC_SUBST(DEFAULT_HYBRIS_LD_LIBRARY_PATH)
 AC_ARG_WITH(android-headers,
   [  --with-android-headers=DIR     Use android headers available in DIR. See utils/extract-headers.sh ],
   [
-    AM_CONDITIONAL([HAS_LIBNFC_NXP_HEADERS], [test -f $withval/libnfc-nxp/phLibNfc.h])
-    AS_IF([test -f $withval/libnfc-nxp/phLibNfc.h], [ANDROID_HEADERS_CFLAGS="-I$withval -I$withval/libnfc-nxp"],[ANDROID_HEADERS_CFLAGS="-I$withval"])
+    CPPFLAGS_saved="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS -I$withval -I$withval/libnfc-nxp"
+    AC_CHECK_HEADER([phLibNfc.h], [ANDROID_HEADERS_CFLAGS="-I$withval -I$withval/libnfc-nxp"], [ANDROID_HEADERS_CFLAGS="-I$withval"])
+    CPPFLAGS="$CPPFLAGS_saved"
+
+    AM_CONDITIONAL([HAS_ANDROID_LIBNFC_NXP], [test -n "$ac_cv_header_phLibNfc_h"])
     AC_SUBST([ANDROID_HEADERS_CFLAGS])
   ],
   [ PKG_CHECK_MODULES(ANDROID_HEADERS, android-headers,, exit) ]
@@ -184,6 +188,11 @@ AM_CONDITIONAL([HAS_ANDROID_4_1_0], [test $android_headers_major -ge 4 -a $andro
 AM_CONDITIONAL([HAS_ANDROID_4_0_3], [test $android_headers_major -ge 4 -a $android_headers_patch -ge 3 ])
 AM_CONDITIONAL([HAS_ANDROID_4_0_0], [test $android_headers_major -ge 4 -a $android_headers_minor -ge 0 ])
 AM_CONDITIONAL([HAS_ANDROID_2_3_0], [test $android_headers_major -ge 2 -a $android_headers_minor -ge 3 ])
+
+AC_CHECK_HEADER([hardware/nfc.h hardware/hwcomposer.h sync/sync.h])
+AM_CONDITIONAL([HAS_ANDROID_HAL_NFC], [test x"$ac_cv_header_hardware_nfc_h" = xyes])
+AM_CONDITIONAL([HAS_ANDROID_LIBSYNC], [test x"$ac_cv_header_sync_sync_h" = xyes])
+AM_CONDITIONAL([HAS_ANDROID_HAL_HWCOMPOSER], [test x"$ac_cv_header_hardware_hwcomposer_h" = xyes -a x"$ac_cv_header_sync_sync_h" = xyes])
 
 
 AC_CONFIG_FILES([

--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -173,21 +173,27 @@ has_ANDROID_VERSION_PATCH ANDROID_VERSION_PATCH
 [android_headers_patch=$ac_awk_cpp_out],
 [AC_MSG_ERROR(require 'patch' version is missing)])
 
-AC_MSG_NOTICE("Android headers version is $android_headers_major.$android_headers_minor.$android_headers_patch.$ac_awk_cpp_out")
+###########################
+AC_AWK_CPP([/has_ANDROID_API_LEVEL/ {print \$2;}],
+[
+#include <android-version.h>
+has_ANDROID_API_LEVEL ANDROID_API_LEVEL
+],
+[android_api_level=$ac_awk_cpp_out],
+[AC_MSG_ERROR(require api level is missing)])
+
 ###########################
 AC_SUBST(ANDROID_VERSION_MAJOR, [$android_headers_major])
 AC_SUBST(ANDROID_VERSION_MINOR, [$android_headers_minor])
 AC_SUBST(ANDROID_VERSION_PATCH, [$android_headers_patch])
+AC_SUBST(ANDROID_API_LEVEL, [$android_api_level])
 
 AC_MSG_NOTICE("Android headers version is $android_headers_major.$android_headers_minor.$android_headers_patch")
+AC_MSG_NOTICE("Android API level is $android_api_level")
 
 # Add automake tests for version/API needs here that you need in code, including test .am's
-AM_CONDITIONAL([HAS_ANDROID_5_0_0], [test $android_headers_major -ge 5 -a $android_headers_minor -ge 0 ])
-AM_CONDITIONAL([HAS_ANDROID_4_2_0], [test $android_headers_major -ge 4 -a $android_headers_minor -ge 2 ])
-AM_CONDITIONAL([HAS_ANDROID_4_1_0], [test $android_headers_major -ge 4 -a $android_headers_minor -ge 1 ])
-AM_CONDITIONAL([HAS_ANDROID_4_0_3], [test $android_headers_major -ge 4 -a $android_headers_patch -ge 3 ])
-AM_CONDITIONAL([HAS_ANDROID_4_0_0], [test $android_headers_major -ge 4 -a $android_headers_minor -ge 0 ])
-AM_CONDITIONAL([HAS_ANDROID_2_3_0], [test $android_headers_major -ge 2 -a $android_headers_minor -ge 3 ])
+AM_CONDITIONAL([HAS_ANDROID_9_OR_NEWER], [test $android_api_level -ge 9])
+AM_CONDITIONAL([HAS_ANDROID_14_OR_NEWER], [test $android_api_level -ge 14])
 
 AC_CHECK_HEADER([hardware/nfc.h hardware/hwcomposer.h sync/sync.h])
 AM_CONDITIONAL([HAS_ANDROID_HAL_NFC], [test x"$ac_cv_header_hardware_nfc_h" = xyes])

--- a/hybris/egl/platforms/Makefile.am
+++ b/hybris/egl/platforms/Makefile.am
@@ -1,9 +1,6 @@
 
 SUBDIRS = common null fbdev
-if HAS_ANDROID_4_2_0
-SUBDIRS += hwcomposer
-endif
-if HAS_ANDROID_5_0_0
+if HAS_ANDROID_HAL_HWCOMPOSER
 SUBDIRS += hwcomposer
 endif
 

--- a/hybris/egl/platforms/common/Makefile.am
+++ b/hybris/egl/platforms/common/Makefile.am
@@ -92,11 +92,7 @@ libhybris_eglplatformcommon_la_LDFLAGS = \
 	$(top_builddir)/common/libhybris-common.la \
 	-version-info "1":"0":"0"
 
-if HAS_ANDROID_4_2_0
-libhybris_eglplatformcommon_la_LDFLAGS += $(top_builddir)/libsync/libsync.la
-endif
-
-if HAS_ANDROID_5_0_0
+if HAS_ANDROID_LIBSYNC
 libhybris_eglplatformcommon_la_LDFLAGS += $(top_builddir)/libsync/libsync.la
 endif
 

--- a/hybris/egl/platforms/common/nativewindowbase.cpp
+++ b/hybris/egl/platforms/common/nativewindowbase.cpp
@@ -5,7 +5,7 @@
 #include "support.h"
 #include <stdarg.h>
 
-#if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=2 || ANDROID_VERSION_MAJOR>=5
+#if (ANDROID_API_LEVEL >= 17)
 extern "C" {
 #include <sync/sync.h>
 }
@@ -99,7 +99,7 @@ BaseNativeWindow::BaseNativeWindow()
 
 	ANativeWindow::setSwapInterval = _setSwapInterval;
 
-#if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=2 || ANDROID_VERSION_MAJOR>=5
+#if (ANDROID_API_LEVEL >= 17)
 	ANativeWindow::lockBuffer_DEPRECATED = &_lockBuffer_DEPRECATED;
 	ANativeWindow::dequeueBuffer_DEPRECATED = &_dequeueBuffer_DEPRECATED;
 	ANativeWindow::queueBuffer_DEPRECATED = &_queueBuffer_DEPRECATED;
@@ -164,7 +164,7 @@ int BaseNativeWindow::_dequeueBuffer_DEPRECATED(ANativeWindow* window, ANativeWi
 
 	*buffer = static_cast<ANativeWindowBuffer*>(temp);
 
-#if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=2 || ANDROID_VERSION_MAJOR>=5
+#if (ANDROID_API_LEVEL >= 17)
 	if (fenceFd >= 0)
 	{
 		sync_wait(fenceFd, -1);
@@ -238,7 +238,7 @@ const char *BaseNativeWindow::_native_window_operation(int what)
 		case NATIVE_WINDOW_UNLOCK_AND_POST: return "NATIVE_WINDOW_UNLOCK_AND_POST";
 		case NATIVE_WINDOW_API_CONNECT: return "NATIVE_WINDOW_API_CONNECT";
 		case NATIVE_WINDOW_API_DISCONNECT: return "NATIVE_WINDOW_API_DISCONNECT";
-#if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=1
+#if (ANDROID_API_LEVEL >= 16)
 		case NATIVE_WINDOW_SET_BUFFERS_USER_DIMENSIONS: return "NATIVE_WINDOW_SET_BUFFERS_USER_DIMENSIONS";
 		case NATIVE_WINDOW_SET_POST_TRANSFORM_CROP: return "NATIVE_WINDOW_SET_POST_TRANSFORM_CROP";
 #endif
@@ -257,7 +257,7 @@ const char *BaseNativeWindow::_native_query_operation(int what)
 		case NATIVE_WINDOW_DEFAULT_WIDTH: return "NATIVE_WINDOW_DEFAULT_WIDTH";
 		case NATIVE_WINDOW_DEFAULT_HEIGHT: return "NATIVE_WINDOW_DEFAULT_HEIGHT";
 		case NATIVE_WINDOW_TRANSFORM_HINT: return "NATIVE_WINDOW_TRANSFORM_HINT";
-#if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=1 || ANDROID_VERSION_MAJOR>=5
+#if (ANDROID_API_LEVEL >= 16)
 		case NATIVE_WINDOW_CONSUMER_RUNNING_BEHIND: return "NATIVE_WINDOW_CONSUMER_RUNNING_BEHIND";
 #endif
 		default: return "NATIVE_UNKNOWN_QUERY";
@@ -371,7 +371,7 @@ int BaseNativeWindow::_perform(struct ANativeWindow* window, int operation, ... 
 	case NATIVE_WINDOW_API_DISCONNECT            : // 14,   /* private */
 		TRACE("api disconnect");
 		break;
-#if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=1 || ANDROID_VERSION_MAJOR>=5
+#if (ANDROID_API_LEVEL >= 16)
 	case NATIVE_WINDOW_SET_BUFFERS_USER_DIMENSIONS : // 15, /* private */
 		TRACE("set buffers user dimensions");
 		break;

--- a/hybris/egl/platforms/fbdev/fbdev_window.cpp
+++ b/hybris/egl/platforms/fbdev/fbdev_window.cpp
@@ -74,7 +74,7 @@ FbDevNativeWindow::FbDevNativeWindow( alloc_device_t* alloc,
     m_bufferCount = 0;
     m_allocateBuffers = true;
 
-#if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=2 || ANDROID_VERSION_MAJOR>=5
+#if (ANDROID_API_LEVEL >= 17)
     if (m_fbDev->numFramebuffers>0)
         setBufferCount(m_fbDev->numFramebuffers);
     else
@@ -188,7 +188,7 @@ int FbDevNativeWindow::dequeueBuffer(BaseNativeWindowBuffer** buffer, int *fence
 
         if (it == m_bufList.end())
         {
-#if ANDROID_VERSION_MAJOR<=4 && ANDROID_VERSION_MINOR<2
+#if (ANDROID_API_LEVEL <= 16)
             /*
              * This is acceptable in case you are on a stack that calls lock() before starting to render into buffer
              * When you are using fences (>= 2) you'll be waiting on the fence to signal instead. 

--- a/hybris/egl/platforms/hwcomposer/Makefile.am
+++ b/hybris/egl/platforms/hwcomposer/Makefile.am
@@ -30,10 +30,7 @@ libhybris_hwcomposerwindow_la_LDFLAGS = \
 	$(top_builddir)/egl/platforms/common/libhybris-eglplatformcommon.la \
 	$(top_builddir)/hardware/libhardware.la
 
-if HAS_ANDROID_4_2_0
-libhybris_hwcomposerwindow_la_LDFLAGS += $(top_builddir)/libsync/libsync.la
-endif
-if HAS_ANDROID_5_0_0
+if HAS_ANDROID_LIBSYNC
 libhybris_hwcomposerwindow_la_LDFLAGS += $(top_builddir)/libsync/libsync.la
 endif
 pkglib_LTLIBRARIES = eglplatform_hwcomposer.la

--- a/hybris/egl/platforms/wayland/Makefile.am
+++ b/hybris/egl/platforms/wayland/Makefile.am
@@ -32,11 +32,6 @@ eglplatform_wayland_la_LDFLAGS = \
 	$(top_builddir)/egl/platforms/common/libhybris-eglplatformcommon.la \
 	$(top_builddir)/hardware/libhardware.la \
 	$(WAYLAND_CLIENT_LIBS)
-if HAS_ANDROID_4_2_0
+if HAS_ANDROID_LIBSYNC
 eglplatform_wayland_la_LDFLAGS += $(top_builddir)/libsync/libsync.la
 endif
-
-if HAS_ANDROID_5_0_0
-eglplatform_wayland_la_LDFLAGS += $(top_builddir)/libsync/libsync.la
-endif
-

--- a/hybris/egl/platforms/wayland/wayland_window.cpp
+++ b/hybris/egl/platforms/wayland/wayland_window.cpp
@@ -35,7 +35,7 @@
 #include "logging.h"
 #include <eglhybris.h>
 
-#if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=2 || ANDROID_VERSION_MAJOR>=5
+#if (ANDROID_API_LEVEL >= 17)
 extern "C" {
 #include <sync/sync.h>
 }
@@ -586,7 +586,7 @@ int WaylandNativeWindow::queueBuffer(BaseNativeWindowBuffer* buffer, int fenceFd
 
     }
 
-#if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=2 || ANDROID_VERSION_MAJOR>=5
+#if (ANDROID_API_LEVEL >= 17)
     HYBRIS_TRACE_BEGIN("wayland-platform", "queueBuffer_waiting_for_fence", "-%p", wnb);
     if (fenceFd >= 0)
     {
@@ -674,7 +674,7 @@ unsigned int WaylandNativeWindow::queueLength() const {
 
 unsigned int WaylandNativeWindow::type() const {
     TRACE("");
-#if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=3 || ANDROID_VERSION_MAJOR>=5
+#if (ANDROID_API_LEVEL >= 18)
     /* https://android.googlesource.com/platform/system/core/+/bcfa910611b42018db580b3459101c564f802552%5E!/ */
     return NATIVE_WINDOW_SURFACE;
 #else

--- a/hybris/libnfc_nxp/libnfc_nxp.c
+++ b/hybris/libnfc_nxp/libnfc_nxp.c
@@ -138,7 +138,7 @@ HYBRIS_IMPLEMENT_FUNCTION2(libnfc_so, NFCSTATUS, phLibNfc_Llcp_SocketGetLocalOpt
 HYBRIS_IMPLEMENT_FUNCTION2(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_SocketGetLocalOptions, phFriNfc_LlcpTransport_Socket_t *, phLibNfc_Llcp_sSocketOptions_t *);
 HYBRIS_IMPLEMENT_FUNCTION3(libnfc_so, NFCSTATUS, phLibNfc_Llcp_SocketGetRemoteOptions, phLibNfc_Handle, phLibNfc_Handle, phLibNfc_Llcp_sSocketOptions_t *);
 HYBRIS_IMPLEMENT_FUNCTION2(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_SocketGetRemoteOptions, phFriNfc_LlcpTransport_Socket_t *, phLibNfc_Llcp_sSocketOptions_t *);
-#if (ANDROID_VERSION_MAJOR == 4 && ANDROID_VERSION_MINOR >= 1) || (ANDROID_VERSION_MAJOR >= 5)
+#if (ANDROID_API_LEVEL >= 16)
 HYBRIS_IMPLEMENT_FUNCTION3(libnfc_so, NFCSTATUS, phLibNfc_Llcp_Bind, phLibNfc_Handle, uint8_t, phNfc_sData_t *);
 HYBRIS_IMPLEMENT_FUNCTION3(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_Bind, phFriNfc_LlcpTransport_Socket_t *, uint8_t, phNfc_sData_t *);
 HYBRIS_IMPLEMENT_FUNCTION3(libnfc_so, NFCSTATUS, phLibNfc_Llcp_Listen, phLibNfc_Handle, pphLibNfc_LlcpSocketListenCb_t, void *);
@@ -191,7 +191,7 @@ HYBRIS_IMPLEMENT_FUNCTION4(libnfc_so, NFCSTATUS, phLibNfc_RemoteDev_FormatNdef, 
 HYBRIS_IMPLEMENT_FUNCTION6(libnfc_so, NFCSTATUS, phFriNfc_NdefSmtCrd_Reset, phFriNfc_sNdefSmtCrdFmt_t *, void *, phHal_sRemoteDevInformation_t *, phHal_sDevInputParam_t *, uint8_t *, uint16_t *);
 HYBRIS_IMPLEMENT_FUNCTION4(libnfc_so, NFCSTATUS, phFriNfc_NdefSmtCrd_SetCR, phFriNfc_sNdefSmtCrdFmt_t *, uint8_t, pphFriNfc_Cr_t, void *);
 HYBRIS_IMPLEMENT_FUNCTION2(libnfc_so, NFCSTATUS, phFriNfc_NdefSmtCrd_Format, phFriNfc_sNdefSmtCrdFmt_t *, const uint8_t *);
-#if (ANDROID_VERSION_MAJOR == 4 && ANDROID_VERSION_MINOR >= 1) || (ANDROID_VERSION_MAJOR >= 5)
+#if (ANDROID_API_LEVEL >= 16)
 HYBRIS_IMPLEMENT_FUNCTION4(libnfc_so, NFCSTATUS, phLibNfc_ConvertToReadOnlyNdef, phLibNfc_Handle, phNfc_sData_t *, pphLibNfc_RspCb_t, void *);
 #else
 HYBRIS_IMPLEMENT_FUNCTION3(libnfc_so, NFCSTATUS, phLibNfc_ConvertToReadOnlyNdef, phLibNfc_Handle, pphLibNfc_RspCb_t, void *);
@@ -470,7 +470,7 @@ HYBRIS_IMPLEMENT_FUNCTION1(libnfc_so, uint32_t, phFriNfc_Llcp_CyclicFifoAvailabl
 HYBRIS_IMPLEMENT_FUNCTION3(libnfc_so, uint32_t, phFriNfc_Llcp_Buffer2Sequence, uint8_t *, uint32_t, phFriNfc_Llcp_sPacketSequence_t *);
 HYBRIS_IMPLEMENT_VOID_FUNCTION5(libnfc_so, Handle_ConnectionOriented_IncommingFrame, phFriNfc_LlcpTransport_t *, phNfc_sData_t *, uint8_t, uint8_t, uint8_t);
 HYBRIS_IMPLEMENT_VOID_FUNCTION4(libnfc_so, Handle_Connectionless_IncommingFrame, phFriNfc_LlcpTransport_t *, phNfc_sData_t *, uint8_t, uint8_t);
-#if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=3 || ANDROID_VERSION_MAJOR >= 5
+#if (ANDROID_API_LEVEL >= 18)
 /* see libnfc-nxp commit 7c4b4fad -- since Android 4.3 */
 HYBRIS_IMPLEMENT_FUNCTION7(libnfc_so, NFCSTATUS, phFriNfc_LlcpTransport_LinkSend, phFriNfc_LlcpTransport_t *, phFriNfc_Llcp_sPacketHeader_t *, phFriNfc_Llcp_sPacketSequence_t *, phNfc_sData_t *, phFriNfc_Llcp_LinkSend_CB_t, uint8_t, void *);
 #else

--- a/hybris/tests/Makefile.am
+++ b/hybris/tests/Makefile.am
@@ -6,28 +6,16 @@ bin_PROGRAMS = \
 	test_vibrator \
 	test_gps
 
-if HAS_ANDROID_4_2_0
-bin_PROGRAMS += test_hwcomposer
-endif
-
-if HAS_ANDROID_5_0_0
+if HAS_ANDROID_HAL_HWCOMPOSER
 bin_PROGRAMS += test_hwcomposer
 endif
 
 
-if HAS_LIBNFC_NXP_HEADERS
+if HAS_ANDROID_LIBNFC_NXP
 # test_nfc depends on NFC hardware HAL interface, which is only
 # available until Android API level 15 (v4.0.3, v4.0.4).
-if HAS_ANDROID_4_0_3
+if HAS_ANDROID_HAL_NFC
 bin_PROGRAMS += test_nfc
-else
-if HAS_ANDROID_4_1_0
-bin_PROGRAMS += test_nfc
-else
-if HAS_ANDROID_5_0_0
-bin_PROGRAMS += test_nfc
-endif
-endif
 endif
 endif
 

--- a/hybris/tests/test_audio.c
+++ b/hybris/tests/test_audio.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
 	assert(audiohw->init_check(audiohw) == 0);
 	printf("Audio Hardware Interface initialized.\n");
 
-#if (ANDROID_VERSION_MAJOR == 4 && ANDROID_VERSION_MINOR >= 1) || (ANDROID_VERSION_MAJOR >= 5)
+#if (ANDROID_API_LEVEL >= 16)
 	if (audiohw->get_master_volume) {
 		float volume;
 		audiohw->get_master_volume(audiohw, &volume);
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
 	}
 #endif
 
-#if (ANDROID_VERSION_MAJOR == 4 && ANDROID_VERSION_MINOR >= 2) || (ANDROID_VERSION_MAJOR >= 5)
+#if (ANDROID_API_LEVEL >= 17)
 	if (audiohw->get_master_mute) {
 		bool mute;
 		audiohw->get_master_mute(audiohw, &mute);

--- a/hybris/tests/test_nfc.c
+++ b/hybris/tests/test_nfc.c
@@ -227,7 +227,7 @@ void testNfc(int readNdefMessages)
 
         phLibNfc_sADD_Cfg_t discoveryConfig;
         discoveryConfig.NfcIP_Mode = phNfc_eP2P_ALL;
-#if (ANDROID_VERSION_MAJOR == 4 && ANDROID_VERSION_MINOR >= 1) || (ANDROID_VERSION_MAJOR >= 5)
+#if (ANDROID_API_LEVEL >= 16)
         discoveryConfig.NfcIP_Target_Mode = 0x0E;
 #endif
         discoveryConfig.Duration = 300000;

--- a/utils/extract-headers.sh
+++ b/utils/extract-headers.sh
@@ -9,6 +9,31 @@ PATCH=$5
 PATCH2=$6
 PATCH3=$7
 
+# Android API level mapping.
+# See http://developer.android.com/guide/topics/manifest/uses-sdk-element.html#ApiLevels
+ANDROID_API_LEVEL_6_0_0=23
+ANDROID_API_LEVEL_5_1_0=22
+ANDROID_API_LEVEL_5_0_0=21
+ANDROID_API_LEVEL_4_4_0=19
+ANDROID_API_LEVEL_4_3_0=18
+ANDROID_API_LEVEL_4_2_0=17
+ANDROID_API_LEVEL_4_1_0=16
+ANDROID_API_LEVEL_4_0_3=15
+ANDROID_API_LEVEL_4_0_0=14
+ANDROID_API_LEVEL_3_2_0=13
+ANDROID_API_LEVEL_3_1_0=12
+ANDROID_API_LEVEL_3_0_0=11
+ANDROID_API_LEVEL_2_3_3=10
+ANDROID_API_LEVEL_2_3_0=9
+ANDROID_API_LEVEL_2_2_0=8
+ANDROID_API_LEVEL_2_1_0=7
+ANDROID_API_LEVEL_2_0_1=6
+ANDROID_API_LEVEL_2_0_0=5
+ANDROID_API_LEVEL_1_6_0=4
+ANDROID_API_LEVEL_1_5_0=3
+ANDROID_API_LEVEL_1_1_0=2
+ANDROID_API_LEVEL_1_0_0=1
+
 usage() {
     echo "Usage: extract-headers.sh <ANDROID_ROOT> <HEADER_PATH> [Android Platform Version]"
     echo
@@ -51,6 +76,23 @@ EOF
     fi
 
     echo -n "Auto-detected version: ${MAJOR}.${MINOR}.${PATCH}";echo "${PATCH2:+.${PATCH2}}${PATCH3:+.${PATCH3}}"
+fi
+
+ANDROID_API_LEVEL=
+if [ $PATCH -gt 0 ]; then
+    p=$PATCH
+    while [ $p -gt 0 ]; do
+        eval "ANDROID_API_LEVEL=\$ANDROID_API_LEVEL_${MAJOR}_${MINOR}_$p"
+        [ -n "${ANDROID_API_LEVEL}" ] && break;
+        p=$(($p - 1))
+    done
+fi
+if [ x$ANDROID_API_LEVEL = x ]; then
+    eval "ANDROID_API_LEVEL=\$ANDROID_API_LEVEL_${MAJOR}_${MINOR}_0"
+    if [ x$ANDROID_API_LEVEL = x ]; then
+        echo "Error: unknown android version ${MAJOR}.${MINOR}.${PATCH}."
+        exit 1
+    fi
 fi
 
 require_sources() {
@@ -114,6 +156,8 @@ cat > $HEADERPATH/android-version.h << EOF
 #define ANDROID_VERSION_PATCH $PATCH
 #define ANDROID_VERSION_PATCH2 $PATCH2
 #define ANDROID_VERSION_PATCH3 $PATCH3
+
+#define ANDROID_API_LEVEL $ANDROID_API_LEVEL
 
 #endif
 EOF


### PR DESCRIPTION
This is an attempt to rewrite error prone Android version comparison expressions with comparisons based on Android API levels.
