### PR TITLE
Fix build on aarch64 devices

### DIFF
--- a/hybris/common/jb/linker.h
+++ b/hybris/common/jb/linker.h
@@ -38,7 +38,7 @@
 #define PAGE_SIZE 4096
 #define PAGE_MASK 4095
 
-#if defined(__x86_64__)
+#if defined(__x86_64__) || defined(__aarch64__)
 typedef Elf64_Ehdr Elf_Ehdr;
 typedef Elf64_Shdr Elf_Shdr;
 typedef Elf64_Sym  Elf_Sym;


### PR DESCRIPTION
If i build on aarch64 device i got
```
dlfcn.c: At top level:
dlfcn.c:220:17: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  220 |       st_value: (Elf_Addr) &android_dlopen,
      |                 ^
dlfcn.c:220:17: error: initializer element is not constant
dlfcn.c:220:17: note: (near initialization for 'libdl_symtab[1].st_value')
dlfcn.c:225:17: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  225 |       st_value: (Elf_Addr) &android_dlclose,
      |                 ^
dlfcn.c:225:17: error: initializer element is not constant
dlfcn.c:225:17: note: (near initialization for 'libdl_symtab[2].st_value')
dlfcn.c:230:17: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  230 |       st_value: (Elf_Addr) &android_dlsym,
      |                 ^
dlfcn.c:230:17: error: initializer element is not constant
dlfcn.c:230:17: note: (near initialization for 'libdl_symtab[3].st_value')
dlfcn.c:235:17: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  235 |       st_value: (Elf_Addr) &android_dlerror,
      |                 ^
dlfcn.c:235:17: error: initializer element is not constant
dlfcn.c:235:17: note: (near initialization for 'libdl_symtab[4].st_value')
dlfcn.c:240:17: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  240 |       st_value: (Elf_Addr) &android_dladdr,
      |                 ^
dlfcn.c:240:17: error: initializer element is not constant
dlfcn.c:240:17: note: (near initialization for 'libdl_symtab[5].st_value')
dlfcn.c:245:17: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  245 |       st_value: (Elf_Addr) &android_dl_iterate_phdr,
      |                 ^
dlfcn.c:245:17: error: initializer element is not constant
dlfcn.c:245:17: note: (near initialization for 'libdl_symtab[6].st_value')
dlfcn.c:251:17: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  251 |       st_value: (Elf_Addr) &android_dl_unwind_find_exidx,
      |                 ^
dlfcn.c:251:17: error: initializer element is not constant
dlfcn.c:251:17: note: (near initialization for 'libdl_symtab[7].st_value')
```