### PR TITLE
fix for future cm13 based adaptations

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -171,7 +171,7 @@ static void *my_malloc(size_t size)
 static void *my_memcpy(void *dst, const void *src, size_t len)
 {
     if (src == NULL || dst == NULL)
-        return NULL;
+        return dst;
 
     return memcpy(dst, src, len);
 }


### PR DESCRIPTION
memcpy has to always return dst

see "man memcpy" and bionic/libc/arch-arm/generic/bionic/memcpy.S

with this and the ported mm linker test_hwcomposer, minimer and lipstick work on mako with cm13 based adaptation.