### PR TITLE
[egl] Set buffer dimensions on window resize. JB#52698

### DIFF
--- a/hybris/egl/platforms/wayland/wayland_window.cpp
+++ b/hybris/egl/platforms/wayland/wayland_window.cpp
@@ -89,8 +89,8 @@ void WaylandNativeWindowBuffer::wlbuffer_from_native_handle(struct android_wlegl
 void WaylandNativeWindow::resize(unsigned int width, unsigned int height)
 {
     lock();
-    this->m_defaultWidth = width;
-    this->m_defaultHeight = height;
+    this->m_defaultWidth = m_width = width;
+    this->m_defaultHeight = m_height = height;
     unlock();
 }
 


### PR DESCRIPTION
Some EGL implementations rightfully doesn't ask the default width
and height of the NativeWindow until transform hint changes, so
SET_BUFFERS_DIMENSIONS is never called. This results in the EGL
surface not being resized when wl_egl_window_resize() is called on
the window.

With this commit WaylandNativeWindow::resize() will set both default
and current dimensions and each buffer will be reallocated as soon as
it is dequeued.