### PR TITLE
egl: add EGL_EXT_platform_base to egl strings

### DIFF
--- a/hybris/egl/egl.c
+++ b/hybris/egl/egl.c
@@ -317,7 +317,7 @@ const char * eglQueryString(EGLDisplay dpy, EGLint name)
 		const char *ret = _eglQueryString(dpy, name);
 		static char eglextensionsbuf[2048];
 		snprintf(eglextensionsbuf, 2046, "%s %s", ret,
-			"EGL_EXT_client_extensions EGL_EXT_platform_wayland EGL_KHR_platform_wayland"
+			"EGL_EXT_client_extensions EGL_EXT_platform_wayland EGL_KHR_platform_wayland EGL_EXT_platform_base"
 		);
 		ret = eglextensionsbuf;
 		return ret;

--- a/hybris/egl/glvnd/eglglvnd.cpp
+++ b/hybris/egl/glvnd/eglglvnd.cpp
@@ -99,7 +99,7 @@ __eglGLVNDGetVendorString(int name)
         return
             "EGL_KHR_platform_android"
 #ifdef WANT_WAYLAND
-            " EGL_EXT_platform_wayland EGL_KHR_platform_wayland"
+            " EGL_EXT_platform_wayland EGL_KHR_platform_wayland EGL_EXT_platform_base"
 #endif
             ;
     }


### PR DESCRIPTION
otherwise apps like fluffychat refuse to launch:

No provider of eglGetPlatformDisplayEXT found.  Requires one of:
    EGL_EXT_platform_base

hybris provides the extensions so this is safe to declare