### PR TITLE
hybris: q: backport ifunc resolvers calling convention from R linker

### DIFF
--- a/hybris/common/q/Makefile.am
+++ b/hybris/common/q/Makefile.am
@@ -19,6 +19,7 @@ AM_CXXFLAGS = \
 
 q_la_SOURCES = \
 	hybris_compat.cpp \
+	bionic/libc/bionic/bionic_call_ifunc_resolver.cpp \
 	dlfcn.cpp \
 	linker_allocator.cpp \
 	linker_block_allocator.cpp \

--- a/hybris/common/q/bionic/libc/bionic/bionic_call_ifunc_resolver.cpp
+++ b/hybris/common/q/bionic/libc/bionic/bionic_call_ifunc_resolver.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "private/bionic_call_ifunc_resolver.h"
+#include <sys/auxv.h>
+#include <sys/ifunc.h>
+
+ElfW(Addr) __bionic_call_ifunc_resolver(ElfW(Addr) resolver_addr) {
+#if defined(__aarch64__)
+  typedef ElfW(Addr) (*ifunc_resolver_t)(uint64_t, __ifunc_arg_t*);
+  static __ifunc_arg_t arg = { sizeof(__ifunc_arg_t), getauxval(AT_HWCAP), getauxval(AT_HWCAP2) };
+  return reinterpret_cast<ifunc_resolver_t>(resolver_addr)(arg._hwcap | _IFUNC_ARG_HWCAP, &arg);
+#elif defined(__arm__)
+  typedef ElfW(Addr) (*ifunc_resolver_t)(unsigned long);
+  static unsigned long hwcap = getauxval(AT_HWCAP);
+  return reinterpret_cast<ifunc_resolver_t>(resolver_addr)(hwcap);
+#else
+  typedef ElfW(Addr) (*ifunc_resolver_t)(void);
+  return reinterpret_cast<ifunc_resolver_t>(resolver_addr)();
+#endif
+}

--- a/hybris/common/q/bionic/libc/include/sys/ifunc.h
+++ b/hybris/common/q/bionic/libc/include/sys/ifunc.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <sys/cdefs.h>
+
+/**
+ * @file sys/ifunc.h
+ * @brief Declarations used for ifunc resolvers. Currently only meaningful for arm64.
+ */
+
+__BEGIN_DECLS
+
+#if defined(__aarch64__)
+
+/**
+ * Provides information about hardware capabilities to ifunc resolvers.
+ *
+ * Starting with API level 30, ifunc resolvers on arm64 are passed two arguments. The first is a
+ * uint64_t whose value is equal to getauxval(AT_HWCAP) | _IFUNC_ARG_HWCAP. The second is a pointer
+ * to a data structure of this type. Prior to API level 30, no arguments are passed to ifunc
+ * resolvers. Code that wishes to be compatible with prior API levels should not accept any
+ * arguments in the resolver.
+ */
+typedef struct __ifunc_arg_t {
+  /** Set to sizeof(__ifunc_arg_t). */
+  unsigned long _size;
+
+  /** Set to getauxval(AT_HWCAP). */
+  unsigned long _hwcap;
+
+  /** Set to getauxval(AT_HWCAP2). */
+  unsigned long _hwcap2;
+} __ifunc_arg_t;
+
+/**
+ * If this bit is set in the first argument to an ifunc resolver, indicates that the second argument
+ * is a pointer to a data structure of type __ifunc_arg_t. This bit is always set on Android
+ * starting with API level 30.
+ */
+#define _IFUNC_ARG_HWCAP (1ULL << 62)
+
+#endif
+
+__END_DECLS

--- a/hybris/common/q/bionic/libc/private/bionic_call_ifunc_resolver.h
+++ b/hybris/common/q/bionic/libc/private/bionic_call_ifunc_resolver.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <link.h>
+#include <sys/cdefs-android.h>
+
+__LIBC_HIDDEN__ ElfW(Addr) __bionic_call_ifunc_resolver(ElfW(Addr) resolver_addr);

--- a/hybris/common/q/linker.cpp
+++ b/hybris/common/q/linker.cpp
@@ -70,6 +70,7 @@
 #include "linker_tls.h"
 #include "linker_utils.h"
 
+#include "private/bionic_call_ifunc_resolver.h"
 #include "private/bionic_globals.h"
 #include "android-base/macros.h"
 //#include "android-base/strings.h"
@@ -2640,11 +2641,9 @@ bool link_namespaces_all_libs(android_namespace_t* namespace_from,
 }
 
 ElfW(Addr) call_ifunc_resolver(ElfW(Addr) resolver_addr) {
-  typedef ElfW(Addr) (*ifunc_resolver_t)(void);
-  ifunc_resolver_t ifunc_resolver = reinterpret_cast<ifunc_resolver_t>(resolver_addr);
-  ElfW(Addr) ifunc_addr = ifunc_resolver();
+  ElfW(Addr) ifunc_addr = __bionic_call_ifunc_resolver(resolver_addr);
   TRACE_TYPE(RELO, "Called ifunc_resolver@%p. The result is %p",
-      ifunc_resolver, reinterpret_cast<void*>(ifunc_addr));
+      reinterpret_cast<void *>(resolver_addr), reinterpret_cast<void*>(ifunc_addr));
 
   return ifunc_addr;
 }


### PR DESCRIPTION
From https://android.googlesource.com/platform/bionic/+/e949195. Needed for Android 12 binaries as tested on a MediaTek device.