### PR TITLE
hybris: common: mm: search lib in library path if opening directly fails.

### DIFF
--- a/hybris/common/mm/linker.cpp
+++ b/hybris/common/mm/linker.cpp
@@ -1139,10 +1139,11 @@ static int open_library(const char* name, off64_t* file_offset) {
   // If the name contains a slash, we should attempt to open it directly and not search the paths.
   if (strchr(name, '/') != nullptr) {
     int fd = TEMP_FAILURE_RETRY(open(name, O_RDONLY | O_CLOEXEC));
+    //... But if it's not there, failback to search it in all other library paths
     if (fd != -1) {
       *file_offset = 0;
+      return fd;
     }
-    return fd;
   }
 
   // Otherwise we try LD_LIBRARY_PATH first, and fall back to the built-in well known paths.


### PR DESCRIPTION
On some device, a binary blob call dlopen with "egl/blah.so". The
correct behavior (and current code's behavior) is to open the library
directly on that path (relative to working directory) and don't look in
library path.

But the sad truth of life is, some binary blob rely on old behavior
which will not open the library directly if the path doesn't start
with '/'. As the library is actually reside in /system/vendor/lib/egl/,
the code will work with old behavior and not new behavior.

This commit makes linker search for library in library path if it can't
open library directly, which is the behavior of Android 5.0's linker.
This will let those libraries work.

This is the reference of this behavior:
https://android.googlesource.com/platform/bionic/+/6971fe4ca52ebdaa85ba676a044412b01d2ef1bf