### PR TITLE
hybris: q: ignore DT_AARCH64_* processor specific DT

### DIFF
--- a/hybris/common/q/linker.cpp
+++ b/hybris/common/q/linker.cpp
@@ -3891,6 +3891,14 @@ bool soinfo::prelink_image() {
         // resolves everything eagerly, so these can be ignored.
         break;
 
+#if defined(__aarch64__)
+      case DT_AARCH64_BTI_PLT:
+      case DT_AARCH64_PAC_PLT:
+      case DT_AARCH64_VARIANT_PCS:
+        // Ignored: AArch64 processor-specific dynamic array tags.
+        break;
+#endif
+
       default:
         if (!relocating_linker) {
           const char* tag_name;


### PR DESCRIPTION
without this patch android prebuilt objects will throw a bunch of linker warnings like so:

```
WARNING: linker Warning: "/android/vendor/lib64/android.hardware.media.c2@1.0.so" unused DT entry: unknown processor-specific (type 0x70000001 arg (nil)) (ignoring)
WARNING: linker Warning: "/android/vendor/lib64/android.hardware.media.c2@1.1.so" unused DT entry: unknown processor-specific (type 0x70000001 arg (nil)) (ignoring)
WARNING: linker Warning: "/android/vendor/lib64/android.hardware.media.c2@1.0.so" unused DT entry: unknown processor-specific (type 0x70000001 arg (nil)) (ignoring)
WARNING: linker Warning: "/android/vendor/lib64/libcodec2_vndk.so" unused DT entry: unknown processor-specific (type 0x70000001 arg (nil)) (ignoring)
WARNING: linker Warning: "/android/vendor/lib64/libstagefright_bufferpool@2.0.1.so" unused DT entry: unknown processor-specific (type 0x70000001 arg (nil)) (ignoring)
WARNING: linker Warning: "/android/vendor/lib64/android.hardware.media.c2@1.0.so" unused DT entry: unknown processor-specific (type 0x70000001 arg (nil)) (ignoring)
WARNING: linker Warning: "/android/vendor/lib64/android.hardware.media.c2@1.1.so" unused DT entry: unknown processor-specific (type 0x70000001 arg (nil)) (ignoring)
WARNING: linker Warning: "/android/vendor/lib64/libcodec2_vndk.so" unused DT entry: unknown processor-specific (type 0x70000001 arg (nil)) (ignoring)
WARNING: linker Warning: "/android/vendor/lib64/libstagefright_bufferpool@2.0.1.so" unused DT entry: unknown processor-specific (type 0x70000001 arg (nil)) (ignoring)
WARNING: linker Warning: "/android/vendor/lib64/android.hardware.media.c2@1.0.so" unused DT entry: unknown processor-specific (type 0x70000001 arg (nil)) (ignoring)
WARNING: linker Warning: "/android/vendor/lib64/android.hardware.media.c2@1.1.so" unused DT entry: unknown processor-specific (type 0x70000001 arg (nil)) (ignoring)
WARNING: linker Warning: "/android/vendor/lib64/android.hardware.media.c2@1.2.so" unused DT entry: unknown processor-specific (type 0x70000001 arg (nil)) (ignoring)
WARNING: linker Warning: "/android/vendor/lib64/libcodec2_vndk.so" unused DT entry: unknown processor-specific (type 0x70000001 arg (nil)) (ignoring
```

these are also ignored in the bionic linker upstream
https://github.com/aosp-mirror/platform_bionic/commit/8d55d1872a6c7f850a13c59ddaedc813d0bc7e26#diff-079364ea4e51091bfd360a355c1842532b6dca2e5078eac9c1105e5cfc5a7d5c