### PR TITLE
waylandws_GetDisplay: handle default display

### DIFF
--- a/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
+++ b/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
@@ -140,7 +140,7 @@ static const wl_callback_listener callback_listener = {
 extern "C" _EGLDisplay *waylandws_GetDisplay(EGLNativeDisplayType display)
 {
 	WaylandDisplay *wdpy = new WaylandDisplay;
-	wdpy->wl_dpy = (wl_display *)display;
+	wdpy->wl_dpy = display ? (wl_display *)display : wl_display_connect(NULL);
 	wdpy->wlegl = NULL;
 	wdpy->queue = wl_display_create_queue(wdpy->wl_dpy);
 	wdpy->registry = wl_display_get_registry(wdpy->wl_dpy);


### PR DESCRIPTION
When an EGL app wants to retrieve the default EGL display, it calls eglGetDisplay(0).
However this results in a crash in wayland, when the platform is "wayland".
To solve this, handle the case when the app simply wants to connect to the default display by connecting to the current wayland display.