### PR TITLE
Catch up with libmedia developments of Ubuntu Touch

### DIFF
--- a/compat/media/Android.mk
+++ b/compat/media/Android.mk
@@ -122,6 +122,13 @@ LOCAL_SHARED_LIBRARIES := \
 	libaudioutils \
 	libmediaplayerservice
 
+ifeq ($(IS_ANDROID_8),true)
+LOCAL_SHARED_LIBRARIES += \
+    liblog \
+    libmedia_omx \
+    libmediaextractor
+endif
+
 LOCAL_C_INCLUDES := \
 	$(HYBRIS_PATH)/include \
 	frameworks/base/media/libstagefright/include \

--- a/compat/media/Android.mk
+++ b/compat/media/Android.mk
@@ -35,9 +35,9 @@ LOCAL_SHARED_LIBRARIES := \
 	libbinder
 
 LOCAL_C_INCLUDES := \
-    frameworks/av/media/libmediaplayerservice \
-    frameworks/av/services/medialog \
-    frameworks/av/services/camera/libcameraservice
+	frameworks/av/media/libmediaplayerservice \
+	frameworks/av/services/medialog \
+	frameworks/av/services/camera/libcameraservice
 
 IS_ANDROID_5 := $(shell test $(ANDROID_VERSION_MAJOR) -ge 5 && echo true)
 
@@ -124,9 +124,9 @@ LOCAL_SHARED_LIBRARIES := \
 
 ifeq ($(IS_ANDROID_8),true)
 LOCAL_SHARED_LIBRARIES += \
-    liblog \
-    libmedia_omx \
-    libmediaextractor
+	liblog \
+	libmedia_omx \
+	libmediaextractor
 endif
 
 LOCAL_C_INCLUDES := \

--- a/compat/media/media_buffer_layer.cpp
+++ b/compat/media/media_buffer_layer.cpp
@@ -172,8 +172,7 @@ MediaMetaDataWrapper* media_buffer_get_meta_data(MediaBufferWrapper *buffer)
         return NULL;
 
 #if ANDROID_VERSION_MAJOR>=8
-    android::MetaData *md = new android::MetaData(d->buffer->meta_data());
-    return new MediaMetaDataPrivate(md);
+    return new MediaMetaDataPrivate(d->buffer);
 #else
     return new MediaMetaDataPrivate(d->buffer->meta_data());
 #endif

--- a/compat/media/media_buffer_layer.cpp
+++ b/compat/media/media_buffer_layer.cpp
@@ -35,24 +35,26 @@ MediaBufferPrivate* MediaBufferPrivate::toPrivate(MediaBufferWrapper *buffer)
 }
 
 #if ANDROID_VERSION_MAJOR>=8
-MediaBufferPrivate::MediaBufferPrivate(android::MediaBufferBase *buffer) :
+MediaBufferPrivate::MediaBufferPrivate(android::MediaBufferBase *buffer, bool managedByWrapper) :
 #else
-MediaBufferPrivate::MediaBufferPrivate(android::MediaBuffer *buffer) :
+MediaBufferPrivate::MediaBufferPrivate(android::MediaBuffer *buffer, bool managedByWrapper) :
 #endif
     buffer(buffer),
     return_callback(NULL),
-    return_callback_data(NULL)
+    return_callback_data(NULL),
+    isBufferManagedByWrapper(managedByWrapper)
 {
 }
 
 MediaBufferPrivate::MediaBufferPrivate() :
-    buffer(NULL)
+    buffer(NULL),
+    isBufferManagedByWrapper(true)
 {
 }
 
 MediaBufferPrivate::~MediaBufferPrivate()
 {
-    if (buffer)
+    if (isBufferManagedByWrapper && buffer)
         buffer->release();
 }
 

--- a/compat/media/media_buffer_layer.cpp
+++ b/compat/media/media_buffer_layer.cpp
@@ -305,7 +305,7 @@ MediaBufferWrapper* media_abuffer_get_media_buffer_base(MediaABufferWrapper *buf
     android::sp<android::RefBase> holder;
     if (d->buffer->meta()->findObject("mediaBufferHolder", &holder)) {
         mbufb = (holder != nullptr) ?
-        static_cast<android::MediaBufferHolder*>(holder.get())->mediaBuffer() : nullptr;
+            static_cast<android::MediaBufferHolder*>(holder.get())->mediaBuffer() : nullptr;
     }
 #else
     android::MediaBufferBase *mbufb = d->buffer->getMediaBufferBase();

--- a/compat/media/media_buffer_priv.h
+++ b/compat/media/media_buffer_priv.h
@@ -34,9 +34,9 @@ public:
     static MediaBufferPrivate* toPrivate(MediaBufferWrapper *source);
 
 #if ANDROID_VERSION_MAJOR>=8
-    MediaBufferPrivate(android::MediaBufferBase *data);
+    MediaBufferPrivate(android::MediaBufferBase *data, bool managedByWrapper = true);
 #else
-    MediaBufferPrivate(android::MediaBuffer *data);
+    MediaBufferPrivate(android::MediaBuffer *data, bool managedByWrapper = true);
 #endif
     MediaBufferPrivate();
     ~MediaBufferPrivate();
@@ -52,6 +52,7 @@ public:
 #endif
     MediaBufferReturnCallback return_callback;
     void *return_callback_data;
+    bool isBufferManagedByWrapper;
 };
 
 struct MediaABufferPrivate

--- a/compat/media/media_buffer_priv.h
+++ b/compat/media/media_buffer_priv.h
@@ -21,6 +21,9 @@
 
 #include <hybris/media/media_buffer_layer.h>
 
+#if ANDROID_VERSION_MAJOR>=8
+#include <media/MediaCodecBuffer.h>
+#endif
 #include <media/stagefright/foundation/ABuffer.h>
 
 #include <media/stagefright/MediaBuffer.h>
@@ -30,13 +33,23 @@ struct MediaBufferPrivate : public android::MediaBufferObserver
 public:
     static MediaBufferPrivate* toPrivate(MediaBufferWrapper *source);
 
+#if ANDROID_VERSION_MAJOR>=8
+    MediaBufferPrivate(android::MediaBufferBase *data);
+#else
     MediaBufferPrivate(android::MediaBuffer *data);
+#endif
     MediaBufferPrivate();
     ~MediaBufferPrivate();
 
+#if ANDROID_VERSION_MAJOR>=8
+    void signalBufferReturned(android::MediaBufferBase *buffer);
+    
+    android::MediaBufferBase *buffer;
+#else
     void signalBufferReturned(android::MediaBuffer *buffer);
 
     android::MediaBuffer *buffer;
+#endif
     MediaBufferReturnCallback return_callback;
     void *return_callback_data;
 };
@@ -47,10 +60,18 @@ public:
     static MediaABufferPrivate* toPrivate(MediaABufferWrapper *source);
 
     MediaABufferPrivate();
+#if ANDROID_VERSION_MAJOR>=8
+    MediaABufferPrivate(android::sp<android::MediaCodecBuffer> buffer);
+#else
     MediaABufferPrivate(android::sp<android::ABuffer> buffer);
+#endif
 
 public:
+#if ANDROID_VERSION_MAJOR>=8
+    android::sp<android::MediaCodecBuffer> buffer;
+#else
     android::sp<android::ABuffer> buffer;
+#endif
 };
 
 #endif

--- a/compat/media/media_codec_source_layer.cpp
+++ b/compat/media/media_codec_source_layer.cpp
@@ -51,7 +51,11 @@ public:
     android::status_t start(android::MetaData *params = NULL);
     android::status_t stop();
     android::sp<android::MetaData> getFormat();
+#if ANDROID_VERSION_MAJOR>=8
+    android::status_t read(android::MediaBufferBase **buffer, const android::MediaSource::ReadOptions *options = NULL);
+#else
     android::status_t read(android::MediaBuffer **buffer, const android::MediaSource::ReadOptions *options = NULL);
+#endif
     android::status_t pause();
 
     android::sp<android::MetaData> format;
@@ -95,7 +99,11 @@ android::sp<android::MetaData> MediaSourcePrivate::getFormat()
     return format;
 }
 
+#if ANDROID_VERSION_MAJOR>=8
+android::status_t MediaSourcePrivate::read(android::MediaBufferBase **buffer, const android::MediaSource::ReadOptions *options)
+#else
 android::status_t MediaSourcePrivate::read(android::MediaBuffer **buffer, const android::MediaSource::ReadOptions *options)
+#endif
 {
     (void) options;
 
@@ -339,7 +347,11 @@ bool media_codec_source_read(MediaCodecSourceWrapper *source, MediaBufferWrapper
     if (!d)
         return false;
 
+#if ANDROID_VERSION_MAJOR>=8
+    android::MediaBufferBase *buff = NULL;
+#else
     android::MediaBuffer *buff = NULL;
+#endif
     android::status_t err = d->codec->read(&buff);
     if (err != android::OK)
         return false;

--- a/compat/media/media_codec_source_layer.cpp
+++ b/compat/media/media_codec_source_layer.cpp
@@ -356,7 +356,9 @@ bool media_codec_source_read(MediaCodecSourceWrapper *source, MediaBufferWrapper
     if (err != android::OK)
         return false;
 
-    *buffer = new MediaBufferPrivate(buff);
+    // This MediaCodecSource layer is the oddball here. It's using a MediaBuffer that's
+    // created by MediaCodecSource into our private object, hence it's already managed.
+    *buffer = new MediaBufferPrivate(buff, false);
 
     return true;
 }

--- a/compat/media/media_compatibility_layer.cpp
+++ b/compat/media/media_compatibility_layer.cpp
@@ -36,6 +36,9 @@
 #else
 #include <gui/GLConsumer.h>
 #endif
+#if ANDROID_VERSION_MAJOR>=8
+#include <gui/BufferQueue.h>
+#endif
 
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>

--- a/compat/media/media_meta_data_layer.cpp
+++ b/compat/media/media_meta_data_layer.cpp
@@ -33,9 +33,20 @@ MediaMetaDataPrivate* MediaMetaDataPrivate::toPrivate(MediaMetaDataWrapper *md)
 }
 
 MediaMetaDataPrivate::MediaMetaDataPrivate() :
+#if ANDROID_VERSION_MAJOR>=8
+    data(nullptr)
+#else
     data(new android::MetaData)
+#endif
 {
 }
+
+#if ANDROID_VERSION_MAJOR>=8
+MediaMetaDataPrivate::MediaMetaDataPrivate(android::MediaBufferBase *buffer) :
+    data(buffer)
+{
+}
+#endif
 
 MediaMetaDataPrivate::MediaMetaDataPrivate(const android::sp<android::MetaData> &md) :
     data(md)

--- a/compat/media/media_meta_data_priv.h
+++ b/compat/media/media_meta_data_priv.h
@@ -20,6 +20,9 @@
 #define MEDIA_META_DATA_PRIV_H_
 
 #include <media/stagefright/MetaData.h>
+#if ANDROID_VERSION_MAJOR>=8
+#include <media/MediaBufferHolder.h>
+#endif
 
 struct MediaMetaDataPrivate
 {

--- a/compat/media/media_meta_data_priv.h
+++ b/compat/media/media_meta_data_priv.h
@@ -31,7 +31,7 @@ public:
 
 #if ANDROID_VERSION_MAJOR>=8
     struct MetaDataPtr {
-        MetaDataPtr(android::MediaBufferBase *buf = nullptr):
+        MetaDataPtr(android::MediaBufferBase *buf = nullptr) :
             buffer(buf)
         {
             if (buffer) {
@@ -42,7 +42,7 @@ public:
             }
         }
 
-        MetaDataPtr(const android::sp<android::MetaData> &md):
+        MetaDataPtr(const android::sp<android::MetaData> &md) :
             buffer(nullptr),
             data(new android::MetaDataBase(*md))
         {

--- a/compat/media/media_recorder.cpp
+++ b/compat/media/media_recorder.cpp
@@ -299,9 +299,17 @@ a::status_t a::MediaRecorder::setOutputFile(const char* path)
 }
 #endif
 
+#if ANDROID_VERSION_MAJOR>=8
+a::status_t a::MediaRecorder::setOutputFile(int fd)
+#else
 a::status_t a::MediaRecorder::setOutputFile(int fd, int64_t offset, int64_t length)
+#endif
 {
+#if ANDROID_VERSION_MAJOR>=8
+    ALOGV("setOutputFile(%d)", fd);
+#else
     ALOGV("setOutputFile(%d, %lld, %lld)", fd, offset, length);
+#endif
     if (mMediaRecorder == NULL) {
         ALOGE("media recorder is not initialized yet");
         return INVALID_OPERATION;
@@ -326,7 +334,11 @@ a::status_t a::MediaRecorder::setOutputFile(int fd, int64_t offset, int64_t leng
         return BAD_VALUE;
     }
 
+#if ANDROID_VERSION_MAJOR>=8
+    status_t ret = mMediaRecorder->setOutputFile(fd);
+#else
     status_t ret = mMediaRecorder->setOutputFile(fd, offset, length);
+#endif
     if (OK != ret) {
         ALOGV("setOutputFile failed: %d", ret);
         mCurrentState = MEDIA_RECORDER_ERROR;

--- a/compat/media/media_recorder.h
+++ b/compat/media/media_recorder.h
@@ -234,7 +234,11 @@ public:
 #if ANDROID_VERSION_MAJOR<=5
     status_t    setOutputFile(const char* path);
 #endif
+#if ANDROID_VERSION_MAJOR>=8
+    status_t    setOutputFile(int fd);
+#else
     status_t    setOutputFile(int fd, int64_t offset, int64_t length);
+#endif
     status_t    setVideoSize(int width, int height);
     status_t    setVideoFrameRate(int frames_per_second);
     status_t    setParameters(const String8& params);

--- a/compat/media/media_recorder_client.cpp
+++ b/compat/media/media_recorder_client.cpp
@@ -147,7 +147,11 @@ status_t MediaRecorderClient::setOutputFile(const char* path)
     return recorder->setOutputFile(path);
 }
 #else
+#if ANDROID_VERSION_MAJOR>=8
+status_t MediaRecorderClient::setInputSurface(const sp<PersistentSurface>& surface)
+#else
 status_t MediaRecorderClient::setInputSurface(const sp<IGraphicBufferConsumer>& surface)
+#endif
 {
     REPORT_FUNCTION();
     Mutex::Autolock lock(recorder_lock);
@@ -159,7 +163,11 @@ status_t MediaRecorderClient::setInputSurface(const sp<IGraphicBufferConsumer>& 
 }
 #endif
 
+#if ANDROID_VERSION_MAJOR>=8
+status_t MediaRecorderClient::setOutputFile(int fd)
+#else
 status_t MediaRecorderClient::setOutputFile(int fd, int64_t offset, int64_t length)
+#endif
 {
     REPORT_FUNCTION();
     Mutex::Autolock lock(recorder_lock);
@@ -167,7 +175,11 @@ status_t MediaRecorderClient::setOutputFile(int fd, int64_t offset, int64_t leng
         ALOGE("recorder must not be NULL");
         return NO_INIT;
     }
+#if ANDROID_VERSION_MAJOR>=8
+    return recorder->setOutputFile(fd);
+#else
     return recorder->setOutputFile(fd, offset, length);
+#endif
 }
 
 status_t MediaRecorderClient::setVideoSize(int width, int height)
@@ -348,7 +360,11 @@ status_t MediaRecorderClient::release()
     return NO_ERROR;
 }
 
+#if ANDROID_VERSION_MAJOR>=8
+status_t MediaRecorderClient::dump(int fd, const Vector<String16>& args)
+#else
 status_t MediaRecorderClient::dump(int fd, const Vector<String16>& args) const
+#endif
 {
     REPORT_FUNCTION();
     if (recorder != NULL) {
@@ -367,3 +383,70 @@ sp<IGraphicBufferProducer> MediaRecorderClient::querySurfaceMediaSource()
     }
     return recorder->querySurfaceMediaSource();
 }
+
+#if ANDROID_VERSION_MAJOR>=8
+status_t MediaRecorderClient::setNextOutputFile(int fd)
+{
+    REPORT_FUNCTION();
+    ALOGV("setNextOutputFile(%d)", fd);
+    Mutex::Autolock lock(recorder_lock);
+    if (recorder == NULL) {
+        ALOGE("recorder is not initialized");
+        return NO_INIT;
+    }
+    return recorder->setNextOutputFile(fd);
+}
+
+status_t MediaRecorderClient::getMetrics(Parcel* reply)
+{
+    REPORT_FUNCTION();
+    ALOGV("MediaRecorderClient::getMetrics");
+    Mutex::Autolock lock(recorder_lock);
+    if (recorder == NULL) {
+        ALOGE("recorder is not initialized");
+        return NO_INIT;
+    }
+    return recorder->getMetrics(reply);
+}
+
+status_t MediaRecorderClient::setInputDevice(audio_port_handle_t deviceId) {
+    REPORT_FUNCTION();
+    ALOGV("setInputDevice(%d)", deviceId);
+    Mutex::Autolock lock(recorder_lock);
+    if (recorder != NULL) {
+        return recorder->setInputDevice(deviceId);
+    }
+    return NO_INIT;
+}
+
+status_t MediaRecorderClient::getRoutedDeviceId(audio_port_handle_t* deviceId) {
+    REPORT_FUNCTION();
+    ALOGV("getRoutedDeviceId");
+    Mutex::Autolock lock(recorder_lock);
+    if (recorder != NULL) {
+        return recorder->getRoutedDeviceId(deviceId);
+    }
+    return NO_INIT;
+}
+
+status_t MediaRecorderClient::enableAudioDeviceCallback(bool enabled) {
+    REPORT_FUNCTION();
+    ALOGV("enableDeviceCallback: %d", enabled);
+    Mutex::Autolock lock(recorder_lock);
+    if (recorder != NULL) {
+        return recorder->enableAudioDeviceCallback(enabled);
+    }
+    return NO_INIT;
+}
+
+status_t MediaRecorderClient::getActiveMicrophones(
+        std::vector<media::MicrophoneInfo>* activeMicrophones) {
+    REPORT_FUNCTION();
+    ALOGV("getActiveMicrophones");
+    Mutex::Autolock lock(recorder_lock);
+    if (recorder != NULL) {
+        return recorder->getActiveMicrophones(activeMicrophones);
+    }
+    return NO_INIT;
+}
+#endif

--- a/compat/media/media_recorder_client.cpp
+++ b/compat/media/media_recorder_client.cpp
@@ -409,7 +409,8 @@ status_t MediaRecorderClient::getMetrics(Parcel* reply)
     return recorder->getMetrics(reply);
 }
 
-status_t MediaRecorderClient::setInputDevice(audio_port_handle_t deviceId) {
+status_t MediaRecorderClient::setInputDevice(audio_port_handle_t deviceId)
+{
     REPORT_FUNCTION();
     ALOGV("setInputDevice(%d)", deviceId);
     Mutex::Autolock lock(recorder_lock);
@@ -419,7 +420,8 @@ status_t MediaRecorderClient::setInputDevice(audio_port_handle_t deviceId) {
     return NO_INIT;
 }
 
-status_t MediaRecorderClient::getRoutedDeviceId(audio_port_handle_t* deviceId) {
+status_t MediaRecorderClient::getRoutedDeviceId(audio_port_handle_t* deviceId)
+{
     REPORT_FUNCTION();
     ALOGV("getRoutedDeviceId");
     Mutex::Autolock lock(recorder_lock);
@@ -429,7 +431,8 @@ status_t MediaRecorderClient::getRoutedDeviceId(audio_port_handle_t* deviceId) {
     return NO_INIT;
 }
 
-status_t MediaRecorderClient::enableAudioDeviceCallback(bool enabled) {
+status_t MediaRecorderClient::enableAudioDeviceCallback(bool enabled)
+{
     REPORT_FUNCTION();
     ALOGV("enableDeviceCallback: %d", enabled);
     Mutex::Autolock lock(recorder_lock);
@@ -440,7 +443,8 @@ status_t MediaRecorderClient::enableAudioDeviceCallback(bool enabled) {
 }
 
 status_t MediaRecorderClient::getActiveMicrophones(
-        std::vector<media::MicrophoneInfo>* activeMicrophones) {
+        std::vector<media::MicrophoneInfo>* activeMicrophones)
+{
     REPORT_FUNCTION();
     ALOGV("getActiveMicrophones");
     Mutex::Autolock lock(recorder_lock);

--- a/compat/media/media_recorder_client.h
+++ b/compat/media/media_recorder_client.h
@@ -28,7 +28,11 @@
 
 namespace android {
 
+#if ANDROID_VERSION_MAJOR>=8
+struct MediaRecorderBase;
+#else
 class MediaRecorderBase;
+#endif
 class Mutex;
 class BpMediaRecorderObserver;
 
@@ -64,9 +68,17 @@ public:
 #if ANDROID_VERSION_MAJOR<=5
     virtual status_t setOutputFile(const char* path);
 #else
+#if ANDROID_VERSION_MAJOR>=8
+    virtual status_t setInputSurface(const sp<PersistentSurface>& surface);
+#else
     virtual status_t setInputSurface(const sp<IGraphicBufferConsumer>& surface);
 #endif
+#endif
+#if ANDROID_VERSION_MAJOR>=8
+    virtual status_t setOutputFile(int fd);
+#else
     virtual status_t setOutputFile(int fd, int64_t offset, int64_t length);
+#endif
     virtual status_t setVideoSize(int width, int height);
     virtual status_t setVideoFrameRate(int frames_per_second);
     virtual status_t setParameters(const String8& params);
@@ -86,8 +98,21 @@ public:
     virtual status_t init();
     virtual status_t close();
     virtual status_t release();
+#if ANDROID_VERSION_MAJOR>=8
+    virtual status_t dump(int fd, const Vector<String16>& args);
+#else
     virtual status_t dump(int fd, const Vector<String16>& args) const;
+#endif
     virtual sp<IGraphicBufferProducer> querySurfaceMediaSource();
+#if ANDROID_VERSION_MAJOR>=8
+    virtual status_t setNextOutputFile(int fd);
+    virtual status_t getMetrics(Parcel* reply);
+    virtual status_t setInputDevice(audio_port_handle_t deviceId);
+    virtual status_t getRoutedDeviceId(audio_port_handle_t* deviceId);
+    virtual status_t enableAudioDeviceCallback(bool enabled);
+    virtual status_t getActiveMicrophones(
+                        std::vector<media::MicrophoneInfo>* activeMicrophones);
+#endif
 
 private:
     sp<BpMediaRecorderObserver> media_recorder_observer;

--- a/compat/media/media_recorder_layer.cpp
+++ b/compat/media/media_recorder_layer.cpp
@@ -342,7 +342,11 @@ int android_recorder_setOutputFile(MediaRecorderWrapper *mr, int fd)
         return android::BAD_VALUE;
     }
 
+#if ANDROID_VERSION_MAJOR>=8
+    return mr->setOutputFile(fd);
+#else
     return mr->setOutputFile(fd, 0, 0);
+#endif
 }
 
 /*!

--- a/compat/media/surface_texture_client_hybris_priv.h
+++ b/compat/media/surface_texture_client_hybris_priv.h
@@ -27,6 +27,9 @@
 #else
 #include <gui/GLConsumer.h>
 #endif
+#if ANDROID_VERSION_MAJOR>=8
+#include <gui/BufferQueue.h>
+#endif
 
 #if ANDROID_VERSION_MAJOR==4 && ANDROID_VERSION_MINOR<=2
 struct _SurfaceTextureClientHybris : public android::SurfaceTextureClient


### PR DESCRIPTION
This changeset adds a few compatibility and memory leak changes to libmedia_compat_layer.

- Enables general support on newer Android
- Fixes metadata buffer handling
- Plugs a memleak caused by wrong refcounting

These are mostly related to Aethercast and QtWebEngine libmedia support, Aethercast being our Miracast
sender service for Wireless External Display, and general HW-accelerated media playback in Chromium.

Supersedes: https://github.com/libhybris/libhybris/pull/483