### PR TITLE
hybris: tests: fix missing android-config.h include in test_common

### DIFF
--- a/hybris/tests/test_common.cpp
+++ b/hybris/tests/test_common.cpp
@@ -17,7 +17,7 @@
  *
  */
 
-#include "test_common.h"
+#include <android-config.h>
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Needed for ANDROID_VERSION_MAJOR/ANDROID_VERSION_MINOR defines. Fixes layer->planeAlpha not getting set.