### PR TITLE
hybris: egl: Provide eglCreatePlatformWindowSurface.

### DIFF
--- a/hybris/egl/egl.c
+++ b/hybris/egl/egl.c
@@ -315,6 +315,11 @@ EGLSurface eglCreateWindowSurface(EGLDisplay dpy, EGLConfig config,
 	HYBRIS_TRACE_END("hybris-egl", "eglCreateWindowSurface", "");
 	return result;
 }
+EGLSurface eglCreatePlatformWindowSurface(EGLDisplay dpy, EGLConfig config,
+		void *native_window, const EGLAttrib *attrib_list)
+{
+	return eglCreateWindowSurface(dpy, config, (uintptr_t) native_window, (const EGLint *) attrib_list);
+}
 
 static EGLSurface _my_eglCreatePlatformWindowSurfaceEXT(EGLDisplay dpy, EGLConfig config,
 		void *native_window, const EGLint *attrib_list)
@@ -503,6 +508,7 @@ static struct FuncNamePair _eglHybrisOverrideFunctions[] = {
 	OVERRIDE_SAMENAME(eglGetPlatformDisplay),
 	OVERRIDE_SAMENAME(eglTerminate),
 	OVERRIDE_SAMENAME(eglCreateWindowSurface),
+	OVERRIDE_SAMENAME(eglCreatePlatformWindowSurface),
 	OVERRIDE_SAMENAME(eglDestroySurface),
 	OVERRIDE_SAMENAME(eglSwapInterval),
 	OVERRIDE_SAMENAME(eglCreateContext),


### PR DESCRIPTION
Since https://github.com/libhybris/libhybris/commit/a1bf776f4c06caba8078c7335deb766b3a77fdf1 the eglGetPlatformDisplay() function has been implemented. This function is part of EGL 1.5.

Some platforms rely on the existence of this function to detect if EGL 1.5 is supported [^1].
However, libhybris does not implement all EGL 1.5 functions, this provides the implementation for the eglCreatePlatformWindowSurface() function to fix a compilation issue with Qt [^2].

It's worth noting that the eglCreatePlatformWindowSurface() function and the eglCreateWindowSurface() function are not identical.
Similar to https://github.com/libhybris/libhybris/commit/362efd97cd5b18f580c402d3fc14555f1ef6e31e we might need to implement additional type conversions at a later stage.

[^1]: https://github.com/qt/qtwayland/blob/5.15.2/src/client/configure.json#L183
[^2]: https://github.com/qt/qtwayland/blob/5.15.2/src/hardwareintegration/client/wayland-egl/qwaylandglcontext.cpp#L356