### PR TITLE
tests: workaround -Wimplicit-function-declaration in system/audio.h

### DIFF
--- a/hybris/tests/test_audio.c
+++ b/hybris/tests/test_audio.c
@@ -15,6 +15,9 @@
  *
  */
 
+/* Allows system/audio.h to see strdup() */
+#define _POSIX_C_SOURCE 200809L
+
 #include <android-config.h>
 #include <memory.h>
 #include <assert.h>


### PR DESCRIPTION
system/audio.h uses strdup(), but it's exposed only with _POSIX_C_SOURCE at least 200809L. So define that.