### PR TITLE
hybris: hwc2: avoid crash in hwc2_compat_display_present

### DIFF
--- a/compat/hwc2/hwc2_compatibility_layer.cpp
+++ b/compat/hwc2/hwc2_compatibility_layer.cpp
@@ -214,7 +214,11 @@ hwc2_error_t hwc2_compat_display_present(hwc2_compat_display_t* display,
     android::sp<android::Fence> presentFence;
     HWC2::Error error = display->self->present(&presentFence);
 
-    *outPresentFence = presentFence->dup();
+    if (presentFence != NULL) {
+        *outPresentFence = presentFence->dup();
+    } else {
+        *outPresentFence = -1;
+    }
 
     return static_cast<hwc2_error_t>(error);
 }


### PR DESCRIPTION
Check if presentFence is a valid pointer before calling dup(), which can happen if HWC2::Display::present() fails for some reason.

Tested to fix random lipstick crashes on Redmi Note 7 (lavender).