### PR TITLE
hook android_fdsan_set_error_level

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -2873,6 +2873,12 @@ void _hybris_hook_free(void *ptr)
 #define cfree free
 #endif
 
+int _hybris_hook_android_fdsan_set_error_level(int new_level)
+{
+    TRACE_HOOK("new_level %d", new_level);
+    return new_level;
+}
+
 void _hybris_hook_android_fdsan_exchange_owner_tag(int fd, uint64_t expected_tag, uint64_t new_tag)
 {
     (void)expected_tag;
@@ -3335,6 +3341,7 @@ static struct _hook hooks_p[] = {
     HOOK_INDIRECT(fgets_unlocked),
     HOOK_INDIRECT(fputs_unlocked),
     /* fdsan.h */
+    HOOK_INDIRECT(android_fdsan_set_error_level),
     HOOK_INDIRECT(android_fdsan_exchange_owner_tag),
     HOOK_INDIRECT(android_fdsan_close_with_tag),
     /* pthread.h */


### PR DESCRIPTION
Changed to int.
~Adding the enum as char as the values are small enough and it should work for little-endian.~ 
The actual [enum](https://github.com/libhybris/libhybris/blob/master/hybris/common/q/bionic/libc/include/android/fdsan.h#L166) I didn't try to import from android "Q" headers.