### PR TITLE
hybris: introduce --enable-adreno-quirks

### DIFF
--- a/hybris/common/Makefile.am
+++ b/hybris/common/Makefile.am
@@ -31,6 +31,10 @@ libhybris_common_la_CPPFLAGS = \
 	-I$(top_srcdir)/common \
 	-DLINKER_PLUGIN_DIR=\"$(libdir)/libhybris/linker\"
 
+if WANT_ADRENO_QUIRKS
+libhybris_common_la_CPPFLAGS += -DWANT_ADRENO_QUIRKS
+endif
+
 if WANT_ARM_TRACING
 # thumb mode not supported
 libhybris_common_la_CFLAGS = \

--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -293,6 +293,10 @@ static void *_hybris_hook_malloc(size_t size)
 {
     TRACE_HOOK("size %zu", size);
 
+#ifdef WANT_ADRENO_QUIRKS
+    if(size == 4) size = 5;
+#endif
+
     void *res = malloc(size);
 
     TRACE_HOOK("res %p", res);
@@ -2431,7 +2435,7 @@ static struct _hook hooks_common[] = {
     HOOK_INDIRECT(__system_property_get),
     HOOK_DIRECT(getenv),
     HOOK_DIRECT_NO_DEBUG(printf),
-    HOOK_DIRECT(malloc),
+    HOOK_INDIRECT(malloc),
     HOOK_DIRECT_NO_DEBUG(free),
     HOOK_DIRECT_NO_DEBUG(calloc),
     HOOK_DIRECT_NO_DEBUG(cfree),

--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -48,6 +48,12 @@ AC_ARG_ENABLE(experimental,
   [experimental="no"])
 AM_CONDITIONAL( [WANT_EXPERIMENTAL], [test x"$experimental" = x"yes"])
 
+AC_ARG_ENABLE(adreno_quirks,
+  [  --enable-adreno-quirks     Enable adreno quirks (default=disabled)],
+  [adreno_quirks=$enableval],
+  [adreno_quirks="no"])
+AM_CONDITIONAL( [WANT_ADRENO_QUIRKS], [test x"$adreno_quirks" = x"yes"])
+
 AC_ARG_ENABLE(trace,
   [  --enable-trace            Enable TRACE statements (default=disabled)],
   [trace=$enableval],


### PR DESCRIPTION
If this is enabled malloc(4) will be treated as if it was malloc(5).

This introduces overhead obviously but solves the following problem:

If sailfishos-browser crashes for no reason with shader compilation
errors this is required. It is most likely a bug in the blobs since
we only experience it on a subset of devices. Also using a jemalloc
implementation as LD_PRELOAD to libhybris works around this problem.
jemalloc is used in android which seems to indicate that it is more
lenient with these kinds of out-of-bounds accesses.

NOTE: sailfishos-browser is not the only affected app, it is just
an example. lipstick and others are also affected but it is not as
noticeable. Reboot/UI-restart is necessary after this change.