### PR TITLE
eglplatform.h: take MESA_EGL_NO_X11_HEADERS into account

### DIFF
--- a/hybris/include/EGL/eglplatform.h
+++ b/hybris/include/EGL/eglplatform.h
@@ -103,7 +103,7 @@ typedef intptr_t EGLNativeDisplayType;
 typedef intptr_t EGLNativePixmapType;
 typedef intptr_t EGLNativeWindowType;
 
-#elif defined(USE_X11)
+#elif defined(USE_X11) && !defined(MESA_EGL_NO_X11_HEADERS)
 
 /* X11 (tentative)  */
 #include <X11/Xlib.h>


### PR DESCRIPTION
When using Qt, the USE_X11 define can be present even when no X11 headers are there. This leads to build issues when trying to include X11/Xlib.h.
As before commit d31230d854c7041a48be64047b939b09dd23f580 , take into account MESA_EGL_NO_X11_HEADERS to exclude X11.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>