### PR TITLE
hybris: add missing top_builddir include in egl/platforms/wayland

### DIFF
--- a/hybris/egl/platforms/wayland/Makefile.am
+++ b/hybris/egl/platforms/wayland/Makefile.am
@@ -6,6 +6,7 @@ eglplatform_wayland_la_CXXFLAGS = \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/egl \
 	-I$(top_srcdir)/egl/platforms/common \
+	-I$(top_builddir)/egl/platforms/common \
 	$(ANDROID_HEADERS_CFLAGS) \
 	$(WAYLAND_CLIENT_CFLAGS)
 


### PR DESCRIPTION
The file wayland-android-client-protocol.h is generated and thus present
in the build directory. When compiling out of source tree, a build dir
include path is thus missing.