### PR TITLE
hybris: fix mismatch between bionic fpos_t size and glibc fpos_t in bionic_file struct

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -1288,6 +1288,8 @@ struct bionic_sbuf {
 };
 #endif
 
+typedef off_t bionic_fpos_t;
+
 /* "struct __sFILE" from bionic/libc/include/stdio.h */
 struct __attribute__((packed)) bionic_file {
     unsigned char *_p;      /* current position in (some) buffer */
@@ -1307,7 +1309,7 @@ struct __attribute__((packed)) bionic_file {
     void *_cookie;          /* cookie passed to io functions */
     int (*_close)(void *);
     int (*_read)(void *, char *, int);
-    fpos_t (*_seek)(void *, fpos_t, int);
+    bionic_fpos_t (*_seek)(void *, bionic_fpos_t, int);
     int (*_write)(void *, const char *, int);
 
     /* extension data, to avoid further ABI breakage */
@@ -1325,7 +1327,7 @@ struct __attribute__((packed)) bionic_file {
 
     /* Unix stdio files get aligned to block boundaries on fseek() */
     int _blksize;           /* stat.st_blksize (may be != _bf._size) */
-    fpos_t _offset;         /* current lseek offset */
+    bionic_fpos_t _offset;         /* current lseek offset */
 };
 
 /*
@@ -1395,11 +1397,16 @@ static int _hybris_hook_fgetc(FILE *fp)
     return fgetc(_get_actual_fp(fp));
 }
 
-static int _hybris_hook_fgetpos(FILE *fp, fpos_t *pos)
+static int _hybris_hook_fgetpos(FILE *fp, bionic_fpos_t *pos)
 {
     TRACE_HOOK("fp %p pos %p", fp, pos);
 
-    return fgetpos(_get_actual_fp(fp), pos);
+    fpos_t my_fpos;
+    int ret = fgetpos(_get_actual_fp(fp), &my_fpos);
+
+    *pos = my_fpos.__pos;
+
+    return ret;
 }
 
 static char* _hybris_hook_fgets(char *s, int n, FILE *fp)
@@ -1479,11 +1486,16 @@ static int _hybris_hook_fseeko(FILE *fp, off_t offset, int whence)
     return fseeko(_get_actual_fp(fp), offset, whence);
 }
 
-static int _hybris_hook_fsetpos(FILE *fp, const fpos_t *pos)
+static int _hybris_hook_fsetpos(FILE *fp, const bionic_fpos_t *pos)
 {
     TRACE_HOOK("fp %p pos %p", fp, pos);
 
-    return fsetpos(_get_actual_fp(fp), pos);
+    fpos_t my_fpos;
+    my_fpos.__pos = *pos;
+    memset(&my_fpos.__state, 0, sizeof(mbstate_t));
+    mbsinit(&my_fpos.__state);
+
+    return fsetpos(_get_actual_fp(fp), &my_fpos);
 }
 
 static long _hybris_hook_ftell(FILE *fp)


### PR DESCRIPTION
to avoid a crash on exit of most programs