### PR TITLE
compat: fix compilation on Android 5 or lower

### DIFF
--- a/compat/camera/camera_compatibility_layer.cpp
+++ b/compat/camera/camera_compatibility_layer.cpp
@@ -141,10 +141,12 @@ void CameraControl::postDataTimestamp(
 	(void) data;
 }
 
+#if ANDROID_VERSION_MAJOR >= 7
 void CameraControl::postRecordingFrameHandleTimestamp(nsecs_t /*timestamp*/, native_handle_t* /*handle*/)
 {
 	REPORT_FUNCTION();
 }
+#endif
 
 #if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=3
 namespace android

--- a/compat/media/media_recorder.cpp
+++ b/compat/media/media_recorder.cpp
@@ -34,7 +34,9 @@
 #include <media/mediaplayer.h>  // for MEDIA_ERROR_SERVER_DIED
 #include <gui/IGraphicBufferProducer.h>
 namespace a = android;
+#if ANDROID_VERSION_MAJOR >= 7
 namespace ah = android::hardware;
+#endif
 
 #if ANDROID_VERSION_MAJOR >= 7
 a::status_t a::MediaRecorder::setCamera(const sp<ah::ICamera>& camera, const sp<ICameraRecordingProxy>& proxy)


### PR DESCRIPTION
postRecordingFrameHandleTimestamp has been ifdef'ed in camera_control.h
but not in camera_compatibility_layer.cpp, which cause "no member
function declared" compile error on Android 5. Add the matching ifdef to
fix it.

Namespace android::hardware doesn't exist on Android 5 or lower. Ifdef
the namespace alias to fix compilation.

Change-Id: I903b66116d35cb9851d88f0723a434bce8f84b04