### PR TITLE
Fix TLS slots to be compatible with x86

### DIFF
--- a/hybris/common/mm/bionic/libc/private/bionic_tls.h
+++ b/hybris/common/mm/bionic/libc/private/bionic_tls.h
@@ -51,12 +51,17 @@ __BEGIN_DECLS
 enum {
   TLS_SLOT_SELF = 0, // The kernel requires this specific slot for x86.
   TLS_SLOT_THREAD_ID,
-  TLS_SLOT_ERRNO = 5,
+
+  TLS_SLOT_STACK_GUARD = 5, // GCC requires this specific slot for x86.
+
+  TLS_SLOT_ERRNO = 6,
 
   // These two aren't used by bionic itself, but allow the graphics code to
   // access TLS directly rather than using the pthread API.
-  TLS_SLOT_OPENGL_API = 6,
-  TLS_SLOT_OPENGL = 7,
+  TLS_SLOT_OPENGL_API = 7,
+  TLS_SLOT_OPENGL = 8,
+
+  TLS_SLOT_DLERROR = 9,
 
   // This slot is only used to pass information from the dynamic linker to
   // libc.so when the C library is loaded in to memory. The C runtime init
@@ -64,11 +69,9 @@ enum {
   // we reuse an existing location that isn't needed during libc startup.
   TLS_SLOT_BIONIC_PREINIT = TLS_SLOT_OPENGL_API,
 
-  TLS_SLOT_STACK_GUARD = 8, // GCC requires this specific slot for x86.
-  TLS_SLOT_DLERROR,
-
   BIONIC_TLS_SLOTS // Must come last!
 };
+
 
 /*
  * Bionic uses some pthread keys internally. All pthread keys used internally

--- a/hybris/common/n/bionic/libc/private/bionic_tls.h
+++ b/hybris/common/n/bionic/libc/private/bionic_tls.h
@@ -51,21 +51,23 @@ __BEGIN_DECLS
 enum {
   TLS_SLOT_SELF = 0, // The kernel requires this specific slot for x86.
   TLS_SLOT_THREAD_ID,
-  TLS_SLOT_ERRNO = 5,
+
+  TLS_SLOT_STACK_GUARD = 5, // GCC requires this specific slot for x86.
+
+  TLS_SLOT_ERRNO = 6,
 
   // These two aren't used by bionic itself, but allow the graphics code to
   // access TLS directly rather than using the pthread API.
-  TLS_SLOT_OPENGL_API = 6,
-  TLS_SLOT_OPENGL = 7,
+  TLS_SLOT_OPENGL_API = 7,
+  TLS_SLOT_OPENGL = 8,
+
+  TLS_SLOT_DLERROR = 9,
 
   // This slot is only used to pass information from the dynamic linker to
   // libc.so when the C library is loaded in to memory. The C runtime init
   // function will then clear it. Since its use is extremely temporary,
   // we reuse an existing location that isn't needed during libc startup.
   TLS_SLOT_BIONIC_PREINIT = TLS_SLOT_OPENGL_API,
-
-  TLS_SLOT_STACK_GUARD = 8, // GCC requires this specific slot for x86.
-  TLS_SLOT_DLERROR,
 
   // Fast storage for Thread::Current() in ART.
   TLS_SLOT_ART_THREAD_SELF,


### PR DESCRIPTION
In a 4 year old commit, a Canonical employee "shifted TLS slots to avoid conflicts with libc/hybris": https://code-review.phablet.ubuntu.com/gitweb?p=aosp/platform/bionic.git;a=commit;h=7b1fefd038b943944be08219270ea1acc31b6b3d

While the change seems to work with ARM devices, it is a no-go for x86 ones. In fact, that patch changes `TLS_SLOT_STACK_GUARD` slot value while the comment tells specifically not to do that.

The change (due to some coincidence) did not harm up to Android 5.0. In more recent versions, applications compiled with those slot values crash immediately due to stack corruption.

All the x86 porters I know who work with recent Android versions modify TLS slots locally. So, I suggest to upstream these tested values that return `TLS_SLOT_STACK_GUARD` to its place, shifting other slots around.