### PR TITLE
Look for libhardware.so from default search path.

### DIFF
--- a/hybris/hardware/hardware.c
+++ b/hybris/hardware/hardware.c
@@ -22,7 +22,7 @@
 #include <hybris/common/binding.h>
 
 #pragma GCC visibility push(hidden)
-HYBRIS_LIBRARY_INITIALIZE(hardware, "/system/lib/libhardware.so");
+HYBRIS_LIBRARY_INITIALIZE(hardware, "libhardware.so");
 #pragma GCC visibility pop
 
 HYBRIS_IMPLEMENT_FUNCTION2(hardware, int, hw_get_module, const char *, const struct hw_module_t **);


### PR DESCRIPTION
This restores commit 98a8779f2235b9a57f9c1d16bf1e77f3c96f267c, which was lost during the merge of Ubuntu version.

It's needed for arm64 libhybris to work (where libhardware is located at /system/lib64), as well as for some SailfishOS devices which require patched libhardware.so.