### PR TITLE
hybris: experimental TLS access patcher for aarch64

### DIFF
--- a/hybris/common/Makefile.am
+++ b/hybris/common/Makefile.am
@@ -50,6 +50,11 @@ libhybris_common_la_SOURCES += \
 	wrapper_code_generic_arm.c
 endif
 
+if WANT_ARCH_ARM64
+libhybris_common_la_SOURCES += \
+	tls_patcher.c
+endif
+
 libhybris_common_la_CPPFLAGS = \
 	-I$(top_srcdir)/include \
 	$(ANDROID_HEADERS_CFLAGS) \

--- a/hybris/common/jb/linker.c
+++ b/hybris/common/jb/linker.c
@@ -51,6 +51,8 @@
 #include "linker_environ.h"
 #include "linker_format.h"
 
+#include "../tls_patcher.h"
+
 #ifdef WANT_ARM_TRACING
 #include "../wrappers.h"
 #endif
@@ -2425,9 +2427,9 @@ unsigned __linker_init(unsigned **elfdata) {
 }
 
 #ifdef WANT_ARM_TRACING
-void android_linker_init(int sdk_version, void *(get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, void *(create_wrapper)(const char*, void*, int), int wrapping_enabled) {
+void android_linker_init(int sdk_version, void *(get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, hybris_tls_patcher_t tls_patcher, void *(create_wrapper)(const char*, void*, int), int wrapping_enabled) {
 #else
-void android_linker_init(int sdk_version, void *(get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support) {
+void android_linker_init(int sdk_version, void *(get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, hybris_tls_patcher_t tls_patcher) {
 #endif
    (void) sdk_version;
    _get_hooked_symbol = get_hooked_symbol;

--- a/hybris/common/mm/linker.cpp
+++ b/hybris/common/mm/linker.cpp
@@ -60,6 +60,7 @@
 
 #include "hybris_compat.h"
 
+#include "../tls_patcher.h"
 #ifdef WANT_ARM_TRACING
 #include "../wrappers.h"
 #endif
@@ -3399,9 +3400,9 @@ static ElfW(Addr) get_elf_exec_load_bias(const ElfW(Ehdr)* elf) {
 }
 
 #ifdef WANT_ARM_TRACING
-extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, void *(create_wrapper)(const char*, void*, int), int wrapping_enabled) {
+extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, hybris_tls_patcher_t tls_patcher, void *(create_wrapper)(const char*, void*, int), int wrapping_enabled) {
 #else
-extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support) {
+extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, hybris_tls_patcher_t tls_patcher) {
 #endif
   // Get a few environment variables.
   const char* LD_DEBUG = getenv("HYBRIS_LD_DEBUG");

--- a/hybris/common/n/linker.cpp
+++ b/hybris/common/n/linker.cpp
@@ -68,6 +68,7 @@
 #include "linker_non_pie.h"
 #endif
 
+#include "../tls_patcher.h"
 #ifdef WANT_ARM_TRACING
 #include "../wrappers.h"
 #endif
@@ -4759,9 +4760,9 @@ static void __linker_cannot_link(KernelArgumentBlock& args) {
 }
 
 #ifdef WANT_ARM_TRACING
-extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, void *(create_wrapper)(const char*, void*, int), int wrapping_enabled) {
+extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, hybris_tls_patcher_t tls_patcher, void *(create_wrapper)(const char*, void*, int), int wrapping_enabled) {
 #else
-extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support) {
+extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, hybris_tls_patcher_t tls_patcher) {
 #endif
   // Get a few environment variables.
   const char* LD_DEBUG = getenv("HYBRIS_LD_DEBUG");

--- a/hybris/common/o/linker_main.cpp
+++ b/hybris/common/o/linker_main.cpp
@@ -51,6 +51,8 @@
 
 #include <vector>
 
+#include "../tls_patcher.h"
+
 extern void __libc_init_globals(KernelArgumentBlock&);
 #ifdef DISABLED_FOR_HYBRIS_SUPPORT
 extern void __libc_init_AT_SECURE(KernelArgumentBlock&);
@@ -515,9 +517,9 @@ void* (*_get_hooked_symbol)(const char *sym, const char *requester);
 #ifdef WANT_ARM_TRACING
 void *(*_create_wrapper)(const char *symbol, void *function, int wrapper_type);
 int _wrapping_enabled = 0;
-extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, void *(create_wrapper)(const char*, void*, int), int wrapping_enabled) {
+extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, hybris_tls_patcher_t tls_patcher, void *(create_wrapper)(const char*, void*, int), int wrapping_enabled) {
 #else
-extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support) {
+extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, hybris_tls_patcher_t tls_patcher) {
 #endif
   // Get a few environment variables.
   const char* LD_DEBUG = getenv("HYBRIS_LD_DEBUG");

--- a/hybris/common/q/linker_main.cpp
+++ b/hybris/common/q/linker_main.cpp
@@ -63,6 +63,8 @@
 
 #include <vector>
 
+#include "../tls_patcher.h"
+
 extern void __libc_init_globals(KernelArgumentBlock&);
 #ifdef DISABLED_FOR_HYBRIS_SUPPORT
 extern void __libc_init_AT_SECURE(KernelArgumentBlock&);
@@ -782,12 +784,13 @@ static const char* get_executable_path() {
 }
 
 void* (*_get_hooked_symbol)(const char *sym, const char *requester);
+hybris_tls_patcher_t _tls_patcher;
 #ifdef WANT_ARM_TRACING
 void *(*_create_wrapper)(const char *symbol, void *function, int wrapper_type);
 int _wrapping_enabled = 0;
-extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, void *(create_wrapper)(const char*, void*, int), int wrapping_enabled) {
+extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, hybris_tls_patcher_t tls_patcher, void *(create_wrapper)(const char*, void*, int), int wrapping_enabled) {
 #else
-extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support) {
+extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(const char*, const char*), int enable_linker_gdb_support, hybris_tls_patcher_t tls_patcher) {
 #endif
   // Get a few environment variables.
   const char* LD_DEBUG = getenv("HYBRIS_LD_DEBUG");
@@ -815,6 +818,7 @@ extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(
 
   _get_hooked_symbol = get_hooked_symbol;
   _linker_enable_gdb_support = enable_linker_gdb_support;
+  _tls_patcher = tls_patcher;
 #ifdef WANT_ARM_TRACING
   _create_wrapper = create_wrapper;
   _wrapping_enabled = wrapping_enabled;

--- a/hybris/common/tls_patcher.c
+++ b/hybris/common/tls_patcher.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2025 Nikita Ukhrenkov <thekit@disroot.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "tls_patcher.h"
+#include "logging.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <libgen.h>
+
+extern void* _hybris_hook___get_tls_hooks(void);
+
+/* Architecture-specific patch function */
+extern void hybris_patch_tls_arch(void* segment_addr, size_t segment_size, int tls_offset);
+
+/* Calculate offset from thread pointer to our TLS area */
+static int hybris_calculate_tls_offset(void) {
+    void* tp = __builtin_thread_pointer();
+    void* tls_area = _hybris_hook___get_tls_hooks();
+    return (int)((uintptr_t)tls_area - (uintptr_t)tp) / sizeof(uintptr_t);
+}
+
+/* Extract filename from path without modifying input */
+static const char* get_basename(const char* path) {
+    const char* base = strrchr(path, '/');
+    return base ? base + 1 : path;
+}
+
+/* Check if library should be patched based on HYBRIS_PATCH_TLS value */
+static int should_patch_library(const char* library_name) {
+    static const char* patch_tls = NULL;
+    static int init_done = 0;
+
+    /* Initialize on first call */
+    if (!init_done) {
+        patch_tls = getenv("HYBRIS_PATCH_TLS");
+        init_done = 1;
+    }
+
+    /* No environment variable set - do nothing */
+    if (!patch_tls) {
+        return 0;
+    }
+
+    /* Simple enable/disable */
+    if (patch_tls[0] == '0' || patch_tls[0] == '1') {
+        return patch_tls[0] == '1';
+    }
+
+    /* Check if library basename is in colon-separated list */
+    const char *start = patch_tls;
+    const char *name = get_basename(library_name);
+    size_t name_len = strlen(name);
+
+    while (start && *start) {
+        const char *end = strchr(start, ':');
+        size_t len = end ? (size_t)(end - start) : strlen(start);
+
+        if (len == name_len && strncmp(start, name, len) == 0) {
+            return 1;
+        }
+
+        start = end ? end + 1 : NULL;
+    }
+
+    return 0;
+}
+
+void hybris_patch_tls(void* segment_addr, size_t segment_size, const char* library_name) {
+    if (!should_patch_library(library_name)) {
+        return;
+    }
+
+    HYBRIS_DEBUG_LOG(HOOKS, "Patching TLS accesses in %s", library_name);
+
+    int tls_offset = hybris_calculate_tls_offset();
+    HYBRIS_DEBUG_LOG(HOOKS, "Offset from thread pointer to hybris tls_space (in words): %d",
+        tls_offset);
+
+    hybris_patch_tls_arch(segment_addr, segment_size, tls_offset);
+}
+
+#ifdef __aarch64__
+#include "tls_patcher_aarch64.c"
+#endif

--- a/hybris/common/tls_patcher.h
+++ b/hybris/common/tls_patcher.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Nikita Ukhrenkov <thekit@disroot.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef TLS_PATCHER_H
+#define TLS_PATCHER_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*hybris_tls_patcher_t)(void* segment_addr, size_t segment_size, const char* library_name);
+
+/* Patches TLS accesses in the given segment at runtime */
+void hybris_patch_tls(void* segment_addr, size_t segment_size, const char* library_name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TLS_PATCHER_H */

--- a/hybris/common/tls_patcher_aarch64.c
+++ b/hybris/common/tls_patcher_aarch64.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025 Nikita Ukhrenkov <thekit@disroot.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include "logging.h"
+
+#define MRS_OPCODE 0xD53
+#define TPIDR_EL0 0x5E82
+
+#define LDR_OPCODE 0xE5
+#define STR_OPCODE 0xE4
+
+#define TLS_SLOT_APP 2
+#define TLS_SLOT_STACK_GUARD 5
+
+/* Instruction format for MRS X<rt>, TPIDR_EL0 */
+struct __attribute__((__packed__)) mrs_inst {
+    uint8_t rt:5;        /* 0:4   - Destination register */
+    uint16_t sys_reg:15; /* 5:19  - System register encoding */
+    uint16_t opcode:12;  /* 20:31 - Must be 0xD53 (MRS instruction) */
+};
+_Static_assert(sizeof(struct mrs_inst) == 4, "MRS instruction size must be 4");
+
+/* Instruction format for LDR X<rt>, [X<rn>, #imm]
+                      and STR X<rt>, [X<rn>, #imm] */
+struct __attribute__((__packed__)) ldr_inst {
+    uint32_t rt:5;       /* 0:4   - Destination register */
+    uint32_t rn:5;       /* 5:9   - Base register */
+    uint32_t imm12:12;   /* 10:21 - 12-bit immediate scaled by 8 */
+    uint32_t opcode:8;   /* 22:29 - Must be 0xe5 (LDR with unsigned offset) */
+    uint32_t size:2;     /* 30:31 - Must be 0b11 for 64-bit load */
+};
+_Static_assert(sizeof(struct ldr_inst) == 4, "LDR instruction size must be 4");
+
+void hybris_patch_tls_arch(void* segment_addr, size_t segment_size, int tls_offset) {
+    static int error_reported = 0;
+
+    /* LDR immediate must fit in 12 bits */
+    if (tls_offset > 0xFFF) {
+        if (!error_reported) {
+            fprintf(stderr,
+                "HYBRIS_TLS_PATCH: TLS area offset %d is too large for LDR instruction",
+                tls_offset);
+            error_reported = 1;
+        }
+        return;
+    }
+
+    uint32_t* text = (uint32_t*)segment_addr;
+    size_t count = segment_size / sizeof(uint32_t);
+
+    for (size_t i = 0; i < count; i++) {
+        const struct mrs_inst* mrs = (const struct mrs_inst*)&text[i];
+
+        /* Look for MRS instruction that reads TPIDR_EL0 */
+        if (mrs->opcode != MRS_OPCODE || mrs->sys_reg != TPIDR_EL0) {
+            continue;
+        }
+
+        /* Found MRS X<rt>, TPIDR_EL0, scan next few instructions for matching LDR */
+        for (int j = 1; j < 5 && (i + j) < count; j++) {
+            struct ldr_inst* ldr = (struct ldr_inst*)&text[i + j];
+
+            /* Check for LDR or STR instruction using the same register as MRS */
+            if ((ldr->opcode == LDR_OPCODE || ldr->opcode == STR_OPCODE)
+                 && ldr->size == 0b11 && ldr->rn == mrs->rt) {
+                if (ldr->imm12 > TLS_SLOT_APP && ldr->imm12 < TLS_SLOT_STACK_GUARD) {
+                    ldr->imm12 += tls_offset;
+                }
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Some Android graphics drivers (noticed with libGLES_mali.so) make use of private bionic TLS slots. Since these slots use fixed offsets from the thread ID register, the access routine is inlined by the compiler and cannot be hooked by libhybris symbol overriding.

The code compiled with glibc has no notion of bionic's reserved TLS area, so these slots may be used by the executable/other libraries. While libtls-padding.so worked when TLS was relocatable, it fails when the main executable uses local-exec TLS model, where access is inlined similarly to bionic and can't be relocated by the linker.

This causes the application and GLES driver to overwrite each other's TLS data, leading to crashes.

As discussed in #559, we could try to work around this by patching TLS access dynamically in loaded libraries. When HYBRIS_TLS_PATCH=1, all libhybris linker-loaded code is analyzed for the pattern:

```
mrs x<rt>, tpidr_el0
ldr/str x<r*>, [x<rt>,#offset]
```

If found, the offset is patched to point to libhybris-allocated TLS area, avoiding conflicts between glibc and bionic-compiled code.

HYBRIS_TLS_PATCH can also be set to a colon-separated list of library filenames to limit the performance impact and avoid breaking unrelated code, e.g.:

`HYBRIS_TLS_PATCH=libGLES_mali.so`

This is pretty much initial attempt and I don't expect the current method to be reliable (it doesn't properly track register access in case there are extra instructions inserted by compiler between mrs and ldr), but workarounds the libGLES_mali.so-related crashes on affected devices.