### PR TITLE
Remove unnecessary header

### DIFF
--- a/hybris/include/hybris/properties/properties.h
+++ b/hybris/include/hybris/properties/properties.h
@@ -25,8 +25,6 @@
 #include <unistd.h>
 #include <stdint.h>
 
-#include <android-config.h>
-
 /* Based on Android */
 #define PROP_SERVICE_NAME "property_service"
 


### PR DESCRIPTION
This removes a unnecessary header that got included in properties.h, as
hybris_properties.c does not include this file there is no reason
libraries that link to it should.

Also libandroid-properties.pc does not require this, so builds depending
on properties will fail to build.