### PR TITLE
Exclude test_camera if Wayland is not available

### DIFF
--- a/hybris/tests/Makefile.am
+++ b/hybris/tests/Makefile.am
@@ -8,7 +8,6 @@ bin_PROGRAMS = \
 	test_sensors \
 	test_input \
 	test_lights \
-	test_camera \
 	test_vibrator \
 	test_media \
 	test_recorder \
@@ -19,6 +18,10 @@ bin_PROGRAMS = \
 	test_nfc \
 	test_dlopen
 
+if WANT_WAYLAND
+bin_PROGRAMS += \
+	test_camera
+endif
 
 test_dlopen_SOURCES = test_dlopen.c
 test_dlopen_CFLAGS = \


### PR DESCRIPTION
If Wayland is not selected/available during the build, the compilation of `test_camera` fails because it relies on Wayland being available.