### PR TITLE
egl: don't crash if eglGetProcAddress is not available

### DIFF
--- a/hybris/egl/egl.c
+++ b/hybris/egl/egl.c
@@ -609,7 +609,7 @@ __eglMustCastToProperFunctionPointerType eglGetProcAddress(const char *procname)
 		ret = ws_eglGetProcAddress(procname);
 	}
 
-	if (ret == NULL) {
+	if (ret == NULL && _eglGetProcAddress != NULL) {
 		ret = (*_eglGetProcAddress)(procname);
 	}
 


### PR DESCRIPTION
In case Android environment is not available but libhybris's EGL is
loaded via libglvnd, it should gracefully fail instead of segfault. This
time, don't crash when libhybris is unable to find eglGetProcAddress;
just return NULL instead. libglvnd will understand.