### PR TITLE
vulkan: hook vkCreateSwapchainKHR and vkGetPhysicalDeviceSurfaceCapabilitiesKHR

### DIFF
--- a/hybris/vulkan/platforms/null/vulkanplatform_null.c
+++ b/hybris/vulkan/platforms/null/vulkanplatform_null.c
@@ -41,7 +41,7 @@ static VkResult nullws_vkEnumerateInstanceExtensionProperties(const char* pLayer
     return (*_vkEnumerateInstanceExtensionProperties)(pLayerName, pPropertyCount, pProperties);
 }
 
-VkResult nullws_vkCreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance)
+static VkResult nullws_vkCreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance)
 {
     if (_vkCreateInstance == NULL) {
         _vkCreateInstance = (VkResult (*)(const VkInstanceCreateInfo *, const VkAllocationCallbacks *, VkInstance *))
@@ -67,6 +67,16 @@ static VkBool32 nullws_vkGetPhysicalDeviceWaylandPresentationSupportKHR(VkPhysic
 static void nullws_vkDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface, const VkAllocationCallbacks* pAllocator)
 {
 }
+
+static VkResult nullws_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR *pSurfaceCapabilities)
+{
+    return VK_ERROR_SURFACE_LOST_KHR;
+}
+
+static VkResult nullws_vkCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain)
+{
+    return VK_ERROR_OUT_OF_HOST_MEMORY;
+}
 #endif
 
 static void nullws_vkSetInstanceProcAddrFunc(PFN_vkVoidFunction addr)
@@ -83,6 +93,8 @@ struct ws_module ws_module_info = {
     nullws_vkCreateWaylandSurfaceKHR,
     nullws_vkGetPhysicalDeviceWaylandPresentationSupportKHR,
     nullws_vkDestroySurfaceKHR,
+    nullws_vkGetPhysicalDeviceSurfaceCapabilitiesKHR,
+    nullws_vkCreateSwapchainKHR,
 #endif
     nullws_vkSetInstanceProcAddrFunc,
 };

--- a/hybris/vulkan/platforms/wayland/vulkanplatform_wayland.cpp
+++ b/hybris/vulkan/platforms/wayland/vulkanplatform_wayland.cpp
@@ -190,7 +190,11 @@ static VkResult waylandws_vkCreateInstance(const VkInstanceCreateInfo *pCreateIn
     VkResult result;
     // Temporary array to replace wayland surface extension with Android surface extension
     char **enabledExtensions = (char **)malloc(pCreateInfo->enabledExtensionCount * sizeof(char *));
-    uint32_t i;
+    uint32_t i, out_count = 0;
+
+    if (enabledExtensions == NULL) {
+        return VK_ERROR_OUT_OF_HOST_MEMORY;
+    }
 
     if (_vkCreateInstance == NULL) {
         _vkCreateInstance = (VkResult (*)(const VkInstanceCreateInfo *, const VkAllocationCallbacks *, VkInstance *))
@@ -198,20 +202,41 @@ static VkResult waylandws_vkCreateInstance(const VkInstanceCreateInfo *pCreateIn
     }
 
     for (i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
-        enabledExtensions[i] = (char *)malloc(VK_MAX_EXTENSION_NAME_SIZE * sizeof(char));
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME) == 0) {
-            strncpy(enabledExtensions[i], VK_KHR_ANDROID_SURFACE_EXTENSION_NAME, VK_MAX_EXTENSION_NAME_SIZE);
-        } else {
-            strncpy(enabledExtensions[i], pCreateInfo->ppEnabledExtensionNames[i], VK_MAX_EXTENSION_NAME_SIZE);
+        const char *ext = pCreateInfo->ppEnabledExtensionNames[i];
+
+        // Skip unsupported VK_KHR_display on Wayland
+        if (strcmp(ext, VK_KHR_DISPLAY_EXTENSION_NAME) == 0) {
+            continue;
         }
+
+        enabledExtensions[out_count] = (char *)malloc(VK_MAX_EXTENSION_NAME_SIZE * sizeof(char));
+        if (enabledExtensions[out_count] == NULL) {
+            uint32_t j;
+            for (j = 0; j < out_count; j++) {
+                free(enabledExtensions[j]);
+            }
+            free(enabledExtensions);
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+
+        if (strcmp(ext, VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME) == 0) {
+            strncpy(enabledExtensions[out_count], VK_KHR_ANDROID_SURFACE_EXTENSION_NAME, VK_MAX_EXTENSION_NAME_SIZE);
+        } else {
+            strncpy(enabledExtensions[out_count], ext, VK_MAX_EXTENSION_NAME_SIZE);
+        }
+
+        enabledExtensions[out_count][VK_MAX_EXTENSION_NAME_SIZE - 1] = '\0';
+        out_count++;
     }
+
+    createInfo.enabledExtensionCount = out_count;
     createInfo.ppEnabledExtensionNames = (const char * const *)enabledExtensions;
 
     // Call actual vkCreateInstance
     result = (*_vkCreateInstance)(&createInfo, pAllocator, pInstance);
 
     // Free temporary array
-    for (i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
+    for (i = 0; i < out_count; i++) {
         free(enabledExtensions[i]);
     }
     free(enabledExtensions);

--- a/hybris/vulkan/platforms/wayland/vulkanplatform_wayland.cpp
+++ b/hybris/vulkan/platforms/wayland/vulkanplatform_wayland.cpp
@@ -52,9 +52,13 @@ struct WaylandDisplay {
     android_wlegl *wlegl;
     WaylandNativeWindow *window;
     wl_display *wl_dpy_wrapper;
+
+    int current_swapchain_width;
+    int current_swapchain_height;
 };
 
 static bool init_done = false;
+static VkInstance g_instance = VK_NULL_HANDLE;
 
 /* Keep track of active Vulkan window surfaces */
 static std::map<VkSurfaceKHR,struct WaylandDisplay *> _surface_window_map;
@@ -84,11 +88,23 @@ struct WaylandDisplay *vulkan_wayland_pop_mapping(VkSurfaceKHR surface)
     return result;
 }
 
+struct WaylandDisplay *vulkan_wayland_get_mapping(VkSurfaceKHR surface)
+{
+    std::map<VkSurfaceKHR, struct WaylandDisplay *>::iterator it;
+    it = _surface_window_map.find(surface);
+
+    if (it != _surface_window_map.end())
+        return it->second;
+    return NULL;
+}
+
 static VkResult (*_vkCreateAndroidSurfaceKHR)(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) = NULL;
 static PFN_vkVoidFunction (*_vkDestroySurfaceKHR)(VkInstance instance, VkSurfaceKHR surface, const VkAllocationCallbacks* pAllocator) = NULL;
 static VkResult (*_vkEnumerateInstanceExtensionProperties)(const char *pLayerName, uint32_t *pPropertyCount, VkExtensionProperties *pProperties) = NULL;
 static VkResult (*_vkCreateInstance)(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance) = NULL;
 static PFN_vkVoidFunction (*_vkGetInstanceProcAddr)(VkInstance instance, const char *pName) = NULL;
+static VkResult (*_vkGetPhysicalDeviceSurfaceCapabilitiesKHR)(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR *pSurfaceCapabilities) = NULL;
+static VkResult (*_vkCreateSwapchainKHR)(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain) = NULL;
 
 extern "C" void waylandws_init_module(struct ws_vulkan_interface *vulkan_iface)
 {
@@ -165,7 +181,9 @@ static VkResult waylandws_vkEnumerateInstanceExtensionProperties(const char* pLa
     return res;
 }
 
-VkResult waylandws_vkCreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance)
+static VkResult waylandws_vkCreateInstance(const VkInstanceCreateInfo *pCreateInfo,
+                                           const VkAllocationCallbacks *pAllocator,
+                                           VkInstance *pInstance)
 {
     VkInstanceCreateInfo createInfo = *pCreateInfo;
     VkResult result;
@@ -197,6 +215,8 @@ VkResult waylandws_vkCreateInstance(const VkInstanceCreateInfo *pCreateInfo, con
     }
     free(enabledExtensions);
 
+    g_instance = *pInstance;
+
     return result;
 }
 
@@ -221,6 +241,8 @@ static VkResult waylandws_vkCreateWaylandSurfaceKHR(VkInstance instance,
 
     wdpy->wl_dpy = pCreateInfo->display;
     wdpy->wlegl = NULL;
+    wdpy->current_swapchain_width = 0;
+    wdpy->current_swapchain_height = 0;
     wdpy->queue = wl_display_create_queue(wdpy->wl_dpy);
     wdpy->wl_dpy_wrapper = (struct wl_display *) wl_proxy_create_wrapper(wdpy->wl_dpy);
     wl_proxy_set_queue((struct wl_proxy *) wdpy->wl_dpy_wrapper, wdpy->queue);
@@ -234,13 +256,43 @@ static VkResult waylandws_vkCreateWaylandSurfaceKHR(VkInstance instance,
     while (ret == 0 && !wdpy->wlegl) {
         ret = wl_display_dispatch_queue(wdpy->wl_dpy, wdpy->queue);
     }
-    assert(ret >= 0);
+
+    if (ret < 0) {
+        HYBRIS_ERROR("Failed to dispatch Wayland queue: %d", ret);
+        delete wdpy;
+        HYBRIS_TRACE_END("hybris-vulkan", "vkCreateWaylandSurfaceKHR", "");
+        return VK_ERROR_SURFACE_LOST_KHR;
+    }
+
+    if (!wdpy->wlegl) {
+        HYBRIS_ERROR("android_wlegl extension not available");
+        delete wdpy;
+        HYBRIS_TRACE_END("hybris-vulkan", "vkCreateWaylandSurfaceKHR", "");
+        return VK_ERROR_EXTENSION_NOT_PRESENT;
+    }
 
     window = wl_egl_window_create(pCreateInfo->surface, 1, 1);
+
+    if (!window) {
+        HYBRIS_ERROR("Failed to create wl_egl_window");
+        freeWaylandDisplay(wdpy);
+        HYBRIS_TRACE_END("hybris-vulkan", "vkCreateWaylandSurfaceKHR", "");
+        return VK_ERROR_SURFACE_LOST_KHR;
+    }
 
     HYBRIS_TRACE_BEGIN("native-vulkan", "vkCreateWaylandSurfaceKHR", "");
 
     win = new WaylandNativeWindow((struct wl_egl_window *)window, wdpy->wl_dpy, wdpy->wlegl);
+
+    if (!win) {
+        HYBRIS_ERROR("Failed to create WaylandNativeWindow");
+        wl_egl_window_destroy(window);
+        freeWaylandDisplay(wdpy);
+        HYBRIS_TRACE_END("native-vulkan", "vkCreateWaylandSurfaceKHR", "");
+        HYBRIS_TRACE_END("hybris-vulkan", "vkCreateWaylandSurfaceKHR", "");
+        return VK_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
     win->common.incRef(&win->common);
     createInfo.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
     createInfo.pNext = NULL;
@@ -261,6 +313,66 @@ static VkResult waylandws_vkCreateWaylandSurfaceKHR(VkInstance instance,
     }
 
     HYBRIS_TRACE_END("hybris-vulkan", "vkCreateWaylandSurfaceKHR", "");
+    return result;
+}
+
+static VkResult waylandws_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice,
+                                                                    VkSurfaceKHR surface,
+                                                                    VkSurfaceCapabilitiesKHR *pSurfaceCapabilities)
+{
+    VkResult result;
+
+    if (_vkGetPhysicalDeviceSurfaceCapabilitiesKHR == NULL) {
+        assert(g_instance != VK_NULL_HANDLE && "vkGetPhysicalDeviceSurfaceCapabilitiesKHR called before vkCreateInstance");
+        _vkGetPhysicalDeviceSurfaceCapabilitiesKHR = (VkResult (*)(VkPhysicalDevice, VkSurfaceKHR, VkSurfaceCapabilitiesKHR *))
+            (*_vkGetInstanceProcAddr)(g_instance, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR");
+    }
+
+    result = (*_vkGetPhysicalDeviceSurfaceCapabilitiesKHR)(physicalDevice, surface, pSurfaceCapabilities);
+
+    if (result == VK_SUCCESS && vulkan_wayland_has_mapping(surface)) {
+        pSurfaceCapabilities->currentExtent.width  = 0xFFFFFFFF;
+        pSurfaceCapabilities->currentExtent.height = 0xFFFFFFFF;
+        pSurfaceCapabilities->minImageExtent.width  = 1;
+        pSurfaceCapabilities->minImageExtent.height = 1;
+        pSurfaceCapabilities->maxImageExtent.width  = 16384;
+        pSurfaceCapabilities->maxImageExtent.height = 16384;
+
+        pSurfaceCapabilities->supportedCompositeAlpha |= VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+    }
+
+    return result;
+}
+
+static VkResult waylandws_vkCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain)
+{
+    VkResult result;
+
+    if (_vkCreateSwapchainKHR == NULL) {
+        _vkCreateSwapchainKHR = (VkResult (*)(VkDevice, const VkSwapchainCreateInfoKHR *, const VkAllocationCallbacks *, VkSwapchainKHR *))
+            (*_vkGetInstanceProcAddr)(NULL, "vkCreateSwapchainKHR");
+    }
+
+    // Check if this is a Wayland surface and resize the window
+    struct WaylandDisplay *wdpy = vulkan_wayland_get_mapping(pCreateInfo->surface);
+    if (wdpy && wdpy->window) {
+        int new_width = pCreateInfo->imageExtent.width;
+        int new_height = pCreateInfo->imageExtent.height;
+
+        if (new_width != wdpy->current_swapchain_width || new_height != wdpy->current_swapchain_height) {
+            HYBRIS_DEBUG("Resizing Wayland window from %dx%d to %dx%d",
+                         wdpy->current_swapchain_width, wdpy->current_swapchain_height,
+                         new_width, new_height);
+
+            wl_egl_window_resize(wdpy->window->m_window, new_width, new_height, 0, 0);
+
+            wdpy->current_swapchain_width = new_width;
+            wdpy->current_swapchain_height = new_height;
+        }
+    }
+
+    result = (*_vkCreateSwapchainKHR)(device, pCreateInfo, pAllocator, pSwapchain);
+
     return result;
 }
 
@@ -301,5 +413,7 @@ struct ws_module ws_module_info = {
     waylandws_vkCreateWaylandSurfaceKHR,
     waylandws_vkGetPhysicalDeviceWaylandPresentationSupportKHR,
     waylandws_vkDestroySurfaceKHR,
+    waylandws_vkGetPhysicalDeviceSurfaceCapabilitiesKHR,
+    waylandws_vkCreateSwapchainKHR,
     waylandws_vkSetInstanceProcAddrFunc,
 };

--- a/hybris/vulkan/platforms/wayland/vulkanplatform_wayland.cpp
+++ b/hybris/vulkan/platforms/wayland/vulkanplatform_wayland.cpp
@@ -103,6 +103,7 @@ static PFN_vkVoidFunction (*_vkDestroySurfaceKHR)(VkInstance instance, VkSurface
 static VkResult (*_vkEnumerateInstanceExtensionProperties)(const char *pLayerName, uint32_t *pPropertyCount, VkExtensionProperties *pProperties) = NULL;
 static VkResult (*_vkCreateInstance)(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkInstance *pInstance) = NULL;
 static PFN_vkVoidFunction (*_vkGetInstanceProcAddr)(VkInstance instance, const char *pName) = NULL;
+static PFN_vkVoidFunction (*_vkGetDeviceProcAddr)(VkDevice device, const char *pName) = NULL;
 static VkResult (*_vkGetPhysicalDeviceSurfaceCapabilitiesKHR)(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR *pSurfaceCapabilities) = NULL;
 static VkResult (*_vkCreateSwapchainKHR)(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain) = NULL;
 
@@ -204,7 +205,7 @@ static VkResult waylandws_vkCreateInstance(const VkInstanceCreateInfo *pCreateIn
             strncpy(enabledExtensions[i], pCreateInfo->ppEnabledExtensionNames[i], VK_MAX_EXTENSION_NAME_SIZE);
         }
     }
-    createInfo.ppEnabledExtensionNames = enabledExtensions;
+    createInfo.ppEnabledExtensionNames = (const char * const *)enabledExtensions;
 
     // Call actual vkCreateInstance
     result = (*_vkCreateInstance)(&createInfo, pAllocator, pInstance);
@@ -215,7 +216,9 @@ static VkResult waylandws_vkCreateInstance(const VkInstanceCreateInfo *pCreateIn
     }
     free(enabledExtensions);
 
-    g_instance = *pInstance;
+    if (result == VK_SUCCESS) {
+        g_instance = *pInstance;
+    }
 
     return result;
 }
@@ -348,9 +351,19 @@ static VkResult waylandws_vkCreateSwapchainKHR(VkDevice device, const VkSwapchai
 {
     VkResult result;
 
+    if (_vkGetDeviceProcAddr == NULL) {
+        assert(g_instance != VK_NULL_HANDLE && "vkGetDeviceProcAddr requested before vkCreateInstance");
+        _vkGetDeviceProcAddr = (PFN_vkVoidFunction (*)(VkDevice, const char *))
+            (*_vkGetInstanceProcAddr)(g_instance, "vkGetDeviceProcAddr");
+    }
+
     if (_vkCreateSwapchainKHR == NULL) {
         _vkCreateSwapchainKHR = (VkResult (*)(VkDevice, const VkSwapchainCreateInfoKHR *, const VkAllocationCallbacks *, VkSwapchainKHR *))
-            (*_vkGetInstanceProcAddr)(NULL, "vkCreateSwapchainKHR");
+            (*_vkGetDeviceProcAddr)(device, "vkCreateSwapchainKHR");
+    }
+
+    if (_vkCreateSwapchainKHR == NULL) {
+        return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
     // Check if this is a Wayland surface and resize the window

--- a/hybris/vulkan/platforms/wayland/wayland_window.h
+++ b/hybris/vulkan/platforms/wayland/wayland_window.h
@@ -59,6 +59,7 @@ public:
     static void resize_callback(struct wl_egl_window *egl_window, void *);
     static void destroy_window_callback(void *data);
     struct wl_event_queue *wl_queue;
+    struct wl_egl_window *m_window;
 
 protected:
     // overloads from BaseNativeWindow
@@ -90,7 +91,6 @@ private:
 
     std::list<WaylandNativeWindowBuffer *> m_bufList;
     std::list<WaylandNativeWindowBuffer *> fronted;
-    struct wl_egl_window *m_window;
     struct wl_display *m_display;
     int m_width;
     int m_height;

--- a/hybris/vulkan/vulkan.c
+++ b/hybris/vulkan/vulkan.c
@@ -683,7 +683,7 @@ VULKAN_IDLOAD(vkCreatePrivateDataSlotEXT);
 VULKAN_IDLOAD(vkDestroyPrivateDataSlotEXT);
 VULKAN_IDLOAD(vkSetPrivateDataEXT);
 VULKAN_IDLOAD(vkGetPrivateDataEXT);
-#if VK_HEADER_VERSION >= 269
+#if VK_HEADER_VERSION >= 269 && defined(VK_ENABLE_BETA_EXTENSIONS)
 VULKAN_IDLOAD(vkCreateCudaModuleNV);
 VULKAN_IDLOAD(vkGetCudaModuleCacheNV);
 VULKAN_IDLOAD(vkCreateCudaFunctionNV);

--- a/hybris/vulkan/vulkan.c
+++ b/hybris/vulkan/vulkan.c
@@ -122,6 +122,16 @@ void vkDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface, const VkAllo
 {
     ws_vkDestroySurfaceKHR(instance, surface, pAllocator);
 }
+
+VkResult vkGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR *pSurfaceCapabilities)
+{
+    return ws_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities);
+}
+
+VkResult vkCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain)
+{
+    return ws_vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain);
+}
 #else
 VULKAN_IDLOAD(vkDestroySurfaceKHR);
 #endif
@@ -145,6 +155,10 @@ PFN_vkVoidFunction vkGetInstanceProcAddr(VkInstance instance, const char* pName)
         return (PFN_vkVoidFunction)vkGetPhysicalDeviceWaylandPresentationSupportKHR;
     } else if (!strcmp(pName, "vkDestroySurfaceKHR")) {
         return (PFN_vkVoidFunction)vkDestroySurfaceKHR;
+    } else if (!strcmp(pName, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR")) {
+        return (PFN_vkVoidFunction)vkGetPhysicalDeviceSurfaceCapabilitiesKHR;
+    } else if (!strcmp(pName, "vkCreateSwapchainKHR")) {
+        return (PFN_vkVoidFunction)vkCreateSwapchainKHR;
 #endif
     }
 
@@ -358,10 +372,8 @@ VULKAN_IDLOAD(vkGetDeviceImageMemoryRequirements);
 VULKAN_IDLOAD(vkGetDeviceImageSparseMemoryRequirements);
 #endif
 VULKAN_IDLOAD(vkGetPhysicalDeviceSurfaceSupportKHR);
-VULKAN_IDLOAD(vkGetPhysicalDeviceSurfaceCapabilitiesKHR);
 VULKAN_IDLOAD(vkGetPhysicalDeviceSurfaceFormatsKHR);
 VULKAN_IDLOAD(vkGetPhysicalDeviceSurfacePresentModesKHR);
-VULKAN_IDLOAD(vkCreateSwapchainKHR);
 VULKAN_IDLOAD(vkDestroySwapchainKHR);
 VULKAN_IDLOAD(vkGetSwapchainImagesKHR);
 VULKAN_IDLOAD(vkAcquireNextImageKHR);

--- a/hybris/vulkan/ws.c
+++ b/hybris/vulkan/ws.c
@@ -88,6 +88,47 @@ void ws_vkDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface, const VkA
     _init_ws();
     ws->vkDestroySurfaceKHR(instance, surface, pAllocator);
 }
+
+VkResult ws_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR *pSurfaceCapabilities)
+{
+    _init_ws();
+    return ws->vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities);
+}
+
+VkResult ws_vkCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain)
+{
+    _init_ws();
+    return ws->vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain);
+}
+
+int vulkan_wayland_has_mapping(VkSurfaceKHR surface)
+{
+    _init_ws();
+    // This is a bit of a hack. For now, we'll assume the platform module exports these symbols
+    extern int vulkan_wayland_has_mapping(VkSurfaceKHR surface);
+    return vulkan_wayland_has_mapping(surface);
+}
+
+void vulkan_wayland_push_mapping(VkSurfaceKHR surface, struct WaylandDisplay *wdpy)
+{
+    _init_ws();
+    extern void vulkan_wayland_push_mapping(VkSurfaceKHR surface, struct WaylandDisplay *wdpy);
+    vulkan_wayland_push_mapping(surface, wdpy);
+}
+
+struct WaylandDisplay *vulkan_wayland_pop_mapping(VkSurfaceKHR surface)
+{
+    _init_ws();
+    extern struct WaylandDisplay *vulkan_wayland_pop_mapping(VkSurfaceKHR surface);
+    return vulkan_wayland_pop_mapping(surface);
+}
+
+struct WaylandDisplay *vulkan_wayland_get_mapping(VkSurfaceKHR surface)
+{
+    _init_ws();
+    extern struct WaylandDisplay *vulkan_wayland_get_mapping(VkSurfaceKHR surface);
+    return vulkan_wayland_get_mapping(surface);
+}
 #endif
 
 void ws_vkSetInstanceProcAddrFunc(PFN_vkVoidFunction addr)

--- a/hybris/vulkan/ws.h
+++ b/hybris/vulkan/ws.h
@@ -30,6 +30,7 @@ struct ws_vulkan_interface {
 
 /* Defined in vulkan.c */
 extern struct ws_vulkan_interface hybris_vulkan_interface;
+struct WaylandDisplay;
 
 struct ws_module {
     void (*init_module)(struct ws_vulkan_interface *vulkan_interface);
@@ -40,6 +41,8 @@ struct ws_module {
     VkResult (*vkCreateWaylandSurfaceKHR)(VkInstance instance, const VkWaylandSurfaceCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
     VkBool32 (*vkGetPhysicalDeviceWaylandPresentationSupportKHR)(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex, struct wl_display* display);
     void (*vkDestroySurfaceKHR)(VkInstance instance, VkSurfaceKHR surface, const VkAllocationCallbacks* pAllocator);
+    VkResult (*vkGetPhysicalDeviceSurfaceCapabilitiesKHR)(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR *pSurfaceCapabilities);
+    VkResult (*vkCreateSwapchainKHR)(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain);
 #endif
     void (*vkSetInstanceProcAddrFunc)(PFN_vkVoidFunction addr);
 };
@@ -50,6 +53,13 @@ VkResult ws_vkCreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAl
 VkResult ws_vkCreateWaylandSurfaceKHR(VkInstance instance, const VkWaylandSurfaceCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
 VkBool32 ws_vkGetPhysicalDeviceWaylandPresentationSupportKHR(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex, struct wl_display* display);
 void ws_vkDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface, const VkAllocationCallbacks* pAllocator);
+VkResult ws_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR *pSurfaceCapabilities);
+VkResult ws_vkCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain);
+
+int vulkan_wayland_has_mapping(VkSurfaceKHR surface);
+void vulkan_wayland_push_mapping(VkSurfaceKHR surface, struct WaylandDisplay *wdpy);
+struct WaylandDisplay *vulkan_wayland_pop_mapping(VkSurfaceKHR surface);
+struct WaylandDisplay *vulkan_wayland_get_mapping(VkSurfaceKHR surface);
 #endif
 void ws_vkSetInstanceProcAddrFunc(PFN_vkVoidFunction addr);
 #endif


### PR DESCRIPTION

Mali's Vulkan driver reports a `currentExtent` of 1x1, which prevents the swapchain from ever taking control of the surface size via its own `imageExtent`. under Wayland, as per the Vulkan spec, unbounded extents are signaled by setting `currentExtent` to `UINT32_MAX`

* to work around this, set `currentExtent.width` and `currentExtent.height` to `0xFFFFFFFF` (UINT32_MAX), allowing the swapchain to define its own size at creation time
* raise `maxImageExtent` from 4096×4096 to 16384×16384 since Android implementations set a very overly conservative value
* add `VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR` alongside `VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR` so applications (e.g. vkgears) that require opaque composite alpha can pass their assertions

also on later versions of vulkan VK_ENABLE_BETA_EXTENSIONS now guards cuda functions, without guarding it in hybris we get:
```
vulkan.c:687:15: error: 'vkCreateCudaModuleNV' undeclared here (not in a function); did you mean 'vkCreateCuModuleNVX'?
  687 | VULKAN_IDLOAD(vkCreateCudaModuleNV);
      |               ^~~~~~~~~~~~~~~~~~~~
vulkan.c:45:8: note: in definition of macro 'VULKAN_IDLOAD'
   45 | typeof(sym) * sym ## _dispatch (void) __asm__ (#sym);\
      |        ^~~
vulkan.c:688:15: error: 'vkGetCudaModuleCacheNV' undeclared here (not in a function)
  688 | VULKAN_IDLOAD(vkGetCudaModuleCacheNV);
      |               ^~~~~~~~~~~~~~~~~~~~~~
vulkan.c:45:8: note: in definition of macro 'VULKAN_IDLOAD'
   45 | typeof(sym) * sym ## _dispatch (void) __asm__ (#sym);\
      |        ^~~
vulkan.c:689:15: error: 'vkCreateCudaFunctionNV' undeclared here (not in a function); did you mean 'vkCreateCuFunctionNVX'?
  689 | VULKAN_IDLOAD(vkCreateCudaFunctionNV);
      |               ^~~~~~~~~~~~~~~~~~~~~~
vulkan.c:45:8: note: in definition of macro 'VULKAN_IDLOAD'
   45 | typeof(sym) * sym ## _dispatch (void) __asm__ (#sym);\
      |        ^~~
vulkan.c:690:15: error: 'vkDestroyCudaModuleNV' undeclared here (not in a function); did you mean 'vkDestroyCuModuleNVX'?
  690 | VULKAN_IDLOAD(vkDestroyCudaModuleNV);
      |               ^~~~~~~~~~~~~~~~~~~~~
vulkan.c:45:8: note: in definition of macro 'VULKAN_IDLOAD'
   45 | typeof(sym) * sym ## _dispatch (void) __asm__ (#sym);\
      |        ^~~
vulkan.c:691:15: error: 'vkDestroyCudaFunctionNV' undeclared here (not in a function); did you mean 'vkDestroyCuFunctionNVX'?
  691 | VULKAN_IDLOAD(vkDestroyCudaFunctionNV);
      |               ^~~~~~~~~~~~~~~~~~~~~~~
vulkan.c:45:8: note: in definition of macro 'VULKAN_IDLOAD'
   45 | typeof(sym) * sym ## _dispatch (void) __asm__ (#sym);\
      |        ^~~
vulkan.c:692:15: error: 'vkCmdCudaLaunchKernelNV' undeclared here (not in a function); did you mean 'vkCmdCuLaunchKernelNVX'?
  692 | VULKAN_IDLOAD(vkCmdCudaLaunchKernelNV);
      |               ^~~~~~~~~~~~~~~~~~~~~~~
vulkan.c:45:8: note: in definition of macro 'VULKAN_IDLOAD'
   45 | typeof(sym) * sym ## _dispatch (void) __asm__ (#sym);\
      |        ^~~
```