### PR TITLE
hybris: hook __cxa_thread_atexit (wrap dtor)

### DIFF
--- a/hybris/common/Makefile.am
+++ b/hybris/common/Makefile.am
@@ -26,6 +26,7 @@ libhybris_common_la_SOURCES = \
 	strlcat.c \
 	logging.c \
 	sysconf.c \
+	dso_handle_counters.cpp \
 	legacy_properties/properties.c \
 	legacy_properties/cache.c
 
@@ -87,10 +88,15 @@ endif
 if HAS_ANDROID_8_0_0
 libhybris_common_la_CPPFLAGS += -DWANT_LINKER_O
 endif
+
+libhybris_common_la_CXXFLAGS = \
+	-std=gnu++11
+
 libhybris_common_la_LDFLAGS = \
 	-ldl \
 	-lrt \
 	-pthread \
 	-lc \
 	-lstdc++ \
+	-lpthread \
 	-version-info "$(LT_CURRENT)":"$(LT_REVISION)":"$(LT_AGE)"

--- a/hybris/common/dso_handle_counters.cpp
+++ b/hybris/common/dso_handle_counters.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2020 UBports Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <unordered_map>
+#include <mutex>
+
+#include <dlfcn.h>
+#include <hybris/common/dlfcn.h>
+
+#include "logging.h"
+#define LOGD(message, ...) HYBRIS_DEBUG_LOG(HOOKS, message, ##__VA_ARGS__)
+
+#include "dso_handle_counters.h"
+
+/*
+ * This file implements a reference-counting system for dso_handle symbols
+ * having outstanding thread-local variables. This is inspired by an
+ * implementation in Android's linker, but instead of using internal Linker
+ * mechanism, this file uses public linker functions to find the library and
+ * dlload() it to increment reference count.
+ *
+ * This file is implemented in C++ so that I can use C++'s unordered_map.
+ *
+ * See https://github.com/aosp-mirror/platform_bionic/commit/55547db4345ee692b9cfe727c97dd860ed8263f8
+ */
+
+struct DsoHandleInfo {
+    size_t counter;
+    void *dl_handle;
+};
+
+static std::unordered_map<void*, struct DsoHandleInfo *> g_dso_handle_counters;
+static std::mutex g_dso_handle_counters_mutex;
+
+void __hybris_add_thread_local_dtor(void* dso_handle)
+{
+    if (dso_handle == nullptr) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> l(g_dso_handle_counters_mutex);
+
+    auto it = g_dso_handle_counters.find(dso_handle);
+    if (it != g_dso_handle_counters.end()) {
+        ++it->second->counter;
+    } else {
+        Dl_info dso_symbol_info;
+
+        if (hybris_dladdr(dso_handle, &dso_symbol_info)) {
+            struct DsoHandleInfo *info = new struct DsoHandleInfo;
+            info->counter = 1U;
+            info->dl_handle = hybris_dlopen(dso_symbol_info.dli_fname, /* flags */ 0);
+
+            g_dso_handle_counters[dso_handle] = info;
+        } else {
+            LOGD(
+                "__hybris_add_thread_local_dtor: Couldn't find a library by dso_handle=%p",
+                dso_handle);
+            // Nothing we can do.
+        }
+    }
+}
+
+void __hybris_remove_thread_local_dtor(void* dso_handle)
+{
+    if (dso_handle == nullptr) {
+        return;
+    }
+
+    // Do dlclose() outside the lock to avoid deadlock.
+    struct DsoHandleInfo *info = nullptr;
+
+    {
+        std::lock_guard<std::mutex> l(g_dso_handle_counters_mutex);
+
+        auto it = g_dso_handle_counters.find(dso_handle);
+
+        if (it == g_dso_handle_counters.end()) {
+            LOGD(
+                "__hybris_remove_thread_local_dtor: Couldn't find a library by dso_handle=%p",
+                dso_handle);
+            return;
+        }
+
+        if (--it->second->counter == 0) {
+            info = it->second;
+            g_dso_handle_counters.erase(it);
+        }
+    }
+
+    if (info) {
+        hybris_dlclose(info->dl_handle);
+        delete info;
+    }
+}

--- a/hybris/common/dso_handle_counters.h
+++ b/hybris/common/dso_handle_counters.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Intel Corporation
+ * Copyright (C) 2020 UBports Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,23 +15,18 @@
  *
  */
 
-#ifndef _HYBRIS_DLFCN_H_
-#define _HYBRIS_DLFCN_H_
+#ifndef _HYBRIS_DSO_HANDLE_COUNTERS_H_
+#define _HYBRIS_DSO_HANDLE_COUNTERS_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void *hybris_dlopen(const char *filename, int flag);
-void *hybris_dlsym(void *handle, const char *symbol);
-int   hybris_dlclose(void *handle);
-char *hybris_dlerror(void);
-int   hybris_dladdr(const void *addr, void *info);
+void __hybris_add_thread_local_dtor(void* dso_handle);
+void __hybris_remove_thread_local_dtor(void* dso_handle);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // _HYBRIS_DLFCN_H_
-
-// vim: noai:ts=4:sw=4:ss=4:expandtab
+#endif // _HYBRIS_DSO_HANDLE_COUNTERS_H_


### PR DESCRIPTION
This function is used by the compiler to destruct `thread_local`
variables at thread's exit. Virtually no one uses it, but I planed to
use to solve libmedia_compat_layer's problem when using remote codec.

This implementation wraps dtor so that we can do reference counting.
This prevents memory leak when a library is dlclose'd, at the expense
of more memory usage and more code to execute.

For an implementation that doesn't wrap dtor, see #456.