### PR TITLE
Fix the makefile generated by the extract-headers.sh script

### DIFF
--- a/utils/extract-headers.sh
+++ b/utils/extract-headers.sh
@@ -283,13 +283,16 @@ fi
 cat > ${HEADERPATH}/Makefile << EOF
 PREFIX?=/usr/local
 INCLUDEDIR?=\$(PREFIX)/include/android
+PKGCONFIGDIR?=\$(PREFIX)/lib/pkgconfig
 all:
 	@echo "Use '\$(MAKE) install' to install"
 
 install:
 	mkdir -p \$(DESTDIR)/\$(INCLUDEDIR)
-	cp android-config.h android-version.h android-headers.pc \$(DESTDIR)/\$(INCLUDEDIR)
-	sed -i -e s:prefix=/usr:prefix=\$(PREFIX):g \$(DESTDIR)/\$(INCLUDEDIR)/android-headers.pc
+	mkdir -p \$(DESTDIR)/\$(PKGCONFIGDIR)
+	cp android-config.h android-version.h \$(DESTDIR)/\$(INCLUDEDIR)
+	cp android-headers.pc \$(DESTDIR)/\$(PKGCONFIGDIR)
+	sed -i -e s:prefix=/usr:prefix=\$(PREFIX):g \$(DESTDIR)/\$(PKGCONFIGDIR)/android-headers.pc
 	cp -r hardware \$(DESTDIR)/\$(INCLUDEDIR)
 	cp -r hardware_legacy \$(DESTDIR)/\$(INCLUDEDIR)
 	cp -r cutils \$(DESTDIR)/\$(INCLUDEDIR)
@@ -299,7 +302,7 @@ install:
 	cp -r sync \$(DESTDIR)/\$(INCLUDEDIR)
 	cp -r libnfc-nxp \$(DESTDIR)/\$(INCLUDEDIR)
 	cp -r private \$(DESTDIR)/\$(INCLUDEDIR)
-    cp -r log \$(DESTDIR)/\$(INCLUDEDIR)
+	cp -r log \$(DESTDIR)/\$(INCLUDEDIR)
 EOF
 
 find "$HEADERPATH" -type f -exec chmod 0644 {} \;

--- a/utils/extract-headers.sh
+++ b/utils/extract-headers.sh
@@ -299,6 +299,7 @@ install:
 	cp -r sync \$(DESTDIR)/\$(INCLUDEDIR)
 	cp -r libnfc-nxp \$(DESTDIR)/\$(INCLUDEDIR)
 	cp -r private \$(DESTDIR)/\$(INCLUDEDIR)
+    cp -r log \$(DESTDIR)/\$(INCLUDEDIR)
 EOF
 
 find "$HEADERPATH" -type f -exec chmod 0644 {} \;


### PR DESCRIPTION
Earlier it didn't install the log directory, which resulted in failure
if headers are installed to system-wide location