### PR TITLE
extract_headers.sh: Do not escape android-headers.pc

### DIFF
--- a/utils/extract-headers.sh
+++ b/utils/extract-headers.sh
@@ -147,7 +147,7 @@ cat > $HEADERPATH/android-config.h << EOF
 #endif
 EOF
 
-cat > $HEADERPATH/android-headers.pc <<EOF
+cat > $HEADERPATH/android-headers.pc <<'EOF'
 Name: Android header files
 Description: Header files needed to write applications for the Android platform
 Version: androidversion


### PR DESCRIPTION
The use of `tee <<EOF` means that the shell ${} variables in the
heredoc are expanded causing compilers to look in the wrong directory,
e.g.:

```
Name: Android header files
Description: Header files needed to write applications for the Android platform
Version: 5.1.51

prefix=/usr
exec_prefix=
includedir=/include

Cflags: -I/android
```

These variables should not be interpreted when written to the
android-headers.pc file, so use the form `tee <<'EOF'`.

Tested when /bin/sh is a symlink to bash and dash.

This was broken in:
commit f597786ae48f6d7fa13bcd3ef8b6f8873d05439f
    utils: fix dash "need redirection"

Signed-off-by: Daniel Cordero <libhybris@xxoo.ws>