### PR TITLE
Fix handling max buffer count. JB#51520

### DIFF
--- a/hybris/egl/platforms/common/nativewindowbase.cpp
+++ b/hybris/egl/platforms/common/nativewindowbase.cpp
@@ -275,6 +275,9 @@ const char *BaseNativeWindow::_native_query_operation(int what)
                 case NATIVE_WINDOW_IS_VALID: return "NATIVE_WINDOW_IS_VALID";
                 case NATIVE_WINDOW_BUFFER_AGE: return "NATIVE_WINDOW_BUFFER_AGE";
 #endif
+#if ANDROID_VERSION_MAJOR>=9
+                case NATIVE_WINDOW_MAX_BUFFER_COUNT: return "NATIVE_WINDOW_MAX_BUFFER_COUNT";
+#endif
 		default: return "NATIVE_UNKNOWN_QUERY";
 	}
 }
@@ -327,6 +330,13 @@ int BaseNativeWindow::_query(const struct ANativeWindow* window, int what, int* 
 		case NATIVE_WINDOW_BUFFER_AGE:
 			// sure :)
 			*value = 2;
+			return NO_ERROR;
+#endif
+#if ANDROID_VERSION_MAJOR>=9
+		case NATIVE_WINDOW_MAX_BUFFER_COUNT:
+			// The default maximum count of BufferQueue items.
+			// See android::BufferQueueDefs::NUM_BUFFER_SLOTS.
+			*value = 64;
 			return NO_ERROR;
 #endif
 	}


### PR DESCRIPTION
Fix handling requests for NATIVE_WINDOW_MAX_BUFFER_COUNT
in functions _query() and _native_query_operation()
what is required in Android 8 and newer.