### PR TITLE
egl: RIP eglHybrisWaylandPostBuffer(EGLNativeWindowType, ANativeWindowBuffer *)

### DIFF
--- a/hybris/egl/glvnd/generate/eglFunctionList.py
+++ b/hybris/egl/glvnd/generate/eglFunctionList.py
@@ -257,8 +257,5 @@ EGL_FUNCTIONS = (
 
     # EGL_HYBRIS_WL_acquire_native_buffer
     _eglFunc("eglHybrisAcquireNativeBufferWL",       "display"),
-
-    # ??? No associated extension ??? (see comment in egl_hybris.xml)
-    _eglFunc("eglHybrisWaylandPostBuffer",           "current"),
 )
 

--- a/hybris/egl/glvnd/generate/egl_hybris.xml
+++ b/hybris/egl/glvnd/generate/egl_hybris.xml
@@ -93,20 +93,5 @@
             <param><ptype>struct wl_resource *</ptype> <name>wlBuffer</name></param>
             <param><ptype>EGLClientBuffer *</ptype> <name>buffer</name></param>
         </command>
-
-        <!--
-            ??? No associated extension ???
-            The function is implemented in eglplatform_wayland.cpp. The only
-            reference I found outside of libhybris is at [1]. And that's the
-            old version; the newer version no longer uses this function.
-
-            [1] https://github.com/krnlyng/sfdroid_renderer
-        -->
-
-        <command>
-            <proto>int <name>eglHybrisWaylandPostBuffer</name></proto>
-            <param><ptype>EGLNativeWindowType</ptype> <name>win</name></param>
-            <param><ptype>void *</ptype> <name>buffer</name></param>
-        </command>
     </commands>
 </registry>

--- a/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
+++ b/hybris/egl/platforms/wayland/eglplatform_wayland.cpp
@@ -230,13 +230,6 @@ extern "C" void waylandws_DestroyWindow(EGLNativeWindowType win)
 	window->common.decRef(&window->common);
 }
 
-extern "C" int waylandws_post(EGLNativeWindowType win, void *buffer)
-{
-	struct wl_egl_window *eglwin = (struct wl_egl_window *) win;
-
-	return ((WaylandNativeWindow *) eglwin->driver_private)->postBuffer((ANativeWindowBuffer *) buffer);
-}
-
 /**
  * Loads libhybris's libEGL at runtime to call hybris_egl_display_get_mapping()
  */
@@ -290,15 +283,10 @@ extern "C" wl_buffer *waylandws_createWlBuffer(EGLDisplay dpy, EGLImageKHR image
 
 extern "C" __eglMustCastToProperFunctionPointerType waylandws_eglGetProcAddress(const char *procname)
 {
-	if (strcmp(procname, "eglHybrisWaylandPostBuffer") == 0)
-	{
-		return (__eglMustCastToProperFunctionPointerType) waylandws_post;
-	}
-	else if (strcmp(procname, "eglCreateWaylandBufferFromImageWL") == 0)
+	if (strcmp(procname, "eglCreateWaylandBufferFromImageWL") == 0)
     {
         return (__eglMustCastToProperFunctionPointerType) waylandws_createWlBuffer;
     }
-	else
 	return eglplatformcommon_eglGetProcAddress(procname);
 }
 

--- a/hybris/egl/platforms/wayland/wayland_window.cpp
+++ b/hybris/egl/platforms/wayland/wayland_window.cpp
@@ -65,61 +65,6 @@ static const struct wl_callback_listener frame_listener = {
     wayland_frame_callback
 };
 
-int WaylandNativeWindow::postBuffer(ANativeWindowBuffer* buffer)
-{
-    TRACE("");
-    WaylandNativeWindowBuffer *wnb = NULL;
-
-    lock();
-    std::list<WaylandNativeWindowBuffer *>::iterator it = post_registered.begin();
-    for (; it != post_registered.end(); ++it)
-    {
-        if ((*it)->other == buffer)
-        {
-            wnb = (*it);
-            break;
-        }
-    }
-    unlock();
-    if (!wnb)
-    {
-        wnb = new WaylandNativeWindowBuffer(buffer);
-
-        wnb->common.incRef(&wnb->common);
-        buffer->common.incRef(&buffer->common);
-    }
-
-    int ret = 0;
-
-    lock();
-    wnb->busy = 1;
-    ret = readQueue(false);
-
-    if (ret < 0) {
-        unlock();
-        return ret;
-    }
-
-    if (wnb->wlbuffer == NULL)
-    {
-        wnb->wlbuffer_from_native_handle(m_android_wlegl, m_display, wl_queue);
-        TRACE("%p add listener with %p inside", wnb, wnb->wlbuffer);
-        wl_buffer_add_listener(wnb->wlbuffer, &wl_buffer_listener, this);
-        wl_proxy_set_queue((struct wl_proxy *) wnb->wlbuffer, this->wl_queue);
-        post_registered.push_back(wnb);
-    }
-    TRACE("%p DAMAGE AREA: %dx%d", wnb, wnb->width, wnb->height);
-    wl_surface_attach(m_window->surface, wnb->wlbuffer, 0, 0);
-    wl_surface_damage(m_window->surface, 0, 0, wnb->width, wnb->height);
-    wl_surface_commit(m_window->surface);
-    wl_display_flush(m_display);
-
-    posted.push_back(wnb);
-    unlock();
-
-    return NO_ERROR;
-}
-
 int WaylandNativeWindow::dequeueBuffer(BaseNativeWindowBuffer **buffer, int *fenceFd){
     HYBRIS_TRACE_BEGIN("wayland-platform", "dequeueBuffer", "");
 

--- a/hybris/egl/platforms/wayland/wayland_window.h
+++ b/hybris/egl/platforms/wayland/wayland_window.h
@@ -52,7 +52,6 @@ public:
     void frame();
     void resize(unsigned int width, unsigned int height);
     void releaseBuffer(struct wl_buffer *buffer);
-    int postBuffer(ANativeWindowBuffer *buffer);
 
     virtual int setSwapInterval(int interval);
     void prepareSwap(EGLint *damage_rects, EGLint damage_n_rects);
@@ -94,8 +93,6 @@ private:
 
     std::list<WaylandNativeWindowBuffer *> m_bufList;
     std::list<WaylandNativeWindowBuffer *> fronted;
-    std::list<WaylandNativeWindowBuffer *> posted;
-    std::list<WaylandNativeWindowBuffer *> post_registered;
     std::deque<WaylandNativeWindowBuffer *> queue;
     struct wl_egl_window *m_window;
     struct wl_display *m_display;

--- a/hybris/platforms/wayland/wayland_window_common.cpp
+++ b/hybris/platforms/wayland/wayland_window_common.cpp
@@ -229,23 +229,7 @@ int WaylandNativeWindow::setSwapInterval(int interval) {
 
 void WaylandNativeWindow::releaseBuffer(struct wl_buffer *buffer)
 {
-    std::list<WaylandNativeWindowBuffer *>::iterator it = posted.begin();
-
-    for (; it != posted.end(); ++it)
-    {
-        if ((*it)->wlbuffer == buffer)
-            break;
-    }
-
-    if (it != posted.end())
-    {
-        WaylandNativeWindowBuffer* pwnb = *it;
-        posted.erase(it);
-        TRACE("released posted buffer: %p", buffer);
-        pwnb->busy = 0;
-        unlock();
-        return;
-    }
+    std::list<WaylandNativeWindowBuffer *>::iterator it;
 
     it = fronted.begin();
 

--- a/hybris/vulkan/platforms/wayland/wayland_window.h
+++ b/hybris/vulkan/platforms/wayland/wayland_window.h
@@ -50,7 +50,6 @@ public:
     void frame();
     void resize(unsigned int width, unsigned int height);
     void releaseBuffer(struct wl_buffer *buffer);
-    int postBuffer(ANativeWindowBuffer *buffer);
 
     virtual int setSwapInterval(int interval);
 
@@ -91,8 +90,6 @@ private:
 
     std::list<WaylandNativeWindowBuffer *> m_bufList;
     std::list<WaylandNativeWindowBuffer *> fronted;
-    std::list<WaylandNativeWindowBuffer *> posted;
-    std::list<WaylandNativeWindowBuffer *> post_registered;
     struct wl_egl_window *m_window;
     struct wl_display *m_display;
     WaylandNativeWindowBuffer *m_lastBuffer;


### PR DESCRIPTION
There is literally no any single user of this undocumented/private API.
The only one user Internet knows about is https://github.com/krnlyng/sfdroid_renderer/commit/17e31ec769214dd41b5e780f902ee94e32940197 ;)
Since then, sfdroid_renderer was replacing it with a more straightforward solution.