### PR TITLE
Prioritize library path set by HYBRIS_LD_LIBRARY_PATH environment variable

### DIFF
--- a/hybris/common/mm/linker.cpp
+++ b/hybris/common/mm/linker.cpp
@@ -3231,10 +3231,10 @@ static ElfW(Addr) __linker_init_post_relocation(KernelArgumentBlock& args, ElfW(
   }
 
   // Use LD_LIBRARY_PATH and LD_PRELOAD (but only if we aren't setuid/setgid).
-  if (DEFAULT_HYBRIS_LD_LIBRARY_PATH)
-    parse_LD_LIBRARY_PATH(DEFAULT_HYBRIS_LD_LIBRARY_PATH);
-  else
+  if (ldpath_env)
     parse_LD_LIBRARY_PATH(ldpath_env);
+  else
+    parse_LD_LIBRARY_PATH(DEFAULT_HYBRIS_LD_LIBRARY_PATH);
   parse_LD_PRELOAD(ldpreload_env);
 
   somain = si;
@@ -3384,10 +3384,10 @@ extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(
     ldpreload_env = getenv("HYBRIS_LD_PRELOAD");
   }
 
-  if (DEFAULT_HYBRIS_LD_LIBRARY_PATH)
-    parse_LD_LIBRARY_PATH(DEFAULT_HYBRIS_LD_LIBRARY_PATH);
-  else
+  if (ldpath_env)
     parse_LD_LIBRARY_PATH(ldpath_env);
+  else
+    parse_LD_LIBRARY_PATH(DEFAULT_HYBRIS_LD_LIBRARY_PATH);
   parse_LD_PRELOAD(ldpreload_env);
 
   if (sdk_version > 0)

--- a/hybris/common/n/linker.cpp
+++ b/hybris/common/n/linker.cpp
@@ -4561,10 +4561,10 @@ static ElfW(Addr) __linker_init_post_relocation(KernelArgumentBlock& args, ElfW(
 #endif
 
   // Use LD_LIBRARY_PATH and LD_PRELOAD (but only if we aren't setuid/setgid).
-  if (DEFAULT_HYBRIS_LD_LIBRARY_PATH)
-    parse_LD_LIBRARY_PATH(DEFAULT_HYBRIS_LD_LIBRARY_PATH);
-  else
+  if (ldpath_env)
     parse_LD_LIBRARY_PATH(ldpath_env);
+  else
+    parse_LD_LIBRARY_PATH(DEFAULT_HYBRIS_LD_LIBRARY_PATH);
   parse_LD_PRELOAD(ldpreload_env);
   parse_LD_SHIM_LIBS(ldshim_libs_env);
 
@@ -4719,10 +4719,10 @@ extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(
     ldpreload_env = getenv("HYBRIS_LD_PRELOAD");
   }
 
-  if (DEFAULT_HYBRIS_LD_LIBRARY_PATH)
-    parse_LD_LIBRARY_PATH(DEFAULT_HYBRIS_LD_LIBRARY_PATH);
-  else
+  if (ldpath_env)
     parse_LD_LIBRARY_PATH(ldpath_env);
+  else
+    parse_LD_LIBRARY_PATH(DEFAULT_HYBRIS_LD_LIBRARY_PATH);
   parse_LD_PRELOAD(ldpreload_env);
 
   if (sdk_version > 0)

--- a/hybris/common/o/linker_main.cpp
+++ b/hybris/common/o/linker_main.cpp
@@ -340,10 +340,10 @@ static ElfW(Addr) __linker_init_post_relocation(KernelArgumentBlock& args) {
   }
 
   // Use LD_LIBRARY_PATH and LD_PRELOAD (but only if we aren't setuid/setgid).
-  if (DEFAULT_HYBRIS_LD_LIBRARY_PATH)
-    parse_LD_LIBRARY_PATH(DEFAULT_HYBRIS_LD_LIBRARY_PATH);
-  else
+  if (ldpath_env)
     parse_LD_LIBRARY_PATH(ldpath_env);
+  else
+    parse_LD_LIBRARY_PATH(DEFAULT_HYBRIS_LD_LIBRARY_PATH);
   parse_LD_PRELOAD(ldpreload_env);
 
   somain = si;
@@ -516,10 +516,10 @@ extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(
     ldpreload_env = getenv("HYBRIS_LD_PRELOAD");
   }
 
-  if (DEFAULT_HYBRIS_LD_LIBRARY_PATH)
-    parse_LD_LIBRARY_PATH(DEFAULT_HYBRIS_LD_LIBRARY_PATH);
-  else
+  if (ldpath_env)
     parse_LD_LIBRARY_PATH(ldpath_env);
+  else
+    parse_LD_LIBRARY_PATH(DEFAULT_HYBRIS_LD_LIBRARY_PATH);
   parse_LD_PRELOAD(ldpreload_env);
 
   if (sdk_version > 0)


### PR DESCRIPTION
When HYBRIS_LD_LIBRARY_PATH is set and security conditions are met, prefer the library path set by that variable. Otherwise, use the path from DEFAULT_HYBRIS_LD_LIBRARY_PATH.

It seems to me that this was original intention in the provided linkers and is as it is done in `hybris/common/jb/linker.c`. 

This PR allows to set the environment as in Flatpak sandbox and use it for accessing GL and other drivers.