### PR TITLE
dlerror() should return NULL on success

### DIFF
--- a/hybris/common/mm/dlfcn.cpp
+++ b/hybris/common/mm/dlfcn.cpp
@@ -39,10 +39,10 @@ extern void *(*_create_wrapper)(const char *symbol, void *function, int wrapper_
 
 /* This file hijacks the symbols stubbed out in libdl.so. */
 
-static pthread_mutex_t g_dl_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+static __thread const char *dl_err_str;
+char __thread dlerror_buffer[__BIONIC_DLERROR_BUFFER_SIZE];
 
-static char dl_err_buf[1024];
-static const char *dl_err_str;
+static pthread_mutex_t g_dl_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 
 static const char* __bionic_set_dlerror(char* new_value) {
 #ifdef DISABLED_FOR_HYBRIS_SUPPORT
@@ -52,9 +52,10 @@ static const char* __bionic_set_dlerror(char* new_value) {
   *dlerror_slot = new_value;
   return old_value;
 #else
-  char *dlerror_slot = dl_err_buf;
-  const char *old_value = dlerror_slot;
-  dlerror_slot = new_value;
+  const char *old_value = dl_err_str;
+
+  dl_err_str = new_value;
+
   return old_value;
 #endif
 }
@@ -63,7 +64,7 @@ static void __bionic_format_dlerror(const char* msg, const char* detail) {
 #ifdef DISABLED_FOR_HYBRIS_SUPPORT
   char* buffer = __get_thread()->dlerror_buffer;
 #else
-  char* buffer = dl_err_buf;
+  char* buffer = dlerror_buffer;
 #endif
   strlcpy(buffer, msg, __BIONIC_DLERROR_BUFFER_SIZE);
   if (detail != nullptr) {


### PR DESCRIPTION
some code depends on dlerror() returning NULL when dlsym succeeds.