### PR TITLE
jb/mm/n: HYBRIS_ENABLE_LINKER_DEBUG_MAP enables Android libs in gdb

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -93,9 +93,9 @@ static int locale_inited = 0;
 static hybris_hook_cb hook_callback = NULL;
 
 #ifdef WANT_ARM_TRACING
-static void (*_android_linker_init)(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), void *(_create_wrapper)(const char*, void*, int)) = NULL;
+static void (*_android_linker_init)(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, void *(_create_wrapper)(const char*, void*, int)) = NULL;
 #else
-static void (*_android_linker_init)(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*)) = NULL;
+static void (*_android_linker_init)(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support) = NULL;
 #endif
 
 void *(*_android_dlopen)(const char* filename, int flag) = NULL;
@@ -3180,6 +3180,14 @@ static int linker_initialized = 0;
 static void __hybris_linker_init()
 {
     LOGD("Linker initialization");
+    
+    int enable_linker_gdb_support = 0;
+    const char *env = getenv("HYBRIS_ENABLE_LINKER_DEBUG_MAP");
+    if (env != NULL) {
+        if (strcmp(env, "1") == 0) {
+            enable_linker_gdb_support = 1;
+        }
+    }
 
     int sdk_version = get_android_sdk_version();
 
@@ -3241,9 +3249,9 @@ static void __hybris_linker_init()
 
     /* Now its time to setup the linker itself */
 #ifdef WANT_ARM_TRACING
-    _android_linker_init(sdk_version, __hybris_get_hooked_symbol, create_wrapper);
+    _android_linker_init(sdk_version, __hybris_get_hooked_symbol, enable_linker_gdb_support, create_wrapper);
 #else
-    _android_linker_init(sdk_version, __hybris_get_hooked_symbol);
+    _android_linker_init(sdk_version, __hybris_get_hooked_symbol, enable_linker_gdb_support);
 #endif
 
     if (_android_set_application_target_sdk_version) {

--- a/hybris/common/jb/linker.c
+++ b/hybris/common/jb/linker.c
@@ -172,8 +172,28 @@ static struct link_map *r_debug_tail = 0;
 
 static pthread_mutex_t _r_debug_lock = PTHREAD_MUTEX_INITIALIZER;
 
+static int _is_android_debug_enabled() 
+{
+  static int _hybris_enable_android_debug = -1; // -1: not initialized
+  
+  if (_hybris_enable_android_debug == -1) {
+    _hybris_enable_android_debug = 0;
+    const char *env = getenv("HYBRIS_ENABLE_LINKER_DEBUG_MAP");
+    if (env != NULL)
+    {
+        if (strcmp(env, "1") == 0) {
+               _hybris_enable_android_debug = 1;
+        }
+    }
+  }
+  
+  return _hybris_enable_android_debug == 1;
+}
+
 static void insert_soinfo_into_debug_map(soinfo * info)
 {
+    if (!_is_android_debug_enabled()) return;
+
     struct link_map * map;
 
     /* Copy the necessary fields into the debug structure.
@@ -232,6 +252,8 @@ static void insert_soinfo_into_debug_map(soinfo * info)
 
 static void remove_soinfo_from_debug_map(soinfo * info)
 {
+    if (!_is_android_debug_enabled()) return;
+    
     struct link_map * map = &(info->linkmap);
 
     if (r_debug_tail == map)

--- a/hybris/common/jb/linker.c
+++ b/hybris/common/jb/linker.c
@@ -172,27 +172,11 @@ static struct link_map *r_debug_tail = 0;
 
 static pthread_mutex_t _r_debug_lock = PTHREAD_MUTEX_INITIALIZER;
 
-static int _is_android_debug_enabled() 
-{
-  static int _hybris_enable_android_debug = -1; // -1: not initialized
-  
-  if (_hybris_enable_android_debug == -1) {
-    _hybris_enable_android_debug = 0;
-    const char *env = getenv("HYBRIS_ENABLE_LINKER_DEBUG_MAP");
-    if (env != NULL)
-    {
-        if (strcmp(env, "1") == 0) {
-               _hybris_enable_android_debug = 1;
-        }
-    }
-  }
-  
-  return _hybris_enable_android_debug == 1;
-}
+static int _linker_enable_gdb_support = 0;
 
 static void insert_soinfo_into_debug_map(soinfo * info)
 {
-    if (!_is_android_debug_enabled()) return;
+    if (!_linker_enable_gdb_support) return;
 
     struct link_map * map;
 
@@ -252,7 +236,7 @@ static void insert_soinfo_into_debug_map(soinfo * info)
 
 static void remove_soinfo_from_debug_map(soinfo * info)
 {
-    if (!_is_android_debug_enabled()) return;
+    if (!_linker_enable_gdb_support) return;
     
     struct link_map * map = &(info->linkmap);
 
@@ -2397,10 +2381,11 @@ unsigned __linker_init(unsigned **elfdata) {
 }
 
 #ifdef WANT_ARM_TRACING
-void android_linker_init(int sdk_version, void *(get_hooked_symbol)(const char*, const char*), void *(create_wrapper)(const char*, void*, int)) {
+void android_linker_init(int sdk_version, void *(get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, void *(create_wrapper)(const char*, void*, int)) {
 #else
-void android_linker_init(int sdk_version, void *(get_hooked_symbol)(const char*, const char*)) {
+void android_linker_init(int sdk_version, void *(get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support) {
 #endif
    (void) sdk_version;
    _get_hooked_symbol = get_hooked_symbol;
+  _linker_enable_gdb_support = enable_linker_gdb_support;
 }

--- a/hybris/common/n/linker.cpp
+++ b/hybris/common/n/linker.cpp
@@ -4684,9 +4684,9 @@ static void __linker_cannot_link(KernelArgumentBlock& args) {
 }
 
 #ifdef WANT_ARM_TRACING
-extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), void *(create_wrapper)(const char*, void*, int)) {
+extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, void *(create_wrapper)(const char*, void*, int)) {
 #else
-extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*)) {
+extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support) {
 #endif
   // Get a few environment variables.
   const char* LD_DEBUG = getenv("HYBRIS_LD_DEBUG");
@@ -4711,6 +4711,7 @@ extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(
     set_application_target_sdk_version(sdk_version);
 
   _get_hooked_symbol = get_hooked_symbol;
+  _linker_enable_gdb_support = enable_linker_gdb_support;
 #ifdef WANT_ARM_TRACING
   _create_wrapper = create_wrapper;
 #endif

--- a/hybris/common/n/linker_gdb_support.cpp
+++ b/hybris/common/n/linker_gdb_support.cpp
@@ -33,26 +33,10 @@ r_debug _r_debug =
 static pthread_mutex_t g__r_debug_mutex = PTHREAD_MUTEX_INITIALIZER;
 static link_map* r_debug_head = nullptr;
 
-static int _is_android_debug_enabled() 
-{
-  static int _hybris_enable_android_debug = -1; // -1: not initialized
-  
-  if (_hybris_enable_android_debug == -1) {
-    _hybris_enable_android_debug = 0;
-    const char *env = getenv("HYBRIS_ENABLE_LINKER_DEBUG_MAP");
-    if (env != NULL)
-    {
-        if (strcmp(env, "1") == 0) {
-               _hybris_enable_android_debug = 1;
-        }
-    }
-  }
-  
-  return _hybris_enable_android_debug == 1;
-}
+int _hybris_enable_android_debug = 0;
 
 void insert_link_map_into_debug_map(link_map* map) {
-  if (!_is_android_debug_enabled()) return;
+  if (!_hybris_enable_android_debug) return;
         
   // Stick the new library at the end of the list.
   // gdb tends to care more about libc than it does
@@ -89,7 +73,7 @@ void insert_link_map_into_debug_map(link_map* map) {
 }
 
 void remove_link_map_from_debug_map(link_map* map) {
-  if (!_is_android_debug_enabled()) return;
+  if (!_hybris_enable_android_debug) return;
         
   if (r_debug_head == map) {
     r_debug_head = map->l_next;

--- a/hybris/common/n/linker_gdb_support.h
+++ b/hybris/common/n/linker_gdb_support.h
@@ -28,6 +28,7 @@ void notify_gdb_of_unload(link_map* map);
 void notify_gdb_of_libraries();
 
 extern struct r_debug _r_debug;
+extern int _linker_enable_gdb_support;
 
 __END_DECLS
 

--- a/hybris/common/o/linker_gdb_support.cpp
+++ b/hybris/common/o/linker_gdb_support.cpp
@@ -45,26 +45,11 @@ r_debug _r_debug =
 static pthread_mutex_t g__r_debug_mutex = PTHREAD_MUTEX_INITIALIZER;
 static link_map* r_debug_head = nullptr;
 
-static int _is_android_debug_enabled() 
-{
-  static int _hybris_enable_android_debug = -1; // -1: not initialized
-  
-  if (_hybris_enable_android_debug == -1) {
-    _hybris_enable_android_debug = 0;
-    const char *env = getenv("HYBRIS_ENABLE_LINKER_DEBUG_MAP");
-    if (env != NULL)
-    {
-        if (strcmp(env, "1") == 0) {
-               _hybris_enable_android_debug = 1;
-        }
-    }
-  }
-  
-  return _hybris_enable_android_debug == 1;
-}
+int _hybris_enable_android_debug = 0;
 
 void insert_link_map_into_debug_map(link_map* map) {
-  if (!_is_android_debug_enabled()) return;
+  if (!_hybris_enable_android_debug) return;
+        
 
   // Stick the new library at the end of the list.
   // gdb tends to care more about libc than it does
@@ -101,7 +86,8 @@ void insert_link_map_into_debug_map(link_map* map) {
 }
 
 void remove_link_map_from_debug_map(link_map* map) {
-  if (!_is_android_debug_enabled()) return;
+  if (!_hybris_enable_android_debug) return;
+        
 
   if (r_debug_head == map) {
     r_debug_head = map->l_next;

--- a/hybris/common/o/linker_gdb_support.cpp
+++ b/hybris/common/o/linker_gdb_support.cpp
@@ -45,7 +45,27 @@ r_debug _r_debug =
 static pthread_mutex_t g__r_debug_mutex = PTHREAD_MUTEX_INITIALIZER;
 static link_map* r_debug_head = nullptr;
 
+static int _is_android_debug_enabled() 
+{
+  static int _hybris_enable_android_debug = -1; // -1: not initialized
+  
+  if (_hybris_enable_android_debug == -1) {
+    _hybris_enable_android_debug = 0;
+    const char *env = getenv("HYBRIS_ENABLE_LINKER_DEBUG_MAP");
+    if (env != NULL)
+    {
+        if (strcmp(env, "1") == 0) {
+               _hybris_enable_android_debug = 1;
+        }
+    }
+  }
+  
+  return _hybris_enable_android_debug == 1;
+}
+
 void insert_link_map_into_debug_map(link_map* map) {
+  if (!_is_android_debug_enabled()) return;
+
   // Stick the new library at the end of the list.
   // gdb tends to care more about libc than it does
   // about leaf libraries, and ordering it this way
@@ -81,6 +101,8 @@ void insert_link_map_into_debug_map(link_map* map) {
 }
 
 void remove_link_map_from_debug_map(link_map* map) {
+  if (!_is_android_debug_enabled()) return;
+
   if (r_debug_head == map) {
     r_debug_head = map->l_next;
   }

--- a/hybris/common/o/linker_gdb_support.h
+++ b/hybris/common/o/linker_gdb_support.h
@@ -40,6 +40,7 @@ void notify_gdb_of_unload(link_map* map);
 void notify_gdb_of_libraries();
 
 extern struct r_debug _r_debug;
+extern int _linker_enable_gdb_support;
 
 __END_DECLS
 

--- a/hybris/common/o/linker_main.cpp
+++ b/hybris/common/o/linker_main.cpp
@@ -499,9 +499,9 @@ void* (*_get_hooked_symbol)(const char *sym, const char *requester);
 void *(*_create_wrapper)(const char *symbol, void *function, int wrapper_type);
 
 #ifdef WANT_ARM_TRACING
-extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), void *(create_wrapper)(const char*, void*, int)) {
+extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, void *(create_wrapper)(const char*, void*, int)) {
 #else
-extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*)) {
+extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support) {
 #endif
   // Get a few environment variables.
   const char* LD_DEBUG = getenv("HYBRIS_LD_DEBUG");
@@ -526,6 +526,7 @@ extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(
     set_application_target_sdk_version(sdk_version);
 
   _get_hooked_symbol = get_hooked_symbol;
+  _linker_enable_gdb_support = enable_linker_gdb_support;
 #ifdef WANT_ARM_TRACING
   _create_wrapper = create_wrapper;
 #endif


### PR DESCRIPTION
There are still some conflicts between android libs and glibc libs in the
gdb lib map.

Very likely, in most cases, the developer only wants to debug the glibc
related code, and is not interested in seeing the Android stack.
Therefore, introduce an env. variable and disable linking of android
libs by default.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>