### PR TITLE
q: Add missing dynamic array tag defines

### DIFF
--- a/hybris/common/q/hybris_compat.h
+++ b/hybris/common/q/hybris_compat.h
@@ -86,4 +86,13 @@ extern "C" size_t strlcat(char *dst, const char *src, size_t size);
 #define R_AARCH64_TLS_DTPMOD64          1029    /* Module index. */
 #define R_AARCH64_TLS_TPREL64           1030    /* TP-relative offset. */
 
+/*
+ * From bionic/libc/include/bits/elf_arm64.h
+ *
+ * Dynamic array tags
+ */
+#define DT_AARCH64_BTI_PLT              0x70000001
+#define DT_AARCH64_PAC_PLT              0x70000003
+#define DT_AARCH64_VARIANT_PCS          0x70000005
+
 #endif


### PR DESCRIPTION
Defined were missing from https://github.com/libhybris/libhybris/pull/550