### PR TITLE
Prevent race condition on multi thread init of ws. Solves #443

### DIFF
--- a/hybris/egl/ws.c
+++ b/hybris/egl/ws.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <sys/auxv.h>
 #include <pthread.h>
+#include <string.h>
 
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -46,6 +47,10 @@ static void _init_ws()
 			egl_platform=getenv("EGL_PLATFORM");
 
 		if (egl_platform == NULL)
+			egl_platform = DEFAULT_EGL_PLATFORM;
+
+		// The env variables may be defined yet empty
+		if (!strcmp(egl_platform, ""))
 			egl_platform = DEFAULT_EGL_PLATFORM;
 
 		const char *eglplatform_dir = PKGLIBDIR;

--- a/hybris/egl/ws.c
+++ b/hybris/egl/ws.c
@@ -33,8 +33,10 @@ static void _init_ws()
 	if (ws == NULL)
 	{
 		pthread_mutex_lock(&mutex);
-		if (ws != NULL)
+		if (ws != NULL) {
+			pthread_mutex_unlock(&mutex);
 			return;
+		}
 
 		char ws_name[2048];
 		char *egl_platform;

--- a/hybris/egl/ws.c
+++ b/hybris/egl/ws.c
@@ -21,6 +21,9 @@
 #include <assert.h>
 #include <stdio.h>
 #include <sys/auxv.h>
+#include <pthread.h>
+
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static struct ws_module *ws = NULL;
 
@@ -28,6 +31,10 @@ static void _init_ws()
 {
 	if (ws == NULL)
 	{
+		pthread_mutex_lock(&mutex);
+		if (ws != NULL)
+			return;
+
 		char ws_name[2048];
 		char *egl_platform;
 
@@ -59,6 +66,8 @@ static void _init_ws()
 		ws = dlsym(wsmod, "ws_module_info");
 		assert(ws != NULL);
 		ws->init_module(&hybris_egl_interface);
+
+		pthread_mutex_unlock(&mutex);
 	}
 }
 


### PR DESCRIPTION
These commits solve two issues:

1. Solves #443 where a multi threaded call to `_init_ws` (while another thread has not yet completed `_init_ws`) leads to a second call of `hybris_gralloc_initialize` which then fails because it has already completed the initialization of the gralloc module.

2. Solves subsequent crashes of `kdeinit` because `HYBRIS_EGLPLATFORM` is reset to "" but it is not unset (it's still defined). This leads to `_init_ws` trying to load the file `eglplatform_.so` which obviously does not exist.
Therefore, fallback to the default EGL platform in case the environment variable is defined but empty.