### PR TITLE
egl: wayland: Remove additional space before EGL_EXT

### DIFF
--- a/hybris/egl/platforms/common/eglplatformcommon.cpp
+++ b/hybris/egl/platforms/common/eglplatformcommon.cpp
@@ -336,13 +336,7 @@ extern "C" const char *eglplatformcommon_eglQueryString(EGLDisplay dpy, EGLint n
 	{
 		const char *ret = (*real_eglQueryString)(dpy, name);
 		static char eglextensionsbuf[2048];
-		snprintf(eglextensionsbuf, 2046, "%sEGL_HYBRIS_native_buffer2 EGL_HYBRIS_WL_acquire_native_buffer %s", ret ? ret : "",
-#ifdef WANT_WAYLAND
-			"EGL_WL_bind_wayland_display "
-#else
-			""
-#endif
-		);
+		snprintf(eglextensionsbuf, 2046, "%sEGL_HYBRIS_native_buffer2 EGL_HYBRIS_WL_acquire_native_buffer EGL_WL_bind_wayland_display", ret ? ret : "");
 		ret = eglextensionsbuf;
 		return ret;
 	}


### PR DESCRIPTION
The string returned by eglplatformcommon_eglQueryString already ends with a space,
adding an additional one causes crashes (tested on a PowerVR device).

Before:
An additional space was visible before EGL_EXT_swap_buffers_with_damage.
<img src="https://user-images.githubusercontent.com/13609393/76711806-39347480-6713-11ea-8a0a-57980ad7ac00.jpg" width=300 />
After:
<img src="https://user-images.githubusercontent.com/13609393/76711787-12763e00-6713-11ea-929c-bc02fbe26340.jpg" width=300 />

This probably needs verification on other devices