### PR TITLE
utils: hardware_legacy/wifi.h needs to be extracted for AOSP 4.1+

### DIFF
--- a/utils/extract-headers.sh
+++ b/utils/extract-headers.sh
@@ -171,13 +171,11 @@ extract_headers_to hardware_legacy \
     hardware/libhardware_legacy/include/hardware_legacy/vibrator.h
 if [ $MAJOR -ge 4 -a $MINOR -ge 1 -o $MAJOR -ge 5 ]; then
     extract_headers_to hardware_legacy \
-        hardware/libhardware_legacy/include/hardware_legacy/audio_policy_conf.h
+        hardware/libhardware_legacy/include/hardware_legacy/audio_policy_conf.h \
+        hardware/libhardware_legacy/include/hardware_legacy/wifi.h
 fi
 
 if [ $MAJOR -ge 6 ]; then
-	extract_headers_to hardware_legacy \
-	    hardware/libhardware_legacy/include/hardware_legacy/wifi.h
-
 	extract_headers_to system \
 	    system/media/audio/include/system/audio.h
 fi


### PR DESCRIPTION
This header was previously extracted with Android 6 only but it is available since 4.1.
The wifi module compilation is not set to be compiled only for Android 6.

That permit to fix compilation issue with older version than 6 on wifi.c :
wifi.c:23:34: fatal error: hardware_legacy/wifi.h: No such file or directory

Tested with AOSP 5.1.1_r30 with success