### PR TITLE
don't hook all functions which contain pthread

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -1681,7 +1681,7 @@ void *get_hooked_symbol(char *sym)
         }
         ptr++;
     }
-    if (strstr(sym, "pthread") != NULL)
+    if (strncmp(sym, "__pthread", 9) == 0 || strncmp(sym, "pthread", 7) == 0)
     {
         /* safe */
         if (strcmp(sym, "pthread_sigmask") == 0)


### PR DESCRIPTION
to negative numbers.

see #325
