### PR TITLE
hooks.c: Wrap some GCC builtin functions, which don't have any addres…

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -1396,6 +1396,32 @@ int my_system_property_get(const char *name, char *value)
 	return property_get(name, value, NULL);
 }
 
+/**
+ * Wrap some GCC builtin functions, which don't have any address
+ */
+__THROW int my__sprintf_chk (char *__restrict __s, int __flag, size_t __slen,
+			  const char *__restrict __format, ...)
+{
+    int ret = 0;
+    va_list args;
+    va_start(args,__format);
+    ret = __vsprintf_chk (__s, __flag, __slen, __format, args);
+    va_end(args);
+
+    return ret;
+}
+__THROW int my__snprintf_chk (char *__restrict __s, size_t __n, int __flag,
+			   size_t __slen, const char *__restrict __format, ...)
+{
+    int ret = 0;
+    va_list args;
+    va_start(args,__format);
+    ret = __vsnprintf_chk (__s, __n, __flag, __slen, __format, args);
+    va_end(args);
+
+    return ret;
+}
+
 static __thread void *tls_hooks[16];
 
 void *__get_tls_hooks()
@@ -1470,8 +1496,8 @@ static struct _hook hooks[] = {
     {"index",index},
     {"rindex",rindex},
     {"strcasecmp",strcasecmp},
-    {"__sprintf_chk", __sprintf_chk},
-    {"__snprintf_chk", __snprintf_chk},
+    {"__sprintf_chk", my__sprintf_chk},
+    {"__snprintf_chk", my__snprintf_chk},
     {"strncasecmp",strncasecmp},
     /* dirent.h */
     {"opendir", opendir},


### PR DESCRIPTION
…s to fix GCC6 build

This addresses the following issues while compiling with GCC6:

| hooks.c: At top level:
| hooks.c:1473:5: error: built-in function '__sprintf_chk' must be
directly called
|      {"__sprintf_chk", __sprintf_chk},
|      ^
| hooks.c:1474:5: error: built-in function '__snprintf_chk' must be
directly called
|      {"__snprintf_chk", __snprintf_chk},
|      ^

Signed-off-by: Christophe Chapuis chris.chapuis@gmail.com
Signed-off-by: Herman van Hazendonk github.com@herrie.org
