### PR TITLE
nativewindowbase: fix hwcomposer/fbdev window creation on some devices

### DIFF
--- a/hybris/egl/platforms/common/nativewindowbase.cpp
+++ b/hybris/egl/platforms/common/nativewindowbase.cpp
@@ -1,6 +1,7 @@
 #include <android-config.h>
 #include <string.h>
 #include <system/window.h>
+#include <system/graphics.h>
 #include <hardware/gralloc.h>
 #include "support.h"
 #include <stdarg.h>
@@ -260,6 +261,10 @@ const char *BaseNativeWindow::_native_query_operation(int what)
 #if ANDROID_VERSION_MAJOR>=4 && ANDROID_VERSION_MINOR>=1 || ANDROID_VERSION_MAJOR>=5
 		case NATIVE_WINDOW_CONSUMER_RUNNING_BEHIND: return "NATIVE_WINDOW_CONSUMER_RUNNING_BEHIND";
 #endif
+#if ANDROID_VERSION_MAJOR>=6
+		case NATIVE_WINDOW_DEFAULT_DATASPACE: return "NATIVE_WINDOW_DEFAULT_DATASPACE";
+		case NATIVE_WINDOW_CONSUMER_USAGE_BITS: return "NATIVE_WINDOW_CONSUMER_USAGE_BITS";
+#endif
 		default: return "NATIVE_UNKNOWN_QUERY";
 	}
 }
@@ -296,6 +301,14 @@ int BaseNativeWindow::_query(const struct ANativeWindow* window, int what, int* 
 		case NATIVE_WINDOW_MIN_UNDEQUEUED_BUFFERS:
 			*value = 1;
 			return NO_ERROR;
+#if ANDROID_VERSION_MAJOR>=6
+		case NATIVE_WINDOW_DEFAULT_DATASPACE:
+			*value = HAL_DATASPACE_UNKNOWN;
+			return NO_ERROR;
+		case NATIVE_WINDOW_CONSUMER_USAGE_BITS:
+			*value = self->getUsage();
+			return NO_ERROR;
+#endif
 	}
 	TRACE("EGL error: unkown window attribute! %i", what);
 	*value = 0;

--- a/hybris/egl/platforms/common/nativewindowbase.h
+++ b/hybris/egl/platforms/common/nativewindowbase.h
@@ -75,6 +75,7 @@ protected:
 	virtual unsigned int defaultHeight() const = 0;
 	virtual unsigned int queueLength() const = 0;
 	virtual unsigned int transformHint() const = 0;
+	virtual unsigned int getUsage() const = 0;
 	//perform interfaces
 	virtual int setBuffersFormat(int format) = 0;
 	virtual int setBuffersDimensions(int width, int height) = 0;

--- a/hybris/egl/platforms/fbdev/fbdev_window.cpp
+++ b/hybris/egl/platforms/fbdev/fbdev_window.cpp
@@ -443,7 +443,13 @@ unsigned int FbDevNativeWindow::transformHint() const
     return 0;
 }
 
-
+/*
+ * returns the current usage of this window
+ */
+unsigned int FbDevNativeWindow::getUsage() const
+{
+    return m_usage;
+}
 
 /*
  *  native_window_set_usage(..., usage)

--- a/hybris/egl/platforms/fbdev/fbdev_window.h
+++ b/hybris/egl/platforms/fbdev/fbdev_window.h
@@ -65,6 +65,7 @@ protected:
     virtual unsigned int defaultHeight() const;
     virtual unsigned int queueLength() const;
     virtual unsigned int transformHint() const;
+    virtual unsigned int getUsage() const;
     // perform calls
     virtual int setUsage(int usage);
     virtual int setBuffersFormat(int format);

--- a/hybris/egl/platforms/hwcomposer/hwcomposer_window.cpp
+++ b/hybris/egl/platforms/hwcomposer/hwcomposer_window.cpp
@@ -414,7 +414,13 @@ unsigned int HWComposerNativeWindow::transformHint() const
     return 0;
 }
 
-
+/*
+ * returns the current usage of this window
+ */
+unsigned int HWComposerNativeWindow::getUsage() const
+{
+    return m_usage;
+}
 
 /*
  *  native_window_set_usage(..., usage)

--- a/hybris/egl/platforms/hwcomposer/hwcomposer_window.h
+++ b/hybris/egl/platforms/hwcomposer/hwcomposer_window.h
@@ -69,6 +69,7 @@ protected:
     virtual unsigned int defaultHeight() const;
     virtual unsigned int queueLength() const;
     virtual unsigned int transformHint() const;
+    virtual unsigned int getUsage() const;
     // perform calls
     virtual int setUsage(int usage);
     virtual int setBuffersFormat(int format);

--- a/hybris/egl/platforms/wayland/wayland_window.cpp
+++ b/hybris/egl/platforms/wayland/wayland_window.cpp
@@ -688,6 +688,13 @@ unsigned int WaylandNativeWindow::transformHint() const {
     return 0;
 }
 
+/*
+ * returns the current usage of this window
+ */
+unsigned int WaylandNativeWindow::getUsage() const {
+    return m_usage;
+}
+
 int WaylandNativeWindow::setBuffersFormat(int format) {
     if (format != m_format)
     {

--- a/hybris/egl/platforms/wayland/wayland_window.h
+++ b/hybris/egl/platforms/wayland/wayland_window.h
@@ -182,6 +182,7 @@ protected:
     virtual unsigned int defaultHeight() const;
     virtual unsigned int queueLength() const;
     virtual unsigned int transformHint() const;
+    virtual unsigned int getUsage() const;
     // perform calls
     virtual int setUsage(int usage);
     virtual int setBuffersFormat(int format);


### PR DESCRIPTION
add querys NATIVE_WINDOW_DEFAULT_DATASPACE and NATIVE_WINDOW_CONSUMER_USAGE_BITS. Some devices fail to create a hwcomposer/fbdev window without this.