### PR TITLE
utils/extract-headers.sh: Don't fail on PLATFORM_VERSION := 6.0

### DIFF
--- a/utils/extract-headers.sh
+++ b/utils/extract-headers.sh
@@ -46,8 +46,11 @@ if [ x$MAJOR = x -o x$MINOR = x -o x$PATCH = x ]; then
 $(IFS="." awk '/PLATFORM_VERSION := ([0-9.]+)/ { print $3; }' < $VERSION_DEFAULTS)
 EOF
 
-    if [ x$MAJOR = x -o x$MINOR = x -o x$PATCH = x ]; then
+    if [ x$MAJOR = x -o x$MINOR = x ]; then
         parse_defaults_failed
+    fi
+    if [ x$PATCH = x ]; then
+        PATCH=0
     fi
 
     echo -n "Auto-detected version: ${MAJOR}.${MINOR}.${PATCH}";echo "${PATCH2:+.${PATCH2}}${PATCH3:+.${PATCH3}}"


### PR DESCRIPTION
It seems Android v6 has dropped patch level from the version number.
Handle this by haveing extract-headers.sh default to patch level 0,
if missing.