### PR TITLE
eglplatform: increase eglextensionsbuf

### DIFF
--- a/hybris/egl/platforms/common/eglplatformcommon.cpp
+++ b/hybris/egl/platforms/common/eglplatformcommon.cpp
@@ -335,8 +335,8 @@ extern "C" const char *eglplatformcommon_eglQueryString(EGLDisplay dpy, EGLint n
 	if (name == EGL_EXTENSIONS)
 	{
 		const char *ret = (*real_eglQueryString)(dpy, name);
-		static char eglextensionsbuf[1024];
-		snprintf(eglextensionsbuf, 1022, "%sEGL_HYBRIS_native_buffer2 EGL_HYBRIS_WL_acquire_native_buffer %s", ret ? ret : "",
+		static char eglextensionsbuf[2048];
+		snprintf(eglextensionsbuf, 2046, "%sEGL_HYBRIS_native_buffer2 EGL_HYBRIS_WL_acquire_native_buffer %s", ret ? ret : "",
 #ifdef WANT_WAYLAND
 			"EGL_WL_bind_wayland_display "
 #else

--- a/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
+++ b/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
@@ -285,8 +285,8 @@ extern "C" const char *waylandws_eglQueryString(EGLDisplay dpy, EGLint name, con
 	const char *ret = eglplatformcommon_eglQueryString(dpy, name, real_eglQueryString);
 	if (ret && name == EGL_EXTENSIONS)
 	{
-		static char eglextensionsbuf[1024];
-		snprintf(eglextensionsbuf, 1022, "%s %s", ret,
+		static char eglextensionsbuf[2048];
+		snprintf(eglextensionsbuf, 2046, "%s %s", ret,
 			"EGL_EXT_swap_buffers_with_damage EGL_WL_create_wayland_buffer_from_image"
 		);
 		ret = eglextensionsbuf;


### PR DESCRIPTION
Increased to fit the extensions on Sony Tama/Akari.

On that device, I had maximal length of strings equal to

```
eglplatformcommon_eglQueryString max string length: 1060
waylandws_eglQueryString max string length: 1133
```