### PR TITLE
Avoid uninitialised handle_ in soinfo.

### DIFF
--- a/hybris/common/mm/linker.cpp
+++ b/hybris/common/mm/linker.cpp
@@ -675,6 +675,7 @@ bool soinfo::elf_lookup(SymbolName& symbol_name,
 soinfo::soinfo(const char* realpath, const struct stat* file_stat,
                off64_t file_offset, int rtld_flags) {
 
+  soname_ = nullptr;
   if (realpath != nullptr) {
     realpath_ = realpath;
   }
@@ -686,9 +687,35 @@ soinfo::soinfo(const char* realpath, const struct stat* file_stat,
     this->st_dev_ = file_stat->st_dev;
     this->st_ino_ = file_stat->st_ino;
     this->file_offset_ = file_offset;
+  } else {
+    st_dev_ = 0;
+    st_ino_ = 0;
+    file_offset_ = 0;
   }
 
   this->rtld_flags_ = rtld_flags;
+
+  dt_flags_1_ = 0;
+  strtab_size_ = 0;
+
+  gnu_nbucket_ = 0;
+  gnu_bucket_ = nullptr;
+  gnu_chain_ = nullptr;
+  gnu_maskwords_ = 0;
+  gnu_shift2_ = 0;
+
+  local_group_root_ = nullptr;
+
+  android_relocs_ = nullptr;
+  android_relocs_size_ = 0;
+
+  versym_ = nullptr;
+  verdef_ptr_ = 0;
+  verdef_cnt_ = 0;
+  verneed_ptr_ = 0;
+  verneed_cnt_ = 0;
+
+  target_sdk_version_ = 0;
 }
 
 

--- a/hybris/common/n/linker.cpp
+++ b/hybris/common/n/linker.cpp
@@ -956,25 +956,55 @@ soinfo::soinfo(android_namespace_t* ns, const char* realpath,
                const struct stat* file_stat, off64_t file_offset,
                int rtld_flags) {
 
+  soname_ = nullptr;
   if (realpath != nullptr) {
     realpath_ = realpath;
   }
 
   flags_ = FLAG_NEW_SOINFO;
   version_ = SOINFO_VERSION;
+  handle_ = 0;
 
   if (file_stat != nullptr) {
     this->st_dev_ = file_stat->st_dev;
     this->st_ino_ = file_stat->st_ino;
     this->file_offset_ = file_offset;
+  } else {
+    st_dev_ = 0;
+    st_ino_ = 0;
+    file_offset_ = 0;
   }
 
   this->rtld_flags_ = rtld_flags;
   this->primary_namespace_ = ns;
+
+  dt_flags_1_ = 0;
+  strtab_size_ = 0;
+
+  gnu_nbucket_ = 0;
+  gnu_bucket_ = nullptr;
+  gnu_chain_ = nullptr;
+  gnu_maskwords_ = 0;
+  gnu_shift2_ = 0;
+
+  local_group_root_ = nullptr;
+
+  android_relocs_ = nullptr;
+  android_relocs_size_ = 0;
+
+  versym_ = nullptr;
+  verdef_ptr_ = 0;
+  verdef_cnt_ = 0;
+  verneed_ptr_ = 0;
+  verneed_cnt_ = 0;
+
+  target_sdk_version_ = 0;
 }
 
 soinfo::~soinfo() {
-  g_soinfo_handles_map.erase(handle_);
+  if (handle_) {
+    g_soinfo_handles_map.erase(handle_);
+  }
 }
 
 static uint32_t calculate_elf_hash(const char* name) {

--- a/hybris/common/o/linker_soinfo.cpp
+++ b/hybris/common/o/linker_soinfo.cpp
@@ -55,25 +55,55 @@ soinfo::soinfo(android_namespace_t* ns, const char* realpath,
                const struct stat* file_stat, off64_t file_offset,
                int rtld_flags) {
 
+  soname_ = nullptr;
   if (realpath != nullptr) {
     realpath_ = realpath;
   }
 
   flags_ = FLAG_NEW_SOINFO;
   version_ = SOINFO_VERSION;
+  handle_ = 0;
 
   if (file_stat != nullptr) {
     this->st_dev_ = file_stat->st_dev;
     this->st_ino_ = file_stat->st_ino;
     this->file_offset_ = file_offset;
+  } else {
+    st_dev_ = 0;
+    st_ino_ = 0;
+    file_offset_ = 0;
   }
 
   this->rtld_flags_ = rtld_flags;
   this->primary_namespace_ = ns;
+
+  dt_flags_1_ = 0;
+  strtab_size_ = 0;
+
+  gnu_nbucket_ = 0;
+  gnu_bucket_ = nullptr;
+  gnu_chain_ = nullptr;
+  gnu_maskwords_ = 0;
+  gnu_shift2_ = 0;
+
+  local_group_root_ = nullptr;
+
+  android_relocs_ = nullptr;
+  android_relocs_size_ = 0;
+
+  versym_ = nullptr;
+  verdef_ptr_ = 0;
+  verdef_cnt_ = 0;
+  verneed_ptr_ = 0;
+  verneed_cnt_ = 0;
+
+  target_sdk_version_ = 0;
 }
 
 soinfo::~soinfo() {
-  g_soinfo_handles_map.erase(handle_);
+  if (handle_) {
+    g_soinfo_handles_map.erase(handle_);
+  }
 }
 
 void soinfo::set_dt_runpath(const char* path) {

--- a/hybris/common/q/linker_soinfo.cpp
+++ b/hybris/common/q/linker_soinfo.cpp
@@ -57,25 +57,58 @@ soinfo::soinfo(android_namespace_t* ns, const char* realpath,
                int rtld_flags) {
 //  memset(this, 0, sizeof(*this));
 
+  soname_ = nullptr;
   if (realpath != nullptr) {
     realpath_ = realpath;
   }
 
   flags_ = FLAG_NEW_SOINFO;
   version_ = SOINFO_VERSION;
+  handle_ = 0;
 
   if (file_stat != nullptr) {
     this->st_dev_ = file_stat->st_dev;
     this->st_ino_ = file_stat->st_ino;
     this->file_offset_ = file_offset;
+  } else {
+    st_dev_ = 0;
+    st_ino_ = 0;
+    file_offset_ = 0;
   }
 
   this->rtld_flags_ = rtld_flags;
   this->primary_namespace_ = ns;
+
+  dt_flags_1_ = 0;
+  strtab_size_ = 0;
+
+  gnu_nbucket_ = 0;
+  gnu_bucket_ = nullptr;
+  gnu_chain_ = nullptr;
+  gnu_maskwords_ = 0;
+  gnu_shift2_ = 0;
+
+  local_group_root_ = nullptr;
+
+  android_relocs_ = nullptr;
+  android_relocs_size_ = 0;
+
+  versym_ = nullptr;
+  verdef_ptr_ = 0;
+  verdef_cnt_ = 0;
+  verneed_ptr_ = 0;
+  verneed_cnt_ = 0;
+
+  target_sdk_version_ = 0;
+
+  relr_ = nullptr;
+  relr_count_ = 0;
 }
 
 soinfo::~soinfo() {
-  g_soinfo_handles_map.erase(handle_);
+  if (handle_) {
+    g_soinfo_handles_map.erase(handle_);
+  }
 }
 
 void soinfo::set_dt_runpath(const char* path) {


### PR DESCRIPTION
Since fc7bfd1b, the soinfo structure fields are uninitialised. But this is creating an issue in linker_main.cpp#823, where a temporary soinfo object is created, but its `handle_` member is not set. Then, on exit of the function, the temporary object is destroied and it mentions in Valgrind a use of an uninitialised value with the following backtrace:
```
==22274== Use of uninitialised value of size 8
==22274==    at 0x9685BB8: soinfo::~soinfo() (in /usr/lib64/libhybris/linker/q.so)
==22274==    by 0x9682B3F: android_linker_init (in /usr/lib64/libhybris/linker/q.so)
==22274==    by 0x6C363DF: ??? (in /usr/lib64/libhybris-common.so.1.0.0)
==22274==    by 0x6C36E2B: android_dlopen (in /usr/lib64/libhybris-common.so.1.0.0)
==22274==    by 0x10B0EB: __load_library (in /home/defaultuser/devel/sextant)
==22274==    by 0x10B1E3: droid_media_camera2_get_number_of_cameras (in /home/defaultuser/devel/sextant)
==22274==    by 0x10AF4B: plop() (main.cpp:15)
==22274==    by 0x10AC9F: main (main.cpp:24)
```

I don't know if it is the best way to solve the problem. Was the memset() call in soinfo constructor commented out for debugging purposes or was it harmful (because scratching initialised members) ? Is it better to put `handle_ = 0;` in the struct soinfo definition ? Should I do it for all other members ?