### PR TITLE
Assign the layer list only to the first display

### DIFF
--- a/hybris/tests/test_hwcomposer.cpp
+++ b/hybris/tests/test_hwcomposer.cpp
@@ -218,7 +218,11 @@ int main(int argc, char **argv)
 
 	int counter = 0;
 	for (; counter < HWC_NUM_DISPLAY_TYPES; counter++)
-		mList[counter] = list;
+		mList[counter] = NULL;
+
+	// Assign the layer list only to the first display,
+	// otherwise HWC might freeze if others are disconnected
+	mList[0] = list;
 
 	hwc_layer_1_t *layer = &list->hwLayers[0];
 	memset(layer, 0, sizeof(hwc_layer_1_t));


### PR DESCRIPTION
It's done the same way in https://github.com/mer-hybris/qt5-qpa-hwcomposer-plugin/blob/master/hwcomposer/hwcomposer_backend_v11.cpp#L229

This fixes test_hwcomposer on MediaTek Helio X10 device (Xiaomi Redmi Note 2), as otherwise HWC will freeze if there are no other displays connected.