### PR TITLE
Fix crashes in threaded EGL wayland rendering

### DIFF
--- a/hybris/egl/platforms/wayland/wayland_window.cpp
+++ b/hybris/egl/platforms/wayland/wayland_window.cpp
@@ -371,12 +371,12 @@ int WaylandNativeWindow::dequeueBuffer(BaseNativeWindowBuffer **buffer, int *fen
     HYBRIS_TRACE_END("wayland-platform", "dequeueBuffer_wait_for_buffer", "");
 
     /* If the buffer doesn't match the window anymore, re-allocate */
-    if (wnb->width != m_window->width || wnb->height != m_window->height
+    if (wnb->width != m_width || wnb->height != m_height
         || wnb->format != m_format || wnb->usage != m_usage)
     {
         TRACE("wnb:%p,win:%p %i,%i %i,%i x%x,x%x x%x,x%x",
             wnb,m_window,
-            wnb->width,m_window->width, wnb->height,m_window->height,
+            wnb->width,m_width, wnb->height,m_height,
             wnb->format,m_format, wnb->usage,m_usage);
         destroyBuffer(wnb);
         m_bufList.erase(it);


### PR DESCRIPTION
Destroying an EGLSurface object in the main thread while a rendering thread is calling eglSwapBuffers() results in various crash / hanging scenarios:
* a segfault in dequeueBuffer() while calling m_window->width();
* a hang in finishSwap() because readQueue() is called blocking on the frame_callback, while this ressource have been killed already and there will be no event in the queue;
* a segfault in finishSwap() while creating the frame_callback with m_window->surface.

This PR is adding more protection against illegal use of m_window, even if the case described above is an illegal case (calling destroying a window while the rendering thread is swapping it). It should solve #402.

What do you think?