### PR TITLE
hooks: remove unneeded TLS variable

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -2165,7 +2165,7 @@ int _hybris_hook_prctl(int option, unsigned long arg2, unsigned long arg3,
 
 static char* _hybris_hook_basename(const char *path)
 {
-    static __thread char buf[PATH_MAX];
+    char buf[PATH_MAX];
 
     TRACE_HOOK("path '%s'", path);
 
@@ -2181,7 +2181,7 @@ static char* _hybris_hook_basename(const char *path)
 
 static char* _hybris_hook_dirname(char *path)
 {
-    static __thread char buf[PATH_MAX];
+    char buf[PATH_MAX];
 
     TRACE_HOOK("path '%s'", path);
 


### PR DESCRIPTION
The two "buf" variables don't need to be stored in TLS or to be global,
as they are only used as intermediate variables for the final glibc call.
Therefore remove the "static __thread" prefixes for these two.

Note: In my case having these two TLS variables did also lead to crashes when the
"tls_hooks" TLS variable is returned in the get_tls_hooks function. However
I couldn't determine conclusively why it crashed in that case.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>