### PR TITLE
hybris: fix out of tree builds

### DIFF
--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -74,9 +74,9 @@ AM_CONDITIONAL( [WANT_MESA], [test x"$mesa" = x"yes"])
 
 AC_ARG_ENABLE(ubuntu-camera-headers,
   [  --enable-ubuntu-camera-headers            Enable Ubuntu camera headers (default=disabled)],
-  [ubuntu-camera-headers=$enableval],
-  [ubuntu-camera-headers="no"])
-AM_CONDITIONAL( [WANT_UBUNTU_CAMERA_HEADERS], [test x"$ubuntu-camera-headers" = x"yes"])
+  [ubuntu_camera_headers=$enableval],
+  [ubuntu_camera_headers="no"])
+AM_CONDITIONAL( [WANT_UBUNTU_CAMERA_HEADERS], [test x"$ubuntu_camera_headers" = x"yes"])
 
 AC_ARG_ENABLE(wayland,
   [  --enable-wayland            Enable wayland support (default=disabled)],

--- a/hybris/properties/Makefile.am
+++ b/hybris/properties/Makefile.am
@@ -12,7 +12,7 @@ endif
 libandroid_properties_la_CFLAGS += -I$(top_srcdir)/include
 
 libandroid_properties_la_LDFLAGS = \
-	$(top_srcdir)/common/libhybris-common.la \
+	$(top_builddir)/common/libhybris-common.la \
 	-version-info "1":"0":"0"
 
 pkgconfigdir = $(libdir)/pkgconfig


### PR DESCRIPTION
The `.la` path should be relative to the build directory not source.
Also fix invalid shell variable name `ubuntu-camera-headers`.