### PR TITLE
Add support for Android 12 and 13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,37 +36,52 @@ hybris/egl/glvnd/10_libhybris.json
 hybris/egl/glvnd/g_egldispatchstubs.h
 hybris/egl/glvnd/g_egldispatchstubs.c
 hybris/egl/platforms/common/hybris-egl-platform.pc
-hybris/egl/platforms/common/wayland-android-client-protocol.h
-hybris/egl/platforms/common/wayland-android-protocol.c
-hybris/egl/platforms/common/wayland-android-server-protocol.h
 hybris/egl/platforms/common/wayland-egl.pc
 hybris/egl/platforms/hwcomposer/hwcomposer-egl.pc
 hybris/glesv1/glesv1_cm.pc
 hybris/glesv2/glesv2.pc
+hybris/gralloc/libgralloc.pc
 hybris/hardware/libhardware.pc
+hybris/hwc2/libhwc2.pc
 hybris/input/libis.pc
 hybris/libnfc_ndef_nxp/libnfc_ndef_nxp.pc
 hybris/libnfc_nxp/libnfc_nxp.pc
 hybris/libsync/libsync.pc
+hybris/media/libmedia.pc
+hybris/opencl/OpenCL.pc
+hybris/platforms/common/wayland-android-client-protocol.h
+hybris/platforms/common/wayland-android-protocol.c
+hybris/platforms/common/wayland-android-server-protocol.h
 hybris/properties/libandroid-properties.pc
 hybris/sf/libsf.pc
 hybris/vibrator/libvibrator.pc
+hybris/wifi/libwifi.pc
 
 # Util binaries
 hybris/utils/getprop
 hybris/utils/setprop
 
 # Test binaries
+hybris/tests/test_audio
 hybris/tests/test_camera
+hybris/tests/test_dlopen
 hybris/tests/test_egl_configs
 hybris/tests/test_gps
+hybris/tests/test_hwcomposer
 hybris/tests/test_input
+hybris/tests/test_media
 hybris/tests/test_nfc
+hybris/tests/test_opencl
+hybris/tests/test_recorder
 hybris/tests/test_sf
 hybris/tests/test_egl
 hybris/tests/test_glesv2
+hybris/tests/test_glesv3
 hybris/tests/test_lights
 hybris/tests/test_offscreen_rendering
 hybris/tests/test_sensors
 hybris/tests/test_ui
+hybris/tests/test_vibrator
+hybris/tests/test_vulkan
+hybris/tests/test_wifi
 

--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -3332,6 +3332,8 @@ static struct _hook hooks_p[] = {
     /* fdsan.h */
     HOOK_INDIRECT(android_fdsan_exchange_owner_tag),
     HOOK_INDIRECT(android_fdsan_close_with_tag),
+    /* pthread.h */
+    HOOK_DIRECT_NO_DEBUG(pthread_setschedprio),
 };
 
 static int hook_cmp(const void *a, const void *b)

--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -2933,6 +2933,8 @@ static struct _hook hooks_common[] = {
     // HOOK_DIRECT(memswap),
     HOOK_DIRECT_NO_DEBUG(index),
     HOOK_DIRECT_NO_DEBUG(rindex),
+    HOOK_DIRECT_NO_DEBUG(stpcpy),
+    HOOK_DIRECT_NO_DEBUG(stpncpy),
     HOOK_DIRECT_NO_DEBUG(strchr),
     HOOK_DIRECT_NO_DEBUG(strrchr),
     HOOK_INDIRECT(strlen),

--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -256,6 +256,8 @@ AC_SUBST(ANDROID_VERSION_PATCH, [$android_headers_patch])
 AC_MSG_NOTICE("Android headers version is $android_headers_major.$android_headers_minor.$android_headers_patch")
 
 # Add automake tests for version/API needs here that you need in code, including test .am's
+AM_CONDITIONAL([HAS_ANDROID_13_0_0],[test $android_headers_major -ge 13 -a $android_headers_minor -ge 0 ])
+AM_CONDITIONAL([HAS_ANDROID_12_0_0],[test $android_headers_major -ge 12 -a $android_headers_minor -ge 0 ])
 AM_CONDITIONAL([HAS_ANDROID_11_0_0],[test $android_headers_major -ge 11 -a $android_headers_minor -ge 0 ])
 AM_CONDITIONAL([HAS_ANDROID_10_0_0],[test $android_headers_major -ge 10 -a $android_headers_minor -ge 0 ])
 AM_CONDITIONAL([HAS_ANDROID_9_0_0], [test $android_headers_major -ge 9 -a $android_headers_minor -ge 0 ])

--- a/hybris/egl/egl.c
+++ b/hybris/egl/egl.c
@@ -17,6 +17,8 @@
 
 #include "config.h"
 
+#include <android-config.h>
+
 /* EGL function pointers */
 #define EGL_EGLEXT_PROTOTYPES
 #include <EGL/egl.h>

--- a/hybris/egl/eglhybris.h
+++ b/hybris/egl/eglhybris.h
@@ -19,10 +19,11 @@
 #ifndef EGL_HYBRIS_H_
 #define EGL_HYBRIS_H_
 
+#include "platformcommon.h"
+
 /* Needed for ICS window.h */
 #include <string.h>
 #include <system/window.h>
-#include "platformcommon.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hybris/egl/platforms/common/eglnativewindowbase.h
+++ b/hybris/egl/platforms/common/eglnativewindowbase.h
@@ -17,12 +17,12 @@
 #ifndef EGLNATIVEWINDOWBASE_H
 #define EGLNATIVEWINDOWBASE_H
 
+#include "nativewindowbase.h"
+
 /* for ICS window.h */
 #include <string.h>
 #include <system/window.h>
 #include <EGL/egl.h>
-
-#include "nativewindowbase.h"
 
 /**
  * @brief A Class to do common ANativeWindow initialization and thunk c-style

--- a/hybris/hwc2/hwc2.c
+++ b/hybris/hwc2/hwc2.c
@@ -19,6 +19,8 @@
 #include <dlfcn.h>
 #include <stddef.h>
 
+#include <android-config.h>
+
 #include <hybris/common/binding.h>
 #include <hybris/hwc2/hwc2_compatibility_layer.h>
 

--- a/hybris/include/hybris/gralloc/gralloc.h
+++ b/hybris/include/hybris/gralloc/gralloc.h
@@ -22,6 +22,8 @@
 extern "C" {
 #endif
 
+#include <android-config.h>
+
 #include <cutils/native_handle.h>
 #include <system/window.h>
 

--- a/hybris/libsync/sync.c
+++ b/hybris/libsync/sync.c
@@ -21,9 +21,9 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include <android-version.h>
+#include <android-config.h>
 
-#if (ANDROID_VERSION_MAJOR >= 10)
+#if (ANDROID_VERSION_MAJOR >= 10) && (ANDROID_VERSION_MAJOR < 12)
 #include <linux/sync_file.h>
 struct sync_file_info* sync_file_info(int32_t fd);
 static inline struct sync_fence_info* sync_get_fence_info(const struct sync_file_info* info) {

--- a/hybris/platforms/common/nativewindowbase.cpp
+++ b/hybris/platforms/common/nativewindowbase.cpp
@@ -21,6 +21,8 @@
 #define TRACE(message, ...)
 #endif
 
+#include "nativewindowbase.h"
+
 #include <string.h>
 #include <system/window.h>
 #include <system/graphics.h>
@@ -38,8 +40,6 @@ extern "C" {
 #define HYBRIS_TRACE_BEGIN(...)
 #define HYBRIS_TRACE_END(...)
 #endif
-
-#include "nativewindowbase.h"
 
 BaseNativeWindowBuffer::BaseNativeWindowBuffer()
 {

--- a/hybris/platforms/common/nativewindowbase.h
+++ b/hybris/platforms/common/nativewindowbase.h
@@ -17,6 +17,8 @@
 #ifndef NATIVEWINDOWBASE_H
 #define NATIVEWINDOWBASE_H
 
+#include <android-config.h>
+
 /* for ICS window.h */
 #include <string.h>
 #include <system/window.h>

--- a/hybris/platforms/common/platformcommon.h
+++ b/hybris/platforms/common/platformcommon.h
@@ -18,6 +18,8 @@
 #ifndef PLATFORM_COMMON_H_
 #define PLATFORM_COMMON_H_
 
+#include <android-config.h>
+
 /* Needed for ICS window.h */
 #include <string.h>
 #include <system/window.h>

--- a/hybris/platforms/common/server_wlegl.cpp
+++ b/hybris/platforms/common/server_wlegl.cpp
@@ -24,6 +24,8 @@
 #include <android-config.h>
 #include <cstring>
 
+#include "server_wlegl.h"
+
 extern "C" {
 #include <cutils/native_handle.h>
 }

--- a/hybris/platforms/common/server_wlegl.h
+++ b/hybris/platforms/common/server_wlegl.h
@@ -24,6 +24,8 @@
 #ifndef SERVER_WLEGL_H
 #define SERVER_WLEGL_H
 
+#include <android-config.h>
+
 #include <system/window.h>
 
 extern "C" {

--- a/hybris/platforms/common/server_wlegl_buffer.h
+++ b/hybris/platforms/common/server_wlegl_buffer.h
@@ -23,6 +23,8 @@
 #ifndef SERVER_WLEGL_BUFFER_H
 #define SERVER_WLEGL_BUFFER_H
 
+#include <android-config.h>
+
 #include <cutils/native_handle.h>
 #include <string.h>
 #include <system/window.h>

--- a/hybris/platforms/common/server_wlegl_handle.h
+++ b/hybris/platforms/common/server_wlegl_handle.h
@@ -23,6 +23,8 @@
 #ifndef SERVER_WLEGL_HANDLE_H
 #define SERVER_WLEGL_HANDLE_H
 
+#include <android-config.h>
+
 #include <stdint.h>
 #include <string.h>
 #include <wayland-server.h>

--- a/hybris/platforms/common/windowbuffer.h
+++ b/hybris/platforms/common/windowbuffer.h
@@ -23,6 +23,8 @@
 #ifndef WINDOWBUFFER_H
 #define WINDOWBUFFER_H
 
+#include <android-config.h>
+
 #include <cutils/native_handle.h>
 #include <string.h>
 #include <system/window.h>

--- a/hybris/ui/ui.c
+++ b/hybris/ui/ui.c
@@ -17,7 +17,8 @@
 #include <dlfcn.h>
 #include <stddef.h>
 
-#include <android-version.h>
+#include <android-config.h>
+
 #if ANDROID_VERSION_MAJOR>=10
 #include <android/rect.h>
 #include <cutils/native_handle.h>


### PR DESCRIPTION
Add missing hook for pthread_setschedprio. Make sure android-config.h is always included before any Android headers. Update .gitignore file to match current builds.