### PR TITLE
Fix for devices which use qcom bsp and jb linker tracing.

### DIFF
--- a/hybris/common/Makefile.am
+++ b/hybris/common/Makefile.am
@@ -59,16 +59,6 @@ if WANT_ADRENO_QUIRKS
 libhybris_common_la_CPPFLAGS += -DWANT_ADRENO_QUIRKS
 endif
 
-if WANT_ARM_TRACING
-if WANT_ARCH_ARM
-# thumb mode not supported
-libhybris_common_la_CFLAGS += \
-	-marm
-libhybris_common_la_CPPFLAGS += \
-	-marm
-endif
-endif
-
 if WANT_TRACE
 libhybris_common_la_CPPFLAGS += -DDEBUG
 endif

--- a/hybris/common/wrapper_code.h
+++ b/hybris/common/wrapper_code.h
@@ -22,7 +22,10 @@
 extern "C" {
 #endif
 
-void wrapper_code_generic() __attribute__((naked,noinline));
+void wrapper_code_generic() __attribute__((naked,noinline)) __attribute__((target("arm")));
+#ifdef __arm__
+void wrapper_code_generic_thumb() __attribute__((naked,noinline)) __attribute__((target("thumb")));
+#endif
 
 #ifdef __cplusplus
 }

--- a/hybris/common/wrapper_code_generic_arm.c
+++ b/hybris/common/wrapper_code_generic_arm.c
@@ -137,3 +137,32 @@ wrapper_code_generic()
     );
 #endif
 }
+
+#ifdef __arm__
+void
+wrapper_code_generic_thumb()
+{
+    // we can never use r0-r11, neither the stack
+    asm volatile(
+        // preserve the registers
+        "push {r0-r11, lr}\n"
+
+        "ldr r0, tfun\n" // load the function pointer to r0
+        "ldr r1, tname\n" // load the address of the functions name to r1
+        "ldr r2, tstr\n" // load the string to print
+        "ldr r4, ttc\n" // load the address of trace_callback to r4
+        "blx r4\n" // call trace_callback
+
+        // restore the registers
+        "pop {r0-r11, lr}\n"
+        "ldr pc, tfun\n"     // jump to function
+
+        // dummy instructions, this is where we locate our pointers
+        "tname: .word 0xFFFFFFFF\n" // name of function to call
+        "tfun: .word 0xFFFFFFFF\n" // function to call
+        "ttc: .word 0xFFFFFFFF\n" // address of trace_callback
+        "tstr: .word 0xFFFFFFFF\n" // the string being printed in trace_callback
+    );
+}
+#endif
+

--- a/hybris/common/wrappers.c
+++ b/hybris/common/wrappers.c
@@ -107,6 +107,15 @@ void *create_wrapper(const char *symbol, void *function, int wrapper_type)
 #endif
     void *wrapper_addr = NULL;
     int helper = 0;
+    int thumb_fixup = 0;
+
+#ifdef __arm__
+    if ((uint32_t)function & 1) {
+        // thumb
+        wrapper_code = (void*)((uint32_t)wrapper_code_generic_thumb & 0xFFFFFFFE);
+        thumb_fixup = 1;
+    }
+#endif
 
     const char *msg = NULL;
 
@@ -176,7 +185,7 @@ void *create_wrapper(const char *symbol, void *function, int wrapper_type)
 
     register_wrapper(wrapper_addr, wrapper_size, symbol, wrapper_type);
 
-    return (void*)wrapper_addr;
+    return (void*)wrapper_addr + thumb_fixup;
 }
 
 void release_all_wrappers()

--- a/hybris/egl/platforms/wayland/wayland_window.cpp
+++ b/hybris/egl/platforms/wayland/wayland_window.cpp
@@ -26,6 +26,7 @@
 
 
 #include <android-config.h>
+#include <hardware/gralloc.h>
 #include "wayland_window.h"
 #include "wayland-egl-priv.h"
 #include <assert.h>

--- a/hybris/gralloc/gralloc.c
+++ b/hybris/gralloc/gralloc.c
@@ -1,3 +1,4 @@
+#include <android-config.h>
 #include <stdlib.h>
 
 #include <hardware/hardware.h>
@@ -12,7 +13,6 @@
 #ifdef ANDROID_BUILD
 #include "hybris-gralloc.h"
 #else
-#include <android-config.h>
 #include <hybris/gralloc/gralloc.h>
 #include <hybris/common/binding.h>
 #endif

--- a/hybris/include/hybris/gralloc/gralloc.h
+++ b/hybris/include/hybris/gralloc/gralloc.h
@@ -5,13 +5,8 @@
 extern "C" {
 #endif
 
-// for usage definitions and so on
-#if HAS_GRALLOC1_HEADER
-#include <hardware/gralloc1.h>
-#endif
-#include <hardware/gralloc.h>
-
 #include <cutils/native_handle.h>
+#include <system/window.h>
 
 void hybris_gralloc_deinitialize(void);
 void hybris_gralloc_initialize(int framebuffer);


### PR DESCRIPTION
While adding the gralloc1 support we broke devices which use QCOM_BSP.
This fixes it and adds tracing support to the jb linker.