### PR TITLE
Revert "use global hybris macros whenever available"

### DIFF
--- a/hybris/egl/egl.c
+++ b/hybris/egl/egl.c
@@ -38,8 +38,8 @@
 #include <system/window.h>
 #include "logging.h"
 
-static void *egl_handle = NULL;
-static void *glesv2_handle = NULL;
+static void *_libegl = NULL;
+static void *_libgles = NULL;
 static void *_hybris_libgles1 = NULL;
 static void *_hybris_libgles2 = NULL;
 static int _egl_context_client_version = 1;
@@ -121,26 +121,16 @@ static __eglMustCastToProperFunctionPointerType (*_eglGetProcAddress)(const char
 
 static void _init_androidegl()
 {
-	egl_handle = (void *) android_dlopen(getenv("LIBEGL") ? getenv("LIBEGL") : "libEGL.so", RTLD_LAZY);
-	glesv2_handle = (void *) android_dlopen(getenv("LIBGLESV2") ? getenv("LIBGLESV2") : "libGLESv2.so", RTLD_LAZY);
-}
-
-static inline void hybris_egl_initialize()
-{
-	_init_androidegl();
-}
-
-static inline void hybris_glesv2_initialize()
-{
-	_init_androidegl();
+	_libegl = (void *) android_dlopen(getenv("LIBEGL") ? getenv("LIBEGL") : "libEGL.so", RTLD_LAZY);
+	_libgles = (void *) android_dlopen(getenv("LIBGLESV2") ? getenv("LIBGLESV2") : "libGLESv2.so", RTLD_LAZY);
 }
 
 static void * _android_egl_dlsym(const char *symbol)
 {
-	if (egl_handle == NULL)
+	if (_libegl == NULL)
 		_init_androidegl();
 
-	return android_dlsym(egl_handle, symbol);
+	return android_dlsym(_libegl, symbol);
 }
 
 struct ws_egl_interface hybris_egl_interface = {
@@ -149,7 +139,14 @@ struct ws_egl_interface hybris_egl_interface = {
 	egl_helper_get_mapping,
 };
 
-HYBRIS_IMPLEMENT_FUNCTION0(egl, EGLint, eglGetError);
+#define EGL_DLSYM(fptr, sym) do { if (_libegl == NULL) { _init_androidegl(); }; if (*(fptr) == NULL) { *(fptr) = (void *) android_dlsym(_libegl, sym); } } while (0)
+#define GLESv2_DLSYM(fptr, sym) do { if (_libgles == NULL) { _init_androidegl(); }; if (*(fptr) == NULL) { *(fptr) = (void *) android_dlsym(_libgles, sym); } } while (0)
+
+EGLint eglGetError(void)
+{
+	EGL_DLSYM(&_eglGetError, "eglGetError");
+	return (*_eglGetError)();
+}
 
 #define _EGL_MAX_DISPLAYS 100
 
@@ -187,7 +184,7 @@ struct _EGLDisplay *hybris_egl_display_get_mapping(EGLDisplay display)
 
 EGLDisplay eglGetDisplay(EGLNativeDisplayType display_id)
 {
-	HYBRIS_DLSYSM(egl, &_eglGetDisplay, "eglGetDisplay");
+	EGL_DLSYM(&_eglGetDisplay, "eglGetDisplay");
 	EGLNativeDisplayType real_display;
 
 	real_display = (*_eglGetDisplay)(EGL_DEFAULT_DISPLAY);
@@ -209,27 +206,57 @@ EGLDisplay eglGetDisplay(EGLNativeDisplayType display_id)
 	return real_display;
 }
 
-HYBRIS_IMPLEMENT_FUNCTION3(egl, EGLBoolean, eglInitialize, EGLDisplay, EGLint *, EGLint *);
+EGLBoolean eglInitialize(EGLDisplay dpy, EGLint *major, EGLint *minor)
+{
+	EGL_DLSYM(&_eglInitialize, "eglInitialize");
+	return (*_eglInitialize)(dpy, major, minor);
+}
 
 EGLBoolean eglTerminate(EGLDisplay dpy)
 {
-	HYBRIS_DLSYSM(egl, &_eglTerminate, "eglTerminate");
+	EGL_DLSYM(&_eglTerminate, "eglTerminate");
 
 	struct _EGLDisplay *display = hybris_egl_display_get_mapping(dpy);
 	ws_Terminate(display);
 	return (*_eglTerminate)(dpy);
 }
 
-HYBRIS_IMPLEMENT_FUNCTION2(egl, const char *, eglQueryString, EGLDisplay, EGLint);
-HYBRIS_IMPLEMENT_FUNCTION4(egl, EGLBoolean, eglGetConfigs, EGLDisplay, EGLConfig *, EGLint, EGLint *);
-HYBRIS_IMPLEMENT_FUNCTION5(egl, EGLBoolean, eglChooseConfig, EGLDisplay, const EGLint *, EGLConfig *, EGLint, EGLint *);
-HYBRIS_IMPLEMENT_FUNCTION4(egl, EGLBoolean, eglGetConfigAttrib, EGLDisplay, EGLConfig, EGLint, EGLint *);
+const char * eglQueryString(EGLDisplay dpy, EGLint name)
+{
+	EGL_DLSYM(&_eglQueryString, "eglQueryString");
+	return ws_eglQueryString(dpy, name, _eglQueryString);
+}
+
+EGLBoolean eglGetConfigs(EGLDisplay dpy, EGLConfig *configs,
+		EGLint config_size, EGLint *num_config)
+{
+	EGL_DLSYM(&_eglGetConfigs, "eglGetConfigs");
+	return (*_eglGetConfigs)(dpy, configs, config_size, num_config);
+}
+
+EGLBoolean eglChooseConfig(EGLDisplay dpy, const EGLint *attrib_list,
+		EGLConfig *configs, EGLint config_size,
+		EGLint *num_config)
+{
+	EGL_DLSYM(&_eglChooseConfig, "eglChooseConfig");
+	return (*_eglChooseConfig)(dpy, attrib_list,
+			configs, config_size,
+			num_config);
+}
+
+EGLBoolean eglGetConfigAttrib(EGLDisplay dpy, EGLConfig config,
+		EGLint attribute, EGLint *value)
+{
+	EGL_DLSYM(&_eglGetConfigAttrib, "eglGetConfigAttrib");
+	return (*_eglGetConfigAttrib)(dpy, config,
+			attribute, value);
+}
 
 EGLSurface eglCreateWindowSurface(EGLDisplay dpy, EGLConfig config,
 		EGLNativeWindowType win,
 		const EGLint *attrib_list)
 {
-	HYBRIS_DLSYSM(egl, &_eglCreateWindowSurface, "eglCreateWindowSurface");
+	EGL_DLSYM(&_eglCreateWindowSurface, "eglCreateWindowSurface");
 
 	HYBRIS_TRACE_BEGIN("hybris-egl", "eglCreateWindowSurface", "");
 	struct _EGLDisplay *display = hybris_egl_display_get_mapping(dpy);
@@ -246,12 +273,24 @@ EGLSurface eglCreateWindowSurface(EGLDisplay dpy, EGLConfig config,
 	return result;
 }
 
-HYBRIS_IMPLEMENT_FUNCTION3(egl, EGLSurface, eglCreatePbufferSurface, EGLDisplay, EGLConfig, const EGLint *);
-HYBRIS_IMPLEMENT_FUNCTION4(egl, EGLSurface, eglCreatePixmapSurface, EGLDisplay, EGLConfig, EGLNativePixmapType, const EGLint *);
+EGLSurface eglCreatePbufferSurface(EGLDisplay dpy, EGLConfig config,
+		const EGLint *attrib_list)
+{
+	EGL_DLSYM(&_eglCreatePbufferSurface, "eglCreatePbufferSurface");
+	return (*_eglCreatePbufferSurface)(dpy, config, attrib_list);
+}
+
+EGLSurface eglCreatePixmapSurface(EGLDisplay dpy, EGLConfig config,
+		EGLNativePixmapType pixmap,
+		const EGLint *attrib_list)
+{
+	EGL_DLSYM(&_eglCreatePixmapSurface, "eglCreatePixmapSurface");
+	return (*_eglCreatePixmapSurface)(dpy, config, pixmap, attrib_list);
+}
 
 EGLBoolean eglDestroySurface(EGLDisplay dpy, EGLSurface surface)
 {
-	HYBRIS_DLSYSM(egl, &_eglDestroySurface, "eglDestroySurface");
+	EGL_DLSYM(&_eglDestroySurface, "eglDestroySurface");
 	EGLBoolean result = (*_eglDestroySurface)(dpy, surface);
 
 	/**
@@ -265,15 +304,64 @@ EGLBoolean eglDestroySurface(EGLDisplay dpy, EGLSurface surface)
 	return result;
 }
 
-HYBRIS_IMPLEMENT_FUNCTION4(egl, EGLBoolean, eglQuerySurface, EGLDisplay, EGLSurface, EGLint, EGLint *);
-HYBRIS_IMPLEMENT_FUNCTION1(egl, EGLBoolean, eglBindAPI, EGLenum);
-HYBRIS_IMPLEMENT_FUNCTION0(egl, EGLenum, eglQueryAPI);
-HYBRIS_IMPLEMENT_FUNCTION0(egl, EGLBoolean, eglWaitClient);
-HYBRIS_IMPLEMENT_FUNCTION0(egl, EGLBoolean, eglReleaseThread);
-HYBRIS_IMPLEMENT_FUNCTION5(egl, EGLSurface, eglCreatePbufferFromClientBuffer, EGLDisplay, EGLenum, EGLClientBuffer, EGLConfig, const EGLint *);
-HYBRIS_IMPLEMENT_FUNCTION4(egl, EGLBoolean, eglSurfaceAttrib, EGLDisplay, EGLSurface, EGLint, EGLint);
-HYBRIS_IMPLEMENT_FUNCTION3(egl, EGLBoolean, eglBindTexImage, EGLDisplay, EGLSurface, EGLint);
-HYBRIS_IMPLEMENT_FUNCTION3(egl, EGLBoolean, eglReleaseTexImage, EGLDisplay, EGLSurface, EGLint);
+EGLBoolean eglQuerySurface(EGLDisplay dpy, EGLSurface surface,
+		EGLint attribute, EGLint *value)
+{
+	EGL_DLSYM(&_eglQuerySurface, "eglQuerySurface");
+	return (*_eglQuerySurface)(dpy, surface, attribute, value);
+}
+
+
+EGLBoolean eglBindAPI(EGLenum api)
+{
+	EGL_DLSYM(&_eglBindAPI, "eglBindAPI");
+	return (*_eglBindAPI)(api);
+}
+
+EGLenum eglQueryAPI(void)
+{
+	EGL_DLSYM(&_eglQueryAPI, "eglQueryAPI");
+	return (*_eglQueryAPI)();
+}
+
+EGLBoolean eglWaitClient(void)
+{
+	EGL_DLSYM(&_eglWaitClient, "eglWaitClient");
+	return (*_eglWaitClient)();
+}
+
+EGLBoolean eglReleaseThread(void)
+{
+	EGL_DLSYM(&_eglReleaseThread, "eglReleaseThread");
+	return (*_eglReleaseThread)();
+}
+
+EGLSurface eglCreatePbufferFromClientBuffer(
+		EGLDisplay dpy, EGLenum buftype, EGLClientBuffer buffer,
+		EGLConfig config, const EGLint *attrib_list)
+{
+	EGL_DLSYM(&_eglCreatePbufferFromClientBuffer, "eglCreatePbufferFromClientBuffer");
+	return (*_eglCreatePbufferFromClientBuffer)(dpy, buftype, buffer, config, attrib_list);
+}
+
+EGLBoolean eglSurfaceAttrib(EGLDisplay dpy, EGLSurface surface,
+		EGLint attribute, EGLint value)
+{
+	EGL_DLSYM(&_eglSurfaceAttrib, "eglSurfaceAttrib");
+	return (*_eglSurfaceAttrib)(dpy, surface, attribute, value);
+}
+
+EGLBoolean eglBindTexImage(EGLDisplay dpy, EGLSurface surface, EGLint buffer)
+{
+	EGL_DLSYM(&_eglBindTexImage, "eglBindTexImage");
+	return (*_eglBindTexImage)(dpy, surface, buffer);
+}
+
+EGLBoolean eglReleaseTexImage(EGLDisplay dpy, EGLSurface surface, EGLint buffer)
+{
+	EGL_DLSYM(&_eglReleaseTexImage, "eglReleaseTexImage");
+	return (*_eglReleaseTexImage)(dpy, surface, buffer);
+}
 
 EGLBoolean eglSwapInterval(EGLDisplay dpy, EGLint interval)
 {
@@ -286,13 +374,13 @@ EGLBoolean eglSwapInterval(EGLDisplay dpy, EGLint interval)
 	 * call.  Since we may support various swap intervals internally, we'll
 	 * call it anyway and then give the wrapped egl implementation a chance
 	 * to chage it. */
-	HYBRIS_DLSYSM(egl, &_eglGetCurrentSurface, "eglGetCurrentSurface");
+	EGL_DLSYM(&_eglGetCurrentSurface, "eglGetCurrentSurface");
 	surface = (*_eglGetCurrentSurface)(EGL_DRAW);
 	if (egl_helper_has_mapping(surface))
 	    ws_setSwapInterval(dpy, egl_helper_get_mapping(surface), interval);
 
 	HYBRIS_TRACE_BEGIN("native-egl", "eglSwapInterval", "=%d", interval);
-	HYBRIS_DLSYSM(egl, &_eglSwapInterval, "eglSwapInterval");
+	EGL_DLSYM(&_eglSwapInterval, "eglSwapInterval");
 	ret = (*_eglSwapInterval)(dpy, interval);
 	HYBRIS_TRACE_END("native-egl", "eglSwapInterval", "");
 	HYBRIS_TRACE_END("hybris-egl", "eglSwapInterval", "");
@@ -303,7 +391,7 @@ EGLContext eglCreateContext(EGLDisplay dpy, EGLConfig config,
 		EGLContext share_context,
 		const EGLint *attrib_list)
 {
-	HYBRIS_DLSYSM(egl, &_eglCreateContext, "eglCreateContext");
+	EGL_DLSYM(&_eglCreateContext, "eglCreateContext");
 
 	EGLint *p = attrib_list;
 	while (p != NULL && *p != EGL_NONE) {
@@ -316,21 +404,62 @@ EGLContext eglCreateContext(EGLDisplay dpy, EGLConfig config,
 	return (*_eglCreateContext)(dpy, config, share_context, attrib_list);
 }
 
-HYBRIS_IMPLEMENT_FUNCTION2(egl, EGLBoolean, eglDestroyContext, EGLDisplay, EGLContext);
-HYBRIS_IMPLEMENT_FUNCTION4(egl, EGLBoolean, eglMakeCurrent, EGLDisplay, EGLSurface, EGLSurface, EGLContext);
-HYBRIS_IMPLEMENT_FUNCTION0(egl, EGLContext, eglGetCurrentContext);
-HYBRIS_IMPLEMENT_FUNCTION1(egl, EGLSurface, eglGetCurrentSurface, EGLint);
-HYBRIS_IMPLEMENT_FUNCTION0(egl, EGLDisplay, eglGetCurrentDisplay);
-HYBRIS_IMPLEMENT_FUNCTION4(egl, EGLBoolean, eglQueryContext, EGLDisplay, EGLContext, EGLint, EGLint *);
-HYBRIS_IMPLEMENT_FUNCTION0(egl, EGLBoolean, eglWaitGL);
-HYBRIS_IMPLEMENT_FUNCTION1(egl, EGLBoolean, eglWaitNative, EGLint);
+EGLBoolean eglDestroyContext(EGLDisplay dpy, EGLContext ctx)
+{
+	EGL_DLSYM(&_eglDestroyContext, "eglDestroyContext");
+	return (*_eglDestroyContext)(dpy, ctx);
+}
+
+EGLBoolean eglMakeCurrent(EGLDisplay dpy, EGLSurface draw,
+		EGLSurface read, EGLContext ctx)
+{
+	EGL_DLSYM(&_eglMakeCurrent, "eglMakeCurrent");
+	return (*_eglMakeCurrent)(dpy, draw, read, ctx);
+}
+
+EGLContext eglGetCurrentContext(void)
+{
+	EGL_DLSYM(&_eglGetCurrentContext, "eglGetCurrentContext");
+	return (*_eglGetCurrentContext)();
+}
+
+EGLSurface eglGetCurrentSurface(EGLint readdraw)
+{
+	EGL_DLSYM(&_eglGetCurrentSurface, "eglGetCurrentSurface");
+	return (*_eglGetCurrentSurface)(readdraw);
+}
+
+EGLDisplay eglGetCurrentDisplay(void)
+{
+	EGL_DLSYM(&_eglGetCurrentDisplay, "eglGetCurrentDisplay");
+	return (*_eglGetCurrentDisplay)();
+}
+
+EGLBoolean eglQueryContext(EGLDisplay dpy, EGLContext ctx,
+		EGLint attribute, EGLint *value)
+{
+	EGL_DLSYM(&_eglQueryContext, "eglQueryContext");
+	return (*_eglQueryContext)(dpy, ctx, attribute, value);
+}
+
+EGLBoolean eglWaitGL(void)
+{
+	EGL_DLSYM(&_eglWaitGL, "eglWaitGL");
+	return (*_eglWaitGL)();
+}
+
+EGLBoolean eglWaitNative(EGLint engine)
+{
+	EGL_DLSYM(&_eglWaitNative, "eglWaitNative");
+	return (*_eglWaitNative)(engine);
+}
 
 EGLBoolean _my_eglSwapBuffersWithDamageEXT(EGLDisplay dpy, EGLSurface surface, EGLint *rects, EGLint n_rects)
 {
 	EGLNativeWindowType win;
 	EGLBoolean ret;
 	HYBRIS_TRACE_BEGIN("hybris-egl", "eglSwapBuffersWithDamageEXT", "");
-	HYBRIS_DLSYSM(egl, &_eglSwapBuffers, "eglSwapBuffers");
+	EGL_DLSYM(&_eglSwapBuffers, "eglSwapBuffers");
 
 	if (egl_helper_has_mapping(surface)) {
 		win = egl_helper_get_mapping(surface);
@@ -353,12 +482,17 @@ EGLBoolean eglSwapBuffers(EGLDisplay dpy, EGLSurface surface)
 	return ret;
 }
 
-HYBRIS_IMPLEMENT_FUNCTION3(egl, EGLBoolean, eglCopyBuffers, EGLDisplay, EGLSurface, EGLNativePixmapType);
+EGLBoolean eglCopyBuffers(EGLDisplay dpy, EGLSurface surface,
+		EGLNativePixmapType target)
+{
+	EGL_DLSYM(&_eglCopyBuffers, "eglCopyBuffers");
+	return (*_eglCopyBuffers)(dpy, surface, target);
+}
 
 
 static EGLImageKHR _my_eglCreateImageKHR(EGLDisplay dpy, EGLContext ctx, EGLenum target, EGLClientBuffer buffer, const EGLint *attrib_list)
 {
-	HYBRIS_DLSYSM(egl, &_eglCreateImageKHR, "eglCreateImageKHR");
+	EGL_DLSYM(&_eglCreateImageKHR, "eglCreateImageKHR");
 	EGLContext newctx = ctx;
 	EGLenum newtarget = target;
 	EGLClientBuffer newbuffer = buffer;
@@ -383,14 +517,14 @@ static EGLImageKHR _my_eglCreateImageKHR(EGLDisplay dpy, EGLContext ctx, EGLenum
 
 static void _my_glEGLImageTargetTexture2DOES(GLenum target, GLeglImageOES image)
 {
-	HYBRIS_DLSYSM(glesv2, &_glEGLImageTargetTexture2DOES, "glEGLImageTargetTexture2DOES");
+	GLESv2_DLSYM(&_glEGLImageTargetTexture2DOES, "glEGLImageTargetTexture2DOES");
 	struct egl_image *img = image;
 	(*_glEGLImageTargetTexture2DOES)(target, img ? img->egl_image : NULL);
 }
 
 __eglMustCastToProperFunctionPointerType eglGetProcAddress(const char *procname)
 {
-	HYBRIS_DLSYSM(egl, &_eglGetProcAddress, "eglGetProcAddress");
+	EGL_DLSYM(&_eglGetProcAddress, "eglGetProcAddress");
 	if (strcmp(procname, "eglCreateImageKHR") == 0)
 	{
 		return _my_eglCreateImageKHR;
@@ -444,7 +578,7 @@ __eglMustCastToProperFunctionPointerType eglGetProcAddress(const char *procname)
 
 EGLBoolean eglDestroyImageKHR(EGLDisplay dpy, EGLImageKHR image)
 {
-	HYBRIS_DLSYSM(egl, &_eglDestroyImageKHR, "eglDestroyImageKHR");
+	EGL_DLSYM(&_eglDestroyImageKHR, "eglDestroyImageKHR");
 	struct egl_image *img = image;
 	EGLBoolean ret = (*_eglDestroyImageKHR)(dpy, img ? img->egl_image : NULL);
 	if (ret == EGL_TRUE) {

--- a/hybris/egl/platforms/null/eglplatform_null.c
+++ b/hybris/egl/platforms/null/eglplatform_null.c
@@ -7,14 +7,26 @@
 #include <eglplatformcommon.h>
 #include "logging.h"
 
+static void * (*_androidCreateDisplaySurface)();
+
+static void *_libui = NULL;
+
 static gralloc_module_t *gralloc = 0;
 static alloc_device_t *alloc = 0;
 
-#pragma GCC visibility push(hidden)
-HYBRIS_LIBRARY_INITIALIZE(nullui, "/system/lib/libui.so");
-#pragma GCC visibility pop
+static void _init_androidui()
+{
+       _libui = (void *) android_dlopen("/system/lib/libui.so", RTLD_LAZY);
+}
 
-static HYBRIS_IMPLEMENT_FUNCTION0(nullui, EGLNativeWindowType, android_createDisplaySurface);
+#define UI_DLSYM(fptr, sym) do { if (_libui == NULL) { _init_androidui(); }; if (*(fptr) == NULL) { *(fptr) = (void *) android_dlsym(_libui, sym); } } while (0) 
+
+static EGLNativeWindowType android_createDisplaySurface()
+{
+ 	UI_DLSYM(&_androidCreateDisplaySurface, "android_createDisplaySurface");
+	return (EGLNativeWindowType) (*_androidCreateDisplaySurface)();
+}
+
 
 static void nullws_init_module(struct ws_egl_interface *egl_iface)
 {

--- a/hybris/hardware/hardware.c
+++ b/hybris/hardware/hardware.c
@@ -15,16 +15,36 @@
  *
  */
 
+#include <android-config.h>
 #include <dlfcn.h>
 #include <stddef.h>
 #include <hardware/hardware.h>
 #include <hybris/common/binding.h>
 
-#pragma GCC visibility push(hidden)
-HYBRIS_LIBRARY_INITIALIZE(hardware, "/system/lib/libhardware.so");
-#pragma GCC visibility pop
+static void *_libhardware = NULL;
 
-HYBRIS_IMPLEMENT_FUNCTION2(hardware, int, hw_get_module, const char *, const struct hw_module_t **);
-HYBRIS_IMPLEMENT_FUNCTION3(hardware, int, hw_get_module_by_class, const char *, const char *, const struct hw_module_t **);
+static int (*_hw_get_module)(const char *id, const struct hw_module_t **module) = NULL;
+
+static int (*_hw_get_module_by_class)(const char *class_id, const char *inst, const struct hw_module_t **module) = NULL;
+
+#define HARDWARE_DLSYM(fptr, sym) do { if (_libhardware == NULL) { _init_lib_hardware(); }; if (*(fptr) == NULL) { *(fptr) = (void *) android_dlsym(_libhardware, sym); } } while (0) 
+
+static void _init_lib_hardware()
+{
+	_libhardware = (void *) android_dlopen("libhardware.so", RTLD_LAZY);
+}
+
+int hw_get_module(const char *id, const struct hw_module_t **module)
+{
+	HARDWARE_DLSYM(&_hw_get_module, "hw_get_module");
+	return (*_hw_get_module)(id, module);
+}
+
+int hw_get_module_by_class(const char *class_id, const char *inst,
+                           const struct hw_module_t **module)
+{
+	HARDWARE_DLSYM(&_hw_get_module_by_class, "hw_get_module_by_class");
+	return (*_hw_get_module_by_class)(class_id, inst, module);
+}
 
 // vim:ts=4:sw=4:noexpandtab

--- a/hybris/vibrator/vibrator.c
+++ b/hybris/vibrator/vibrator.c
@@ -18,6 +18,7 @@
 
 #include <dlfcn.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 #include <hybris/common/binding.h>
 


### PR DESCRIPTION
With commit a6668d293c00b18b7cb755a0c7a600a56bc63339, on Sailfish OS lipstick (Wayland compositor) still works, but any clients (apps) crash upon start with ```Fatal: the server doesn't advertise the android_wlegl global!Aborted```

This PR reverts commit a6668d293c00b18b7cb755a0c7a600a56bc63339.

Thanks to @mlehtima for finding this
