### PR TITLE
Fix BGRA format conditions in eglplatformcommon

### DIFF
--- a/hybris/egl/platforms/common/eglplatformcommon.cpp
+++ b/hybris/egl/platforms/common/eglplatformcommon.cpp
@@ -74,7 +74,7 @@ extern "C" void hybris_dump_buffer_to_file(ANativeWindowBuffer *buf)
 	char b[1024];
 	int bytes_pp = 0;
 
-	if (buf->format == HAL_PIXEL_FORMAT_RGBA_8888)
+	if (buf->format == HAL_PIXEL_FORMAT_RGBA_8888 || buf->format == HAL_PIXEL_FORMAT_BGRA_8888)
 		bytes_pp = 4;
 	else if (buf->format == HAL_PIXEL_FORMAT_RGB_565)
 		bytes_pp = 2;
@@ -116,6 +116,7 @@ extern "C" EGLBoolean eglplatformcommon_eglQueryWaylandBufferWL(EGLDisplay dpy,
 			*value = EGL_TEXTURE_RGB;
 			break;
 		case HAL_PIXEL_FORMAT_RGBA_8888:
+		case HAL_PIXEL_FORMAT_BGRA_8888:
 			*value = EGL_TEXTURE_RGBA;
 			break;
 		default:


### PR DESCRIPTION
For me, the change in L119 fixes Plasma display in KWin.

L77 was changed to align, as we probably want to treat RGBA and BGRA equally here.

Fixes some problems related to #382.