### PR TITLE
sf: 2 new functions and test_sf

### DIFF
--- a/compat/surface_flinger/surface_flinger_compatibility_layer.cpp
+++ b/compat/surface_flinger/surface_flinger_compatibility_layer.cpp
@@ -277,6 +277,19 @@ EGLConfig sf_client_get_egl_config(SfClient* client)
 	}
 }
 
+EGLContext sf_client_get_egl_context(SfClient* client)
+{
+	assert(client);
+
+	if (client->egl_support)
+		return client->egl_context;
+	else {
+		fprintf(stderr, "Warning: sf_client_get_egl_context not supported, EGL "
+				"support disabled\n");
+		return NULL;
+	}
+}
+
 void sf_client_begin_transaction(SfClient* client)
 {
 	assert(client);

--- a/compat/surface_flinger/surface_flinger_compatibility_layer.cpp
+++ b/compat/surface_flinger/surface_flinger_compatibility_layer.cpp
@@ -152,6 +152,41 @@ size_t sf_get_display_height(size_t display_id)
 	return info.h;
 }
 
+size_t sf_get_display_info(size_t display_id, SfDisplayInfo* display_info)
+{
+	android::sp<android::IBinder> display;
+
+	if (display_id == 0) {
+		display = android::SurfaceComposerClient::getBuiltInDisplay(
+				android::ISurfaceComposer::eDisplayIdMain);
+	} else if (display_id == 1) {
+		display = android::SurfaceComposerClient::getBuiltInDisplay(
+				android::ISurfaceComposer::eDisplayIdHdmi);
+	} else {
+		fprintf(stderr, "Warning: sf_get_display_info invalid display_id (0 || 1)\n");
+		return -1;
+	}
+
+	android::DisplayInfo info;
+	android::SurfaceComposerClient::getDisplayInfo(display, &info);
+
+        if (display_info == NULL) {
+            fprintf(stderr, "Warning: sf_get_display_info: display_info is null! Please allocate it before \n");
+            return -2;
+        }
+
+        // partial copy
+        display_info->w = info.w;
+        display_info->h = info.h;
+        display_info->xdpi = info.xdpi;
+        display_info->ydpi = info.ydpi;
+        display_info->fps = info.fps;
+        display_info->density = info.density;
+        display_info->orientation = info.orientation;
+
+	return 0;
+}
+
 SfClient* sf_client_create_full(bool egl_support)
 {
 	SfClient* client = new SfClient();

--- a/hybris/include/hybris/surface_flinger/surface_flinger_compatibility_layer.h
+++ b/hybris/include/hybris/surface_flinger/surface_flinger_compatibility_layer.h
@@ -71,6 +71,7 @@ extern "C" {
 
 	EGLDisplay sf_client_get_egl_display(struct SfClient* display);
 	EGLConfig sf_client_get_egl_config(struct SfClient* client);
+	EGLContext sf_client_get_egl_context(struct SfClient* client);
 	void sf_client_begin_transaction(struct SfClient*);
 	void sf_client_end_transaction(struct SfClient*);
 

--- a/hybris/include/hybris/surface_flinger/surface_flinger_compatibility_layer.h
+++ b/hybris/include/hybris/surface_flinger/surface_flinger_compatibility_layer.h
@@ -29,6 +29,25 @@ extern "C" {
 	struct SfClient;
 	struct SfSurface;
 
+        /* see frameworks/native/include/ui/DisplayInfo.h */
+        struct SfDisplayInfo {
+            uint32_t w;
+            uint32_t h;
+            float xdpi;
+            float ydpi;
+            float fps;
+            float density;
+            uint8_t orientation;
+        };
+
+        /* Display orientations as defined in Surface.java and ISurfaceComposer.h. */
+        enum {
+            DISPLAY_ORIENTATION_0 = 0,
+            DISPLAY_ORIENTATION_90 = 1,
+            DISPLAY_ORIENTATION_180 = 2,
+            DISPLAY_ORIENTATION_270 = 3
+        };
+
 	enum
 	{
 		SURFACE_FLINGER_DEFAULT_DISPLAY_ID = 0
@@ -39,6 +58,7 @@ extern "C" {
 
 	size_t sf_get_display_width(size_t display_id);
 	size_t sf_get_display_height(size_t display_id);
+	size_t sf_get_display_info(size_t display_id, struct SfDisplayInfo* info);
 
 	// The egl_support parameter disables the use of EGL inside the
 	// library. sf_client_create() enables the use of EGL by default. When

--- a/hybris/sf/sf.c
+++ b/hybris/sf/sf.c
@@ -39,6 +39,8 @@ HYBRIS_IMPLEMENT_FUNCTION1(sf, EGLDisplay, sf_client_get_egl_display,
 	struct SfClient*);
 HYBRIS_IMPLEMENT_FUNCTION1(sf, EGLConfig, sf_client_get_egl_config,
 	struct SfClient*);
+HYBRIS_IMPLEMENT_FUNCTION1(sf, EGLContext, sf_client_get_egl_context,
+	struct SfClient*);
 HYBRIS_IMPLEMENT_VOID_FUNCTION1(sf, sf_client_begin_transaction,
 	struct SfClient*);
 HYBRIS_IMPLEMENT_VOID_FUNCTION1(sf, sf_client_end_transaction,

--- a/hybris/sf/sf.c
+++ b/hybris/sf/sf.c
@@ -32,6 +32,7 @@ HYBRIS_IMPLEMENT_VOID_FUNCTION1(sf, sf_blank, size_t);
 HYBRIS_IMPLEMENT_VOID_FUNCTION1(sf, sf_unblank, size_t);
 HYBRIS_IMPLEMENT_FUNCTION1(sf, size_t, sf_get_display_width, size_t);
 HYBRIS_IMPLEMENT_FUNCTION1(sf, size_t, sf_get_display_height, size_t);
+HYBRIS_IMPLEMENT_FUNCTION2(sf, size_t, sf_get_display_info, size_t, struct SfDisplayInfo*);
 HYBRIS_IMPLEMENT_FUNCTION1(sf, struct SfClient*, sf_client_create_full, int);
 HYBRIS_IMPLEMENT_FUNCTION0(sf, struct SfClient*, sf_client_create);
 HYBRIS_IMPLEMENT_FUNCTION1(sf, EGLDisplay, sf_client_get_egl_display,

--- a/hybris/tests/Makefile.am
+++ b/hybris/tests/Makefile.am
@@ -3,6 +3,7 @@ bin_PROGRAMS = \
 	test_egl \
 	test_egl_configs \
 	test_glesv2 \
+	test_sf \
 	test_sensors \
 	test_input \
 	test_lights \


### PR DESCRIPTION
Reintroduce test_sf (previously dropped and partially "reverted" later)

Add 2 new functions to sf that are independent and will not break existing code :
- sf_get_display_info
- sf_client_get_egl_context

sf_get_display_info :
permit to get more details that are not necessary available with current code that requesting the framebuffer. We directly do the request to SurfaceFlinger.

sf_client_get_egl_context : 
permit to get the EGL context of a SfClient. This is useful for QPA.
