### PR TITLE
hooks: add hook for __set_errno_internal

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -2656,6 +2656,7 @@ static struct _hook hooks_common[] = {
     HOOK_INDIRECT(setlinebuf),
     HOOK_TO(__errno, __errno_location),
     HOOK_INDIRECT(__set_errno),
+    HOOK_TO(__set_errno_internal, _hybris_hook___set_errno),
     HOOK_TO(__progname, &program_invocation_name),
     /* net specifics, to avoid __res_get_state */
     HOOK_INDIRECT(getaddrinfo),


### PR DESCRIPTION
This is needed for Android 5.1, to avoid having syscalls
changing errno in bionic's TLS array.

This change is related to https://github.com/ubports/android_bionic/pull/1

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>