### PR TITLE
hybris/egl: Use null EGL platform if the process maps certain libraries or not

### DIFF
--- a/hybris/egl/egl.c
+++ b/hybris/egl/egl.c
@@ -188,6 +188,52 @@ void hybris_egl_display_release_mappings(void)
 	}
 }
 
+static int process_maps_contains_str(const char* str)
+{
+	FILE* maps = fopen("/proc/self/maps", "r");
+	char* line;
+	unsigned int chars = 0;
+	unsigned int i = 0;
+	int c;
+
+	if (maps == NULL) {
+		return 0;
+	}
+
+	line = (char*)malloc(sizeof(char) * 1);
+	chars = 1;
+
+	while ((c = fgetc(maps)) != EOF) {
+		if (i >= chars) {
+			line = realloc(line, sizeof(char) * (chars + 1));
+			chars += 1;
+		}
+
+		line[i] = (char)c;
+
+		if (line[i] == '\n') {
+			line[i] = '\0';
+
+			if (strstr(line, str) != NULL) {
+				free(line);
+				fclose(maps);
+				return 1;
+			}
+
+			free(line);
+			line = (char*)malloc(sizeof(char) * 1);
+			chars = 1;
+			i = 0;
+		} else {
+			i += 1;
+		}
+	}
+
+	free(line);
+	fclose(maps);
+	return 0;
+}
+
 static const char * _defaultEglPlatform()
 {
 	char *egl_platform;
@@ -202,6 +248,20 @@ static const char * _defaultEglPlatform()
 	// The env variables may be defined yet empty
 	if (egl_platform == NULL || strcmp(egl_platform, "") == 0)
 		egl_platform = DEFAULT_EGL_PLATFORM;
+
+	// Automatic detection based on known library names also
+	// loaded by this process
+	if (strcmp(egl_platform, "auto") == 0) {
+		// If this process loaded libGL from gl4es
+		// then assume the null platform. Note that
+		// when gl4es is loaded, libGLX.so is not.
+		if (process_maps_contains_str("/libGL.so") &&
+			!process_maps_contains_str("/libGLX.so"))
+			egl_platform = "null";
+		// Otherwise choose Wayland
+		else
+			egl_platform = "wayland";
+	}
 
 	return egl_platform;
 }


### PR DESCRIPTION
To support the hybris-2404 Snap with both Wayland and X11 (through gl4es) we need some automatic detection of the windowing protocol in use, since HYBRIS_EGLPLATFORM can only be set once from the outside and we have no way of knowing the requirement from there.

Introduce a check for DEFAULT_EGL_PLATFORM being "auto" and open "/proc/self/maps" for checking whether it lists several known library file names or not. On a match it assumes the null platform being requested, otherwise uses Wayland.