### PR TITLE
hybris: q: rename RELR sections defines to DT_ANDROID_RELR

### DIFF
--- a/hybris/common/q/hybris_compat.h
+++ b/hybris/common/q/hybris_compat.h
@@ -50,10 +50,24 @@ extern "C" size_t strlcat(char *dst, const char *src, size_t size);
  * Experimental support for SHT_RELR sections. For details, see proposal
  * at https://groups.google.com/forum/#!topic/generic-abi/bX460iggiKg
  */
-#define DT_RELR 0x6fffe000
-#define DT_RELRSZ 0x6fffe001
-#define DT_RELRENT 0x6fffe003
-#define DT_RELRCOUNT 0x6fffe005
+#define DT_ANDROID_RELR 0x6fffe000
+#define DT_ANDROID_RELRSZ 0x6fffe001
+#define DT_ANDROID_RELRENT 0x6fffe003
+#define DT_ANDROID_RELRCOUNT 0x6fffe005
+
+/* Defined in glibc >= 2.36, and used in bionic since apilevel 30 */
+#ifndef DT_RELRSZ
+#define DT_RELRSZ 35
+#endif
+
+#ifndef DT_RELR
+#define DT_RELR 36
+#endif
+
+#ifndef DT_RELRENT
+#define DT_RELRENT 37
+#endif
+
 /*
  * From bionic/libc/include/elf.h
  *

--- a/hybris/common/q/linker.cpp
+++ b/hybris/common/q/linker.cpp
@@ -3722,14 +3722,17 @@ bool soinfo::prelink_image() {
 
 #endif
       case DT_RELR:
+      case DT_ANDROID_RELR:
         relr_ = reinterpret_cast<ElfW(Relr)*>(load_bias + d->d_un.d_ptr);
         break;
 
       case DT_RELRSZ:
+      case DT_ANDROID_RELRSZ:
         relr_count_ = d->d_un.d_val / sizeof(ElfW(Relr));
         break;
 
       case DT_RELRENT:
+      case DT_ANDROID_RELRENT:
         if (d->d_un.d_val != sizeof(ElfW(Relr))) {
           DL_ERR("invalid DT_RELRENT: %zd", static_cast<size_t>(d->d_un.d_val));
           return false;
@@ -3737,7 +3740,7 @@ bool soinfo::prelink_image() {
         break;
 
       // Ignored (see DT_RELCOUNT comments for details).
-      case DT_RELRCOUNT:
+      case DT_ANDROID_RELRCOUNT:
         break;
 
       case DT_INIT:


### PR DESCRIPTION
glibc-2.36 introduces its own support for relative relocations, and does so using different constants, breaking the q linker.

Rename the Android-specific constants to DT_ANDROID_, and define (and check) the new ones if needed. Since api level 30, bionic switched to those as well [0].

[0] https://github.com/aosp-mirror/platform_bionic/commit/6663f5525dafc31de1891d7e0fa6da88c4c7dc4b