### PR TITLE
linker: introduce HYBRIS_LINKER_FORCE_BASENAME for .so search

### DIFF
--- a/hybris/common/jb/linker.c
+++ b/hybris/common/jb/linker.c
@@ -623,6 +623,13 @@ static int open_library(const char *name)
     if(name == 0) return -1;
     if(strlen(name) > 256) return -1;
 
+    if ((name[0] == '/') && (getenv("HYBRIS_LINKER_FORCE_BASENAME") != NULL))
+    {
+        const char *bname = strrchr(name, '/');
+        if ((bname != NULL) && ((fd = open_library(bname+1)) >= 0))
+            return fd;
+    }
+
     if ((name[0] == '/') && ((fd = _open_lib(name)) >= 0))
         return fd;
 


### PR DESCRIPTION
If HYBRIS_LINKER_FORCE_BASENAME is set, then the linker will first
look for the .so based on the basename of the library, in case an
absolute path has been given.
This way it is possible to redirect .so loading even for absolute paths.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>