### PR TITLE
linker.cpp: Fix issue with newer glibc

### DIFF
--- a/hybris/common/n/linker.cpp
+++ b/hybris/common/n/linker.cpp
@@ -68,6 +68,14 @@
 #include "linker_non_pie.h"
 #endif
 
+// Stay compatible with newer glibc
+#ifndef R_AARCH64_TLS_TPREL64
+#define R_AARCH64_TLS_TPREL64 R_AARCH64_TLS_TPREL
+#endif
+#ifndef R_AARCH64_TLS_DTPREL32
+#define R_AARCH64_TLS_DTPREL32 R_AARCH64_TLS_DTPREL
+#endif
+
 //#include "android-base/strings.h"
 //#include "ziparchive/zip_archive.h"
 


### PR DESCRIPTION
Addresses the following issues with newer glibc

linker.cpp: In member function 'bool soinfo::relocate(const
VersionTracker&, ElfRelIteratorT&&, const soinfo_list_t&, const
soinfo_list_t&)':
linker.cpp:3156:12: error: 'R_AARCH64_TLS_TPREL64' was not declared in
this scope
case R_AARCH64_TLS_TPREL64:
^~~~~~~~~~~~~~~~~~~~~
linker.cpp:3160:12: error: 'R_AARCH64_TLS_DTPREL32' was not declared in
this scope
case R_AARCH64_TLS_DTPREL32:

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>