### PR TITLE
hybris: fix crash when gralloc1 not supported on the device

### DIFF
--- a/hybris/gralloc/gralloc.c
+++ b/hybris/gralloc/gralloc.c
@@ -84,7 +84,8 @@ void hybris_gralloc_initialize(int framebuffer)
     if (version == -1) {
         if (hw_get_module(GRALLOC_HARDWARE_MODULE_ID, (const struct hw_module_t **)&gralloc_hardware_module) == 0) {
 #if HAS_GRALLOC1_HEADER
-            if ((gralloc1_open(gralloc_hardware_module, &gralloc1_device) == 0) && (gralloc1_device != NULL)) {
+            uint8_t majorVersion = (gralloc_hardware_module->module_api_version >> 8) & 0xFF;
+            if ((majorVersion == 1) && (gralloc1_open(gralloc_hardware_module, &gralloc1_device) == 0) && (gralloc1_device != NULL)) {
                 // success
                 gralloc1_init();
                 version = 1;


### PR DESCRIPTION
If HAS_GRALLOC1_HEADER is defined but the device doesn't actually
support gralloc1 then `gralloc1_open` may succeed but the callbacks in
the structure are all NULL. Check the `module_api_version` field before
calling `gralloc1_open` following `Loader::Loader()` in
frameworks/native/libs/ui/Gralloc1.cpp. This fixes a segfault with the
binary libs for Samsung herolte.