### PR TITLE
hybris: q: add missing pthread linkage

### DIFF
--- a/hybris/common/q/Makefile.am
+++ b/hybris/common/q/Makefile.am
@@ -66,6 +66,7 @@ q_la_CPPFLAGS += -DHAS_ANDROID_11_0_0
 endif
 
 q_la_LDFLAGS = \
+	-lpthread \
 	-lsupc++ \
 	-module \
 	-avoid-version


### PR DESCRIPTION
It is used by ScopedWriteLock macro in linker_tls.cpp after TLS relocations became supported in f306111b.

This should fix the error observed on Ubuntu Touch:
`ERROR: Failed to load hybris linker for Android SDK version 34: /usr/lib/aarch64-linux-gnu/libhybris/linker/q.so: undefined symbol: pthread_rwlock_unlock`