### PR TITLE
hybris: platforms: common: Add support for NATIVE_WINDOW_GET_CONSUMER_USAGE64

### DIFF
--- a/hybris/platforms/common/nativewindowbase.cpp
+++ b/hybris/platforms/common/nativewindowbase.cpp
@@ -370,7 +370,7 @@ int BaseNativeWindow::_perform(struct ANativeWindow* window, int operation, ... 
 	va_start(args, operation);
 
 	// FIXME
-	TRACE("operation = %s", _native_window_operation(operation));
+	TRACE("operation = %s (%i)", _native_window_operation(operation), operation);
 	switch(operation) {
 	case NATIVE_WINDOW_SET_USAGE                 : //  0,
 	{

--- a/hybris/platforms/common/nativewindowbase.cpp
+++ b/hybris/platforms/common/nativewindowbase.cpp
@@ -265,6 +265,7 @@ const char *BaseNativeWindow::_native_window_operation(int what)
 #endif
 #if ANDROID_VERSION_MAJOR>=9
 		case NATIVE_WINDOW_SET_USAGE64: return "NATIVE_WINDOW_SET_USAGE64";
+		case NATIVE_WINDOW_GET_CONSUMER_USAGE64: return "NATIVE_WINDOW_GET_CONSUMER_USAGE64";
 #endif
 		default: return "NATIVE_UNKNOWN_OPERATION";
 	}
@@ -441,11 +442,20 @@ int BaseNativeWindow::_perform(struct ANativeWindow* window, int operation, ... 
 #endif
 #if ANDROID_VERSION_MAJOR>=9
 	case NATIVE_WINDOW_SET_USAGE64               : // 30,
+	{
 		TRACE("set usage 64");
 		uint64_t usage = va_arg(args, uint64_t);
 		va_end(args);
 		return self->setUsage(usage);
 		break;
+	}
+	case NATIVE_WINDOW_GET_CONSUMER_USAGE64      : // 31,
+	{
+		TRACE("get consumer usage 64");
+		uint64_t* usage = va_arg(args, uint64_t*);
+		*usage = self->getUsage();
+		break;
+	}
 #endif
 
 	}

--- a/hybris/platforms/common/server_wlegl.cpp
+++ b/hybris/platforms/common/server_wlegl.cpp
@@ -144,9 +144,11 @@ server_wlegl_get_server_buffer_handle(wl_client *client, wl_resource *res, uint3
 	if (format == 0) format = HAL_PIXEL_FORMAT_RGBA_8888;
 
 	int r = hybris_gralloc_allocate(width, height, format, usage, &_handle, (uint32_t*)&_stride);
-        if (r) {
-            HYBRIS_ERROR_LOG(SERVER_WLEGL, "failed to allocate buffer\n");
-        }
+	if (r) {
+		HYBRIS_ERROR_LOG(SERVER_WLEGL, "failed to allocate buffer\n");
+		wl_resource_destroy(resource);
+		return;
+	}
 	server_wlegl_buffer *buffer = server_wlegl_buffer_create_server(client, width, height, _stride, format, usage, _handle, wlegl);
 
 	struct wl_array ints;


### PR DESCRIPTION
Needed for vulkan support in Android 14 base. Improve debugging of operations and fix a crash if gralloc fails.