### PR TITLE
[egl] Increase buffer size for EGL extensions.

### DIFF
--- a/hybris/egl/platforms/common/eglplatformcommon.cpp
+++ b/hybris/egl/platforms/common/eglplatformcommon.cpp
@@ -363,8 +363,8 @@ extern "C" const char *eglplatformcommon_eglQueryString(EGLDisplay dpy, EGLint n
 	if (name == EGL_EXTENSIONS)
 	{
 		const char *ret = (*real_eglQueryString)(dpy, name);
-		static char eglextensionsbuf[512];
-		snprintf(eglextensionsbuf, 510, "%sEGL_HYBRIS_native_buffer2 EGL_HYBRIS_WL_acquire_native_buffer %s", ret ? ret : "",
+		static char eglextensionsbuf[1024];
+		snprintf(eglextensionsbuf, 1022, "%sEGL_HYBRIS_native_buffer2 EGL_HYBRIS_WL_acquire_native_buffer %s", ret ? ret : "",
 #ifdef WANT_WAYLAND
 			"EGL_WL_bind_wayland_display "
 #else

--- a/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
+++ b/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
@@ -253,8 +253,8 @@ extern "C" const char *waylandws_eglQueryString(EGLDisplay dpy, EGLint name, con
 	const char *ret = eglplatformcommon_eglQueryString(dpy, name, real_eglQueryString);
 	if (ret && name == EGL_EXTENSIONS)
 	{
-		static char eglextensionsbuf[512];
-		snprintf(eglextensionsbuf, 510, "%s %s", ret,
+		static char eglextensionsbuf[1024];
+		snprintf(eglextensionsbuf, 1022, "%s %s", ret,
 			"EGL_EXT_swap_buffers_with_damage EGL_WL_create_wayland_buffer_from_image"
 		);
 		ret = eglextensionsbuf;


### PR DESCRIPTION
Larger buffer is needed on some hybris-13.0 based devices. At least on Samsung Galaxy Tab 4 WiFi the buffer is too short and last entry in the list is cut in half causing apps using Wayland EGL to fail.