### PR TITLE
Add support for Android 15 and 16. Improvements for linker library paths

### DIFF
--- a/compat/hwc2/AidlComposerHal.cpp
+++ b/compat/hwc2/AidlComposerHal.cpp
@@ -234,6 +234,14 @@ public:
     }
 #endif
 
+#if ANDROID_VERSION_MAJOR >= 15
+    ::ndk::ScopedAStatus onHdcpLevelsChanged(int64_t in_display,
+            const ::aidl::android::hardware::drm::HdcpLevels& in_levels) override {
+        mCallback.onComposerHalHdcpLevelsChanged(in_display, in_levels);
+        return ::ndk::ScopedAStatus::ok();
+    }
+#endif
+
 private:
     HWC2::ComposerCallback& mCallback;
 };

--- a/compat/hwc2/HWC2.h
+++ b/compat/hwc2/HWC2.h
@@ -78,6 +78,10 @@ using aidl::android::hardware::graphics::common::DisplayHotplugEvent;
 using aidl::android::hardware::graphics::composer3::RefreshRateChangedDebugData;
 #endif
 
+#if ANDROID_VERSION_MAJOR >= 15
+using aidl::android::hardware::drm::HdcpLevels;
+#endif
+
 // Implement this interface to receive hardware composer events.
 //
 // These callback functions will generally be called on a hwbinder thread, but
@@ -102,6 +106,10 @@ struct ComposerCallback {
 #endif
 #if ANDROID_VERSION_MAJOR >= 14
     virtual void onRefreshRateChangedDebug(const RefreshRateChangedDebugData&) = 0;
+#endif
+#if ANDROID_VERSION_MAJOR >= 15
+    virtual void onComposerHalHdcpLevelsChanged(hal::HWDisplayId,
+                                                const HdcpLevels&) = 0;
 #endif
 
 protected:

--- a/compat/hwc2/hwc2_compatibility_layer.cpp
+++ b/compat/hwc2/hwc2_compatibility_layer.cpp
@@ -36,38 +36,42 @@ public:
         listener(listener) { }
 
 #if ANDROID_VERSION_MAJOR < 14
-    void onComposerHalHotplug(hal::HWDisplayId display, hal::Connection connection) {
+    void onComposerHalHotplug(hal::HWDisplayId display, hal::Connection connection) override {
         listener->on_hotplug_received(listener, 0, display,
                                     connection == hal::Connection::CONNECTED,
                                     true);
     }
 #else
-    void onComposerHalHotplugEvent(hal::HWDisplayId display, HWC2::DisplayHotplugEvent event) {
+    void onComposerHalHotplugEvent(hal::HWDisplayId display, HWC2::DisplayHotplugEvent event) override {
         listener->on_hotplug_received(listener, 0, display,
                                     event == HWC2::DisplayHotplugEvent::CONNECTED,
                                     true);
     }
 #endif
 
-    void onComposerHalRefresh(hal::HWDisplayId display) {
+    void onComposerHalRefresh(hal::HWDisplayId display) override {
         listener->on_refresh_received(listener, 0, display);
     }
 
     void onComposerHalVsync(hal::HWDisplayId display, int64_t timestamp,
-                            uint32_t /*vsyncPeriodNanos*/) {
+                            uint32_t /*vsyncPeriodNanos*/) override {
         listener->on_vsync_received(listener, 0, display, timestamp);
     }
 
 #if ANDROID_VERSION_MAJOR >= 11
     void onComposerHalVsyncPeriodTimingChanged(hal::HWDisplayId,
-                                               const hal::VsyncPeriodChangeTimeline&) { }
-    void onComposerHalSeamlessPossible(hal::HWDisplayId) { }
+                                               const hal::VsyncPeriodChangeTimeline&) override { }
+    void onComposerHalSeamlessPossible(hal::HWDisplayId) override { }
 #endif
 #if ANDROID_VERSION_MAJOR >= 13
-    void onComposerHalVsyncIdle(hal::HWDisplayId) { }
+    void onComposerHalVsyncIdle(hal::HWDisplayId) override { }
 #endif
 #if ANDROID_VERSION_MAJOR >= 14
     void onRefreshRateChangedDebug(const HWC2::RefreshRateChangedDebugData&) override { }
+#endif
+
+#if ANDROID_VERSION_MAJOR >= 15
+    void onComposerHalHdcpLevelsChanged(hal::HWDisplayId, const HWC2::HdcpLevels&) override {};
 #endif
 
     virtual ~HWComposerCallback() { };

--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -114,7 +114,7 @@ void (*_android_get_LD_LIBRARY_PATH)(char* buffer, size_t buffer_size) = NULL;
 void (*_android_update_LD_LIBRARY_PATH)(const char* ld_library_path) = NULL;
 void *(*_android_dlopen_ext)(const char* filename, int flag, const void* extinfo) = NULL;
 void (*_android_set_application_target_sdk_version)(uint32_t target) = NULL;
-uint32_t (*_android_get_application_target_sdk_version)() = NULL;
+int (*_android_get_application_target_sdk_version)() = NULL;
 void *(*_android_create_namespace)(const char* name,
                                  const char* ld_library_path,
                                  const char* default_library_path,
@@ -2821,7 +2821,7 @@ void _hybris_hook_android_set_application_target_sdk_version(uint32_t target)
     _android_set_application_target_sdk_version(target);
 }
 
-uint32_t _hybris_hook_android_get_application_target_sdk_version()
+int _hybris_hook_android_get_application_target_sdk_version()
 {
     TRACE("");
 
@@ -3807,7 +3807,7 @@ void android_set_application_target_sdk_version(uint32_t target)
     _android_set_application_target_sdk_version(target);
 }
 
-uint32_t android_get_application_target_sdk_version()
+int android_get_application_target_sdk_version()
 {
     ENSURE_LINKER_IS_LOADED();
 
@@ -3928,7 +3928,7 @@ void hybris_set_application_target_sdk_version(uint32_t target)
     android_set_application_target_sdk_version(target);
 }
 
-uint32_t hybris_get_application_target_sdk_version()
+int hybris_get_application_target_sdk_version()
 {
     return android_get_application_target_sdk_version();
 }

--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -1018,6 +1018,42 @@ static int _hybris_hook_pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t 
     return pthread_cond_wait(realcond, realmutex);
 }
 
+static int _hybris_hook_pthread_cond_clockwait(pthread_cond_t *cond, pthread_mutex_t *mutex,
+                 clockid_t clock_id, const struct timespec *abstime)
+{
+    /* Both cond and mutex can be statically initialized, check for both */
+    uintptr_t cvalue = (*(uintptr_t *) cond);
+    uintptr_t mvalue = (*(uintptr_t *) mutex);
+
+    TRACE_HOOK("cond %p mutex %p abstime %p", cond, mutex, abstime);
+
+    if (hybris_check_android_shared_cond(cvalue) ||
+        hybris_check_android_shared_mutex(mvalue)) {
+        LOGD("Shared condition/mutex with Android, not waiting.");
+        return 0;
+    }
+
+    pthread_cond_t *realcond = (pthread_cond_t *) cvalue;
+    if (hybris_is_pointer_in_shm((void*)cvalue))
+        realcond = (pthread_cond_t *)hybris_get_shmpointer((hybris_shm_pointer_t)cvalue);
+
+    if (cvalue <= ANDROID_TOP_ADDR_VALUE_COND) {
+        realcond = hybris_alloc_init_cond();
+        *((uintptr_t *) cond) = (uintptr_t) realcond;
+    }
+
+    pthread_mutex_t *realmutex = (pthread_mutex_t *) mvalue;
+    if (hybris_is_pointer_in_shm((void*)mvalue))
+        realmutex = (pthread_mutex_t *)hybris_get_shmpointer((hybris_shm_pointer_t)mvalue);
+
+    if (mvalue <= ANDROID_TOP_ADDR_VALUE_MUTEX) {
+        realmutex = hybris_alloc_init_mutex(mvalue);
+        *((uintptr_t *) mutex) = (uintptr_t) realmutex;
+    }
+
+    return pthread_cond_clockwait(realcond, realmutex, clock_id, abstime);
+}
+
 static int _hybris_hook_pthread_cond_timedwait(pthread_cond_t *cond,
                 pthread_mutex_t *mutex, const struct timespec *abstime)
 {
@@ -3043,6 +3079,7 @@ static struct _hook hooks_common[] = {
     HOOK_INDIRECT(pthread_cond_broadcast),
     HOOK_INDIRECT(pthread_cond_signal),
     HOOK_INDIRECT(pthread_cond_wait),
+    HOOK_INDIRECT(pthread_cond_clockwait),
     HOOK_INDIRECT(pthread_cond_timedwait),
     HOOK_TO(pthread_cond_timedwait_monotonic, _hybris_hook_pthread_cond_timedwait),
     HOOK_TO(pthread_cond_timedwait_monotonic_np, _hybris_hook_pthread_cond_timedwait),

--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -2583,6 +2583,15 @@ static void* _hybris_hook_mmap(void *addr, size_t len, int prot,
     return mmap(addr, len, prot, flags, fd, offset);
 }
 
+static void* _hybris_hook_mmap64(void *addr, size_t len, int prot,
+                  int flags, int fd, off64_t offset)
+{
+    TRACE_HOOK("addr %p len %zu prot %i flags %i fd %i offset %ld",
+               addr, len, prot, flags, fd, offset);
+
+    return mmap64(addr, len, prot, flags, fd, offset);
+}
+
 static int _hybris_hook_munmap(void *addr, size_t length)
 {
     TRACE_HOOK("addr %p length %zu", addr, length);
@@ -3274,6 +3283,7 @@ static struct _hook hooks_mm[] = {
 #else
     HOOK_INDIRECT(mmap),
 #endif
+    HOOK_DIRECT(mmap64),
     HOOK_DIRECT(munmap),
     /* wchar.h */
     HOOK_DIRECT_NO_DEBUG(wmemchr),

--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -339,6 +339,17 @@ static void *_hybris_hook_malloc(size_t size)
     return res;
 }
 
+static void *_hybris_hook_aligned_alloc(size_t alignment, size_t size)
+{
+    TRACE_HOOK("alignment %zu size %zu", alignment, size);
+
+    void *res = aligned_alloc(alignment, size);
+
+    TRACE_HOOK("res %p", res);
+
+    return res;
+}
+
 #ifdef WANT_ADRENO_QUIRKS
 static void *_hybris_hook_malloc45(size_t size)
 {
@@ -2922,6 +2933,7 @@ static struct _hook hooks_common[] = {
     HOOK_DIRECT(getenv),
     HOOK_DIRECT_NO_DEBUG(printf),
     HOOK_INDIRECT(malloc),
+    HOOK_INDIRECT(aligned_alloc),
     HOOK_INDIRECT(free),
     HOOK_DIRECT_NO_DEBUG(calloc),
     HOOK_DIRECT_NO_DEBUG(free),

--- a/hybris/common/q/linker.cpp
+++ b/hybris/common/q/linker.cpp
@@ -119,6 +119,7 @@ static const char* const kAsanSystemLibDir    = "/data/asan/system/lib64";
 static const char* const kAsanOdmLibDir       = "/data/asan/odm/lib64";
 static const char* const kAsanVendorLibDir    = "/data/asan/vendor/lib64";
 static const char* const kRuntimeApexLibDir   = "/apex/com.android.runtime/lib64";
+static const char* const kI18nApexLibDir      = "/apex/com.android.i18n/lib64";
 #else
 static const char* const kSystemLibDir        = "/system/lib";
 static const char* const kOdmLibDir           = "/odm/lib";
@@ -127,6 +128,7 @@ static const char* const kAsanSystemLibDir    = "/data/asan/system/lib";
 static const char* const kAsanOdmLibDir       = "/data/asan/odm/lib";
 static const char* const kAsanVendorLibDir    = "/data/asan/vendor/lib";
 static const char* const kRuntimeApexLibDir   = "/apex/com.android.runtime/lib";
+static const char* const kI18nApexLibDir      = "/apex/com.android.i18n/lib";
 #endif
 
 static const char* const kAsanLibDirPrefix = "/data/asan";
@@ -136,6 +138,7 @@ static const char* const kDefaultLdPaths[] = {
   kOdmLibDir,
   kVendorLibDir,
   kRuntimeApexLibDir,
+  kI18nApexLibDir,
   nullptr
 };
 
@@ -147,6 +150,7 @@ static const char* const kAsanDefaultLdPaths[] = {
   kAsanVendorLibDir,
   kVendorLibDir,
   kRuntimeApexLibDir,
+  kI18nApexLibDir,
   nullptr
 };
 

--- a/hybris/common/q/linker.cpp
+++ b/hybris/common/q/linker.cpp
@@ -135,6 +135,7 @@ static const char* const kDefaultLdPaths[] = {
   kSystemLibDir,
   kOdmLibDir,
   kVendorLibDir,
+  kRuntimeApexLibDir,
   nullptr
 };
 
@@ -145,6 +146,7 @@ static const char* const kAsanDefaultLdPaths[] = {
   kOdmLibDir,
   kAsanVendorLibDir,
   kVendorLibDir,
+  kRuntimeApexLibDir,
   nullptr
 };
 

--- a/hybris/platforms/common/nativewindowbase.cpp
+++ b/hybris/platforms/common/nativewindowbase.cpp
@@ -58,6 +58,9 @@ BaseNativeWindowBuffer::BaseNativeWindowBuffer()
 	ANativeWindowBuffer::format = 0;
 	ANativeWindowBuffer::usage = 0;
 	ANativeWindowBuffer::handle = 0;
+#if ANDROID_VERSION_MAJOR>=8
+	ANativeWindowBuffer::layerCount = 1;
+#endif
 
 	refcount = 0;
 }

--- a/hybris/platforms/common/server_wlegl_buffer.cpp
+++ b/hybris/platforms/common/server_wlegl_buffer.cpp
@@ -42,7 +42,7 @@ static const struct wl_buffer_interface server_wlegl_buffer_impl = {
 server_wlegl_buffer *
 server_wlegl_buffer_from(struct wl_resource *buffer)
 {
-	if (!buffer || !wl_resource_instance_of(buffer, &wl_buffer_interface, &server_wlegl_buffer_impl))
+	if (!buffer)
 		return NULL;
 	return static_cast<server_wlegl_buffer *>(wl_resource_get_user_data(buffer));
 }

--- a/hybris/platforms/common/server_wlegl_handle.cpp
+++ b/hybris/platforms/common/server_wlegl_handle.cpp
@@ -76,7 +76,7 @@ server_wlegl_handle_dtor(struct wl_resource *resource)
 server_wlegl_handle *
 server_wlegl_handle_from(struct wl_resource *resource)
 {
-	if (!resource || !wl_resource_instance_of(resource, &android_wlegl_handle_interface, &server_handle_impl))
+	if (!resource)
 		return NULL;
 	return static_cast<server_wlegl_handle *>(wl_resource_get_user_data(resource));
 }

--- a/hybris/tests/test_common.cpp
+++ b/hybris/tests/test_common.cpp
@@ -379,6 +379,7 @@ HWComposer *create_hwcomposer1_window()
 HWComposer *create_hwcomposer_window()
 {
 #if HAS_HWCOMPOSER2_HEADERS
+#if ANDROID_VERSION_MAJOR < 8
 	int err;
 	hw_module_t *hwcModule = 0;
 	hwc_composer_device_1_t *hwcDevicePtr = 0;
@@ -395,6 +396,9 @@ HWComposer *create_hwcomposer_window()
 
 	hwc_close_1(hwcDevicePtr);
 	if (hwc_version == HWC_DEVICE_API_VERSION_2_0) {
+#else
+	if (true) {
+#endif
 		return create_hwcomposer2_window();
 	} else
 #endif


### PR DESCRIPTION
Set NativeWindowBuffer layerCount to 1 which is needed on new MediaTek devices.
Add some hooks needed on MediaTek devices with Android 16.
Fix get_application_target_sdk_version return value.
Fix tests on some newer devices.
Relax checks done in recent change to fix https://github.com/libhybris/libhybris/issues/605