### PR TITLE
hybris (arm): introduce HYBRIS_TRACE_(DYNHOOKED/UNHOOKED/HOOKED)

### DIFF
--- a/hybris/common/Makefile.am
+++ b/hybris/common/Makefile.am
@@ -18,11 +18,27 @@ libhybris_common_la_SOURCES = \
 	strlcat.c \
 	logging.c \
 	sysconf.c
+
+if WANT_ARM_TRACING
+libhybris_common_la_SOURCES += \
+	wrappers.c \
+	wrapper_code_generic_arm.c
+endif
+
 libhybris_common_la_CPPFLAGS = \
 	-I$(top_srcdir)/include \
 	$(ANDROID_HEADERS_CFLAGS) \
 	-I$(top_srcdir)/common \
 	-DLINKER_PLUGIN_DIR=\"$(libdir)/libhybris/linker\"
+
+if WANT_ARM_TRACING
+# thumb mode not supported
+libhybris_common_la_CFLAGS = \
+	-marm
+libhybris_common_la_CPPFLAGS += \
+	-marm
+endif
+
 if WANT_TRACE
 libhybris_common_la_CPPFLAGS += -DDEBUG
 endif
@@ -40,6 +56,9 @@ libhybris_common_la_CPPFLAGS += -DWANT_LINKER_JB
 endif
 if WANT_EXPERIMENTAL
 libhybris_common_la_CPPFLAGS += -DWANT_LINKER_MM
+endif
+if WANT_ARM_TRACING
+libhybris_common_la_CPPFLAGS += -DWANT_ARM_TRACING
 endif
 libhybris_common_la_LDFLAGS = \
 	-ldl \

--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -72,11 +72,20 @@
 #include <hybris/properties/properties.h>
 #include <hybris/common/hooks.h>
 
+#ifdef WANT_ARM_TRACING
+#include "wrappers.h"
+#endif
+
 static locale_t hybris_locale;
 static int locale_inited = 0;
 static hybris_hook_cb hook_callback = NULL;
 
+#ifdef WANT_ARM_TRACING
+static void (*_android_linker_init)(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), void *(_create_wrapper)(const char*, void*, int)) = NULL;
+#else
 static void (*_android_linker_init)(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*)) = NULL;
+#endif
+
 static void* (*_android_dlopen)(const char *filename, int flags) = NULL;
 static void* (*_android_dlsym)(void *handle, const char *symbol) = NULL;
 static void* (*_android_dladdr)(void *addr, Dl_info *info) = NULL;
@@ -2977,7 +2986,11 @@ static void __hybris_linker_init()
     _android_dlerror = dlsym(linker_handle, "android_dlerror");
 
     /* Now its time to setup the linker itself */
+#ifdef WANT_ARM_TRACING
+    _android_linker_init(sdk_version, __hybris_get_hooked_symbol, create_wrapper);
+#else
     _android_linker_init(sdk_version, __hybris_get_hooked_symbol);
+#endif
 
     linker_initialized = 1;
 }

--- a/hybris/common/jb/Makefile.am
+++ b/hybris/common/jb/Makefile.am
@@ -30,3 +30,9 @@ jb_la_CFLAGS += -DLINKER_DEBUG=1
 else
 jb_la_CFLAGS += -DLINKER_DEBUG=0
 endif
+
+if WANT_ARM_TRACING
+jb_la_CPPFLAGS = \
+	-DWANT_ARM_TRACING
+endif
+

--- a/hybris/common/jb/linker.c
+++ b/hybris/common/jb/linker.c
@@ -2344,7 +2344,11 @@ unsigned __linker_init(unsigned **elfdata) {
     return __linker_init_post_relocation(elfdata);
 }
 
+#ifdef WANT_ARM_TRACING
+void android_linker_init(int sdk_version, void *(get_hooked_symbol)(const char*, const char*), void *(create_wrapper)(const char*, void*, int)) {
+#else
 void android_linker_init(int sdk_version, void *(get_hooked_symbol)(const char*, const char*)) {
+#endif
    (void) sdk_version;
    _get_hooked_symbol = get_hooked_symbol;
 }

--- a/hybris/common/mm/Makefile.am
+++ b/hybris/common/mm/Makefile.am
@@ -50,3 +50,9 @@ else
 mm_la_CPPFLAGS += \
 	-DTRACE_DEBUG=1
 endif
+
+if WANT_ARM_TRACING
+mm_la_CPPFLAGS += \
+	-DWANT_ARM_TRACING
+endif
+

--- a/hybris/common/wrapper_code.h
+++ b/hybris/common/wrapper_code.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2017 Franz-Josef Haider <f_haider@gmx.at>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef WRAPPER_CODE_H
+#define WRAPPER_CODE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void wrapper_code_generic() __attribute__((naked,noinline));
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WRAPPER_CODE_H */

--- a/hybris/common/wrapper_code_generic_arm.c
+++ b/hybris/common/wrapper_code_generic_arm.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2017 Franz-Josef Haider <f_haider@gmx.at>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "wrapper_code.h"
+
+void
+wrapper_code_generic()
+{
+    // we can never use r0-r11, neither the stack
+    asm volatile(
+        // preserve the registers
+	".arm\n\
+        push {r0-r11, lr}\n"
+
+	".arm\n\
+        ldr r0, fun\n" // load the function pointer to r0
+	".arm\n\
+        ldr r1, name\n" // load the address of the functions name to r1
+	".arm\n\
+        ldr r2, str\n" // load the string to print
+	".arm\n\
+        ldr r4, tc\n" // load the address of trace_callback to r4
+	".arm\n\
+        blx r4\n" // call trace_callback
+
+        // restore the registers
+	".arm\n\
+        pop {r0-r11, lr}\n"
+	".arm\n\
+        ldr pc, fun\n"     // jump to function
+
+        // dummy instructions, this is where we locate our pointers
+        "name: .word 0xFFFFFFFF\n" // name of function to call
+        "fun: .word 0xFFFFFFFF\n" // function to call
+        "tc: .word 0xFFFFFFFF\n" // address of trace_callback
+        "str: .word 0xFFFFFFFF\n" // the string being printed in trace_callback
+    );
+}

--- a/hybris/common/wrappers.c
+++ b/hybris/common/wrappers.c
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2017 Franz-Josef Haider <f_haider@gmx.at>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "wrappers.h"
+#include "wrapper_code.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <sys/mman.h>
+#include <stdint.h>
+#include <assert.h>
+
+static int trace_dynhooked = 0;
+static int trace_unhooked = 0;
+static int trace_hooked = 0;
+static int trace_env_checked = 0;
+
+struct wrapper {
+    char *name;
+    void *ptr;
+    unsigned int size;
+    int type;
+    struct wrapper *next;
+};
+
+struct wrapper *wrappers = NULL;
+
+int wrapper_cmp(void *a, void *b) {
+    struct wrapper *key = (struct wrapper*)a;
+    struct wrapper *elem = (struct wrapper*)b;
+    int c = strcmp(key->name, elem->name);
+    if(0 == c) {
+        return (key->type - elem->type);
+    }
+    return c;
+}
+
+void register_wrapper(void *wrapper_ptr, unsigned int size, const char *name, int type)
+{
+    struct wrapper *it = wrappers;
+    struct wrapper *last = NULL;
+    while(NULL != it)
+    {
+        last = it;
+        it = it->next;
+    }
+    struct wrapper *w = (struct wrapper*)malloc(sizeof(struct wrapper));
+    w->name = (char*)name;
+    w->ptr = wrapper_ptr;
+    w->type = type;
+    w->size = size;
+    w->next = NULL;
+    if(NULL == last)
+    {
+        wrappers = w;
+    }
+    else
+    {
+        last->next = w;
+    }
+}
+
+void trace_callback(void *function, char *name, char *msg)
+{
+    fprintf(stderr, "%s: %s@%p\n", msg, name, function);
+}
+
+const char *msg_unhooked = "calling unhooked method";
+const char *msg_dynhook = "calling dynamically loaded method";
+const char *msg_hooked = "calling hooked method";
+
+static size_t
+get_wrapper_code_size(void *wrapper)
+{
+    // Find first occurence of 0xFFFFFFFF in the code object,
+    // which is the placeholder for the attached data words
+    uint32_t *ptr = wrapper;
+    while (*ptr != 0xFFFFFFFF) {
+        ptr++;
+    }
+    return ((void *)ptr - (void *)wrapper);
+}
+
+void *create_wrapper(const char *symbol, void *function, int wrapper_type)
+{
+    size_t wrapper_size = 0;
+    void *wrapper_code = (void*)((uint32_t)wrapper_code_generic & 0xFFFFFFFE);
+    void *wrapper_addr = NULL;
+    int helper = 0;
+
+    const char *msg = NULL;
+
+    if(!trace_env_checked)
+    {
+        trace_hooked = getenv("HYBRIS_TRACE_HOOKED") ? atoi(getenv("HYBRIS_TRACE_HOOKED")) : 0;
+        trace_unhooked = getenv("HYBRIS_TRACE_UNHOOKED") ? atoi(getenv("HYBRIS_TRACE_UNHOOKED")) : 0;
+        trace_dynhooked = getenv("HYBRIS_TRACE_DYNHOOKED") ? atoi(getenv("HYBRIS_TRACE_DYNHOOKED")) : 0;
+
+        trace_env_checked = 1;
+    }
+
+    switch(wrapper_type)
+    {
+        case WRAPPER_HOOKED:
+            if(!trace_hooked) return function;
+            msg = msg_hooked;
+            break;
+        case WRAPPER_UNHOOKED:
+            if(!trace_unhooked) return function;
+            msg = msg_unhooked;
+            break;
+        case WRAPPER_DYNHOOK:
+            if(!trace_dynhooked) return function;
+            msg = msg_dynhook;
+            break;
+        default:
+            assert(NULL == "ERROR: invalid wrapper type!\n");
+    };
+
+    wrapper_size = get_wrapper_code_size(wrapper_code);
+
+    // 4 additional longs for data storage, see below
+    wrapper_size += 4 * sizeof(uint32_t);
+
+    // reserve memory for the generated wrapper
+    wrapper_addr = mmap(NULL, wrapper_size,
+        PROT_READ | PROT_WRITE | PROT_EXEC,
+        MAP_ANONYMOUS | MAP_PRIVATE,
+        0, 0);
+
+    if(MAP_FAILED == wrapper_addr)
+    {
+        printf("ERROR: failed to create wrapper for %s@%p (mmap failed).\n", symbol, function);
+        return function;
+    }
+
+    memcpy(wrapper_addr, wrapper_code, wrapper_size);
+
+    // Helper = offset of data fields in wrapper_addr (interpreted as int32_t)
+    helper = wrapper_size / sizeof(uint32_t) - 4;
+
+    switch(wrapper_type)
+    {
+        case WRAPPER_HOOKED:
+        case WRAPPER_UNHOOKED:
+        case WRAPPER_DYNHOOK:
+            ((int32_t*)wrapper_addr)[helper++] = (uint32_t)symbol;
+            ((int32_t*)wrapper_addr)[helper++] = (uint32_t)function;
+            ((int32_t*)wrapper_addr)[helper++] = (uint32_t)trace_callback;
+            ((int32_t*)wrapper_addr)[helper++] = (uint32_t)msg;
+            break;
+        default:
+            assert(0);
+            break;
+    };
+
+    register_wrapper(wrapper_addr, wrapper_size, symbol, wrapper_type);
+
+    return (void*)wrapper_addr;
+}
+
+void release_all_wrappers()
+{
+    struct wrapper *it = wrappers;
+    while(NULL != it)
+    {
+        struct wrapper *next = it->next;
+        munmap(it->ptr,it->size);
+        free(it);
+        it = next;
+    }
+}
+

--- a/hybris/common/wrappers.h
+++ b/hybris/common/wrappers.h
@@ -1,0 +1,52 @@
+#ifndef __WRAPPERS_H__
+#define __WRAPPERS_H__
+/**
+ * Copyright (c) 2013, Franz-Josef Haider <f_haider@gmx.at>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum wrapper_type_t {
+    WRAPPER_UNHOOKED = 0,
+    WRAPPER_DYNHOOK,
+    WRAPPER_HOOKED
+};
+
+void *create_wrapper(const char *symbol, void *function, int wrapper_type);
+void release_all_wrappers();
+
+// taken from <linux/elf.h>
+#define ELF_ST_TYPE(x)       (((unsigned int) x) & 0xf)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -54,6 +54,12 @@ AC_ARG_ENABLE(trace,
   [trace="no"])
 AM_CONDITIONAL( [WANT_TRACE], [test x"$trace" = x"yes"])
 
+AC_ARG_ENABLE(mm_arm_tracing,
+  [  --enable-mm-arm-tracing            Enable ARM (32-bit only) tracing, useful for understanding what the blob is doing, currently only the mm linker is supported. (default=disabled)],
+  [mm_arm_tracing=$enableval],
+  [mm_arm_tracing="no"])
+AM_CONDITIONAL([WANT_ARM_TRACING], [test x"$mm_arm_tracing" = x"yes"])
+
 AC_ARG_ENABLE(mesa,
   [  --enable-mesa            Enable mesa headers (default=disabled)],
   [mesa=$enableval],


### PR DESCRIPTION
useful to trace calls to and between android blobs.

shows you (somewhat) what the blobs are actually doing

works for functions which have no debug hook (HOOK_DIRECT_NO_DEBUG) but cannot print arguments, nevertheless i found it useful many times

implemented by injecting a wrapper function between a function that is called and it's actual implementation

it is entirely optional (--enable-mm-arm-tracing)

for example you could run
HYBRIS_TRACE_UNHOOKED=1 test_egl
and IF it would say: calling unhooked method malloc@ptr
you would know that malloc is unhooked (which it shouldn't be) and is called.

if for example test_egl crashes you could run
HYBRIS_TRACE_HOOKED=1 test_egl
and if you're lucky it would tell you maybe: calling hooked method foo@ptr with a crash immediately afterwards -> it's likely that there is a bug in this methods wrapper.

HYBRIS_TRACE_DYNHOOKED=1 would show you which functions are called which where previously loaded via dlsym and is a nice way of tracing egl/gl calls.

limitations:
* currently only implemented for the mm linker (would be possible to port)
* currently only available for arm 32 bit
* cannot show you which symbol is referenced, only which functions are called