### PR TITLE
hooks: remove __attribute__((packed)) from struct bionic_file

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -1387,7 +1387,7 @@ struct bionic_sbuf {
 typedef off_t bionic_fpos_t;
 
 /* "struct __sFILE" from bionic/libc/include/stdio.h */
-struct __attribute__((packed)) bionic_file {
+struct bionic_file {
     unsigned char *_p;      /* current position in (some) buffer */
     int _r;                 /* read space left for getc() */
     int _w;                 /* write space left for putc() */


### PR DESCRIPTION
Bionic does not have this attribute for struct __sFILE definition. Fixes struct size mismatch on aarch64 (used to be 144 vs 152 on Android), which resulted in crash of code using stdout/stderr symbols like fprintf(stderr, ...) found in MTK audio HAL.

Thanks to @krnlyng for noticing this.