### PR TITLE
wayland: Fix UB in destroyBuffers()

### DIFF
--- a/hybris/platforms/wayland/wayland_window_common.cpp
+++ b/hybris/platforms/wayland/wayland_window_common.cpp
@@ -462,7 +462,6 @@ void WaylandNativeWindow::destroyBuffers()
     for (; it!=m_bufList.end(); ++it)
     {
         destroyBuffer(*it);
-        it = m_bufList.erase(it);
     }
     m_bufList.clear();
     m_freeBufs = 0;


### PR DESCRIPTION
++it or it = erase, not both