### PR TITLE
hybris: Hook pthread_getname_np

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -3015,6 +3015,7 @@ static struct _hook hooks_common[] = {
     HOOK_TO(pthread_cond_timedwait_monotonic_np, _hybris_hook_pthread_cond_timedwait),
     HOOK_INDIRECT(pthread_cond_timedwait_relative_np),
     HOOK_DIRECT_NO_DEBUG(pthread_key_delete),
+    HOOK_DIRECT_NO_DEBUG(pthread_getname_np),
     HOOK_INDIRECT(pthread_setname_np),
     HOOK_DIRECT_NO_DEBUG(pthread_once),
     HOOK_DIRECT_NO_DEBUG(pthread_key_create),


### PR DESCRIPTION
Needed by audio HAL on QCM6490 with API 30 vendor (found on FP5):

```
calling unhooked method: _ZN14PerfThreadPoolC2Ev@0x7fe8b2c8cc
calling hooked method: getpid@0x7ff7af5d30
calling hooked method: pthread_self@0x7ff7ac5ab8
calling hooked method: pthread_getname_np@0xfffffffffffffffe

Thread 1 "pulseaudio" received signal SIGBUS, Bus error.
0xfffffffffffffffe in ?? ()
```
