### PR TITLE
Putting GLES2_LOAD(glReadPixels) to initialization sequence

### DIFF
--- a/hybris/glesv2/glesv2.c
+++ b/hybris/glesv2/glesv2.c
@@ -299,6 +299,7 @@ static void  __attribute__((constructor)) _init_androidglesv2()  {
 	GLES2_LOAD(glIsTexture);
 	GLES2_LOAD(glLinkProgram);
 	GLES2_LOAD(glPixelStorei);
+	GLES2_LOAD(glReadPixels);
 	GLES2_LOAD(glReleaseShaderCompiler);
 	GLES2_LOAD(glRenderbufferStorage);
 	GLES2_LOAD(glScissor);


### PR DESCRIPTION
The a38512b7 introduces logic, when GLES2_IDLOAD(func) could refer
to func_wrapper and invoke _func, which is set in constructor
via GLES2_LOAD. For some reason GLES2_LOAD is not invoked for
glReadPixels.

Signed-off-by: Alex Hoppus <alexhoppus111@gmail.com>