### PR TITLE
hybris: egl: Remove Thread-Local Storage keyword to fix a segmentation fault.

### DIFF
--- a/hybris/egl/egl.c
+++ b/hybris/egl/egl.c
@@ -107,7 +107,7 @@ struct ws_egl_interface hybris_egl_interface = {
 	egl_helper_get_mapping,
 };
 
-static __thread EGLint __eglHybrisError = EGL_SUCCESS;
+static EGLint __eglHybrisError = EGL_SUCCESS;
 
 void __eglHybrisSetError(EGLint error)
 {


### PR DESCRIPTION
I'll start by mentioning that I know very little about this. I've just observed these things mentioned below and found a potential workaround. A different approach is more than welcome :smile: 

When using SDL2 based application the use of the __thread keyword caused the application to crash whenever it calls the SDL_CreateWindow() function.
Removing this keyword seems to fix this issue.
There are various references to a segmentation fault relating to the use of Thread-Local Storage, but no concrete solutions seem to be available [^1][^2].

[^1]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81142, suggests a workaround (-mtls-dialect=gnu2) that does not appear to work.
[^2]: https://stackoverflow.com/questions/20410943/segmentation-fault-when-accessing-statically-initialized-thread-variable, mentions that it's fixed in a recent GCC, I've tested this by cross-compiling with GCC 11.2.