### PR TITLE
compat/media: fix handling of metadata in Android > 8

### DIFF
--- a/compat/media/media_buffer_layer.cpp
+++ b/compat/media/media_buffer_layer.cpp
@@ -159,7 +159,11 @@ MediaMetaDataWrapper* media_buffer_get_meta_data(MediaBufferWrapper *buffer)
     if (!d || !d->buffer)
         return NULL;
 
+#if ANDROID_VERSION_MAJOR>=8
+    return new MediaMetaDataPrivate(d->buffer);
+#else
     return new MediaMetaDataPrivate(d->buffer->meta_data());
+#endif
 }
 
 void media_buffer_set_return_callback(MediaBufferWrapper *buffer,

--- a/compat/media/media_meta_data_layer.cpp
+++ b/compat/media/media_meta_data_layer.cpp
@@ -33,9 +33,20 @@ MediaMetaDataPrivate* MediaMetaDataPrivate::toPrivate(MediaMetaDataWrapper *md)
 }
 
 MediaMetaDataPrivate::MediaMetaDataPrivate() :
+#if ANDROID_VERSION_MAJOR>=8
+    data(nullptr)
+#else
     data(new android::MetaData)
+#endif
 {
 }
+
+#if ANDROID_VERSION_MAJOR>=8
+MediaMetaDataPrivate::MediaMetaDataPrivate(android::MediaBufferBase *buffer) :
+    data(buffer)
+{
+}
+#endif
 
 MediaMetaDataPrivate::MediaMetaDataPrivate(const android::sp<android::MetaData> &md) :
     data(md)

--- a/compat/media/media_meta_data_priv.h
+++ b/compat/media/media_meta_data_priv.h
@@ -26,11 +26,58 @@ struct MediaMetaDataPrivate
 public:
     static MediaMetaDataPrivate* toPrivate(MediaMetaDataWrapper *md);
 
+#if ANDROID_VERSION_MAJOR>=8
+    struct MetaDataPtr {
+        MetaDataPtr(android::MediaBufferBase *buf = nullptr):
+            buffer(buf)
+        {
+            if (buffer) {
+                buffer->add_ref();
+                data = &buffer->meta_data();
+            } else {
+                data = new android::MetaDataBase;
+            }
+        }
+
+        MetaDataPtr(const android::sp<android::MetaData> &md):
+            buffer(nullptr),
+            data(new android::MetaDataBase(*md))
+        {
+        }
+
+        ~MetaDataPtr() {
+            if (buffer) {
+                buffer->release();
+                buffer = nullptr;
+                data = nullptr;
+            } else {
+                delete data;
+            }
+        }
+
+        inline android::MetaDataBase &operator*() const { return *data; }
+        inline android::MetaDataBase *operator->() const { return data; }
+        inline android::MetaDataBase *get() const { return data; }
+        inline operator android::MetaData *() { return new android::MetaData(*data); }
+
+    private:
+        android::MediaBufferBase *buffer;
+        android::MetaDataBase *data;
+    };
+#endif
+
     MediaMetaDataPrivate();
+#if ANDROID_VERSION_MAJOR>=8
+    MediaMetaDataPrivate(android::MediaBufferBase *buffer);
+#endif
     MediaMetaDataPrivate(const android::sp<android::MetaData> &md);
     ~MediaMetaDataPrivate();
 
+#if ANDROID_VERSION_MAJOR>=8
+    MetaDataPtr data;
+#else
     android::sp<android::MetaData> data;
+#endif
 };
 
 #endif


### PR DESCRIPTION
The metadata buffer is held as a member variable by the MediaBuffer
class, which returns it as a reference. We should not make a copy of it,
or any change we make to the metadata will be affecting only our local
copy.
This commit ensures that we only keep a pointer to the metadata object
which is associated with the given buffer. We also need to increase the
reference count of the buffer for the lifetime of our class, to ensure
it does not get destroyed while we are using it.

Change-Id: I87c82decb099936d9d2ac79148c1f2a7b0e7a382