### PR TITLE
hybris: tests: Don't build vulkan test when headers aren't available.

### DIFF
--- a/hybris/tests/Makefile.am
+++ b/hybris/tests/Makefile.am
@@ -20,8 +20,11 @@ bin_PROGRAMS = \
 
 if WANT_WAYLAND
 bin_PROGRAMS += \
-	test_vulkan \
 	test_camera
+if HAS_VULKAN_HEADERS
+bin_PROGRAMS += \
+	test_vulkan
+endif
 endif
 
 test_dlopen_SOURCES = test_dlopen.c


### PR DESCRIPTION
The Vulkan test will fail to compile when the relevant headers do not exist.