### PR TITLE
eglplatform_wayland: load libEGL at runtime

### DIFF
--- a/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
+++ b/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
@@ -36,6 +36,7 @@
 #include <unistd.h>
 #include <assert.h>
 #include <stdlib.h>
+#include <dlfcn.h>
 extern "C" {
 #include <eglplatformcommon.h>
 };
@@ -60,6 +61,13 @@ static __eglMustCastToProperFunctionPointerType (*_eglGetProcAddress)(const char
 static EGLSyncKHR (*_eglCreateSyncKHR)(EGLDisplay dpy, EGLenum type, const EGLint *attrib_list) = NULL;
 static EGLBoolean (*_eglDestroySyncKHR)(EGLDisplay dpy, EGLSyncKHR sync) = NULL;
 static EGLint (*_eglClientWaitSyncKHR)(EGLDisplay dpy, EGLSyncKHR sync, EGLint flags, EGLTimeKHR timeout) = NULL;
+
+/* The following function is implemented in libhybris's libEGL.so.
+ * However, eglplatform_wayland.so is not linking to libEGL directly,
+ * causing undefined symbol errors during loading, if libEGL was not
+ * already loaded by some other dependencies. Therefore, we should try
+ * to load libEGL at runtime here and resolve this function dynamically */
+typedef struct _EGLDisplay *(*PFNHYBRISEGLDISPLAYGETMAPPINGPROC)(EGLDisplay dpy);
 
 struct WaylandDisplay {
 	_EGLDisplay base;
@@ -202,6 +210,36 @@ extern "C" int waylandws_post(EGLNativeWindowType win, void *buffer)
 	return ((WaylandNativeWindow *) eglwin->nativewindow)->postBuffer((ANativeWindowBuffer *) buffer);
 }
 
+/**
+ * Loads libhybris's libEGL at runtime to call hybris_egl_display_get_mapping()
+ */
+static struct _EGLDisplay *_hybris_egl_display_get_mapping(EGLDisplay dpy)
+{
+	static void *libEGL_handle = NULL;
+	static PFNHYBRISEGLDISPLAYGETMAPPINGPROC hybris_egl_display_get_mapping_fn = NULL;
+
+	if (!libEGL_handle) {
+		dlerror();  // cleanup error buffer
+		libEGL_handle = dlopen("libEGL.so.1", RTLD_NOW | RTLD_GLOBAL);
+		if (!libEGL_handle) {
+			HYBRIS_ERROR("ERROR: Failed to dlopen libEGL! %s", dlerror());
+			abort();
+		}
+	}
+
+	if (!hybris_egl_display_get_mapping_fn) {
+		dlerror();  // cleanup error buffer
+		hybris_egl_display_get_mapping_fn = (PFNHYBRISEGLDISPLAYGETMAPPINGPROC)dlsym(
+			libEGL_handle, "hybris_egl_display_get_mapping");
+		if (!hybris_egl_display_get_mapping_fn) {
+			HYBRIS_ERROR("ERROR: Cannot resolve 'hybris_egl_display_get_mapping' in libEGL! %s", dlerror());
+			abort();
+		}
+	}
+	
+	return hybris_egl_display_get_mapping_fn(dpy);
+}
+
 extern "C" wl_buffer *waylandws_createWlBuffer(EGLDisplay dpy, EGLImageKHR image)
 {
 	egl_image *img = reinterpret_cast<egl_image *>(image);
@@ -211,7 +249,7 @@ extern "C" wl_buffer *waylandws_createWlBuffer(EGLDisplay dpy, EGLImageKHR image
 	    return NULL;
 	}
 	if (img->target == EGL_WAYLAND_BUFFER_WL) {
-		WaylandDisplay *wdpy = (WaylandDisplay *)hybris_egl_display_get_mapping(dpy);
+		WaylandDisplay *wdpy = (WaylandDisplay *)_hybris_egl_display_get_mapping(dpy);
 		server_wlegl_buffer *buf = server_wlegl_buffer_from((wl_resource *)img->egl_buffer);
 		WaylandNativeWindowBuffer wnb(buf->buf);
 		// The buffer will be managed by the app, so pass NULL as the queue so that


### PR DESCRIPTION
`hybris_egl_display_get_mapping()`  function is implemented
in libhybris's libEGL.so. However, eglplatform_wayland.so
is not linked to libEGL directly, causing undefined symbol
errors during loading, if libEGL was not already loaded by
some other dependencies. Therefore, we should try
to load libEGL at runtime here and resolve this function
dynamically.

Error is seen at startup of Plasma Mobile in postmarketOS, for example:
```
klte:~$ cat /tmp/plasmashell_logs 
Error: could not determine $DISPLAY.
org.kde.kwindowsystem: Loaded plugin "/usr/lib/qt5/plugins/kf5/org.kde.kwindowsystem.platforms/KF5WindowSystemKWaylandPlugin.so" for platform "wayland"
Using Wayland-EGL
ERROR: /usr/lib/libhybris/eglplatform_wayland.so
        Error relocating /usr/lib/libhybris/eglplatform_wayland.so: hybris_egl_display_get_mapping: symbol not found
Assertion failed: 0 (ws.c: _init_ws: 49)
KCrash: Attempting to start /usr/bin/plasmashell from kdeinit
Warning: connect() failed: : Connection refused
KCrash: Attempting to start /usr/bin/plasmashell directly
KCrash: Application 'plasmashell' crashing...
org.kde.kwindowsystem: Loaded plugin "/usr/lib/qt5/plugins/kf5/org.kde.kwindowsystem.platforms/KF5WindowSystemKWaylandPlugin.so" for platform "wayland"
Using Wayland-EGL
ERROR: /usr/lib/libhybris/eglplatform_wayland.so
        Error relocating /usr/lib/libhybris/eglplatform_wayland.so: hybris_egl_display_get_mapping: symbol not found
Assertion failed: 0 (ws.c: _init_ws: 49)
```

Some googling and talking to people reveals that this problem is known at least since year 2017:

```
Jan 23 17:01:21 <NotKit> Using Wayland-EGL … ERROR: /usr/lib/libhybris/eglplatform_wayland.so …
    Error relocating /usr/lib/libhybris/eglplatform_wayland.so: hybris_egl_display_get_mapping: symbol not found
Jan 23 17:01:25 <NotKit> oh, that famous issue
Jan 23 17:01:53 <bhushanshah> huh?
Jan 23 17:02:18 <NotKit> I think that also happened on Arch
Jan 23 17:02:34 <bhushanshah> do you know solution?
Jan 23 17:04:52 <NotKit> I remember that it required linker arguments change during libhybris build
Jan 23 17:05:24 <NotKit> used export LD_PRELOAD=/usr/lib/libEGL.so.1.0.0 as quick hack
```
http://www.merproject.org/logs/%23sailfishos-porters/%23sailfishos-porters.2017-10-01.log.html :
```
krnlyng    bshah, try adding -lEGL to LDFLAGS of hybris/egl/platforms/wayland/Makefile.am
```

But suggested solutions are not real solutions, but only a workarounds. True solution is using `dlopen()`, because as I understand, platform plugins are not supposed to be linked directly to egl implementation. And by the way, in libhybris buildsystem libEGL itself is built *after* egl_platform plugins.

-------------------------------------------------
Bug was originally reported at https://gitlab.com/postmarketOS/pmaports/issues/347