### PR TITLE
common/q: drop linker_memory and fix allocator free()

### DIFF
--- a/hybris/common/q/bionic/libc/bionic/bionic_allocator.cpp
+++ b/hybris/common/q/bionic/libc/bionic/bionic_allocator.cpp
@@ -348,7 +348,7 @@ void* BionicAllocator::realloc(void* ptr, size_t size) {
   }
 
   if (size == 0) {
-    //free(ptr);
+    free(ptr);
     return nullptr;
   }
 
@@ -370,7 +370,7 @@ void* BionicAllocator::realloc(void* ptr, size_t size) {
   if (old_size < size) {
     void *result = alloc(size);
     memcpy(result, ptr, old_size);
-    //free(ptr);
+    free(ptr);
     return result;
   }
 
@@ -392,7 +392,7 @@ void BionicAllocator::free(void* ptr) {
       async_safe_fatal("invalid pointer %p (invalid allocator address for the page)", ptr);
     }
 
-    //allocator->free(ptr);
+    allocator->free(ptr);
   }
 }
 

--- a/hybris/common/q/linker_memory.cpp
+++ b/hybris/common/q/linker_memory.cpp
@@ -40,6 +40,7 @@
 
 #define gettid() syscall(SYS_gettid)
 
+#if DISABLED_FOR_HYBRIS_SUPPORT
 static BionicAllocator g_bionic_allocator;
 static std::atomic<pid_t> fallback_tid(0);
 
@@ -98,3 +99,4 @@ void* reallocarray(void* p, size_t item_count, size_t item_size) {
 void free(void* ptr) {
   get_allocator().free(ptr);
 }
+#endif


### PR DESCRIPTION
When using the TLS relocation patches on Android 14 with Ubuntu Touch, we ran into a peculiar issue where the global malloc/calloc/free symbols in libhybris were overwriting the glibc symbols, which caused these symbols to start freeing memory allocated by glibc. Moreover, due to the global symbols being replaced, the commented-out lines didn't work, which they now perfectly do.
Tested on Pixel 7 Pro with Halium 14