### PR TITLE
hybris/common/q: fix `DL_ERR()` to not print on every invocation

### DIFF
--- a/hybris/common/q/dlfcn.cpp
+++ b/hybris/common/q/dlfcn.cpp
@@ -98,33 +98,56 @@ static pthread_mutex_t g_dl_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 static __thread char *dl_err_str;
 char __thread dlerror_buffer[__BIONIC_DLERROR_BUFFER_SIZE];
 
-static char* __bionic_set_dlerror(char* new_value) {
 #ifdef DISABLED_FOR_HYBRIS_SUPPORT
+static char* __bionic_set_dlerror(char* new_value) {
   char* old_value = __get_thread()->current_dlerror;
   __get_thread()->current_dlerror = new_value;
 
   if (new_value != nullptr) LD_LOG(kLogErrors, "dlerror set to \"%s\"", new_value);
   return old_value;
+}
 #else
+static char* __bionic_set_dlerror(char* new_value, bool print = false) {
   char *old_value = dl_err_str;
   dl_err_str = new_value;
+
+  if (print && new_value)
+    fprintf(stderr, "%s\n", new_value);
+
   return old_value;
-#endif
 }
+#endif
 
 static void __bionic_format_dlerror(const char* msg, const char* detail) {
 #ifdef DISABLED_FOR_HYBRIS_SUPPORT
   char* buffer = __get_thread()->dlerror_buffer;
 #else
   char* buffer = dlerror_buffer;
+
+  /* Hybris: detect and skip "no print" indicator. See `DL_ERR_NO_PRINT()`. */
+  bool print = true;
+  if (msg[0] == '#') {
+    print = false;
+    msg++;
+  }
+
+  if (detail && detail[0] == '#') {
+    print = false;
+    detail++;
+  }
 #endif
+
   strlcpy(buffer, msg, __BIONIC_DLERROR_BUFFER_SIZE);
   if (detail != nullptr) {
     strlcat(buffer, ": ", __BIONIC_DLERROR_BUFFER_SIZE);
     strlcat(buffer, detail, __BIONIC_DLERROR_BUFFER_SIZE);
   }
 
+#ifdef DISABLED_FOR_HYBRIS_SUPPORT
   __bionic_set_dlerror(buffer);
+#else
+  __bionic_set_dlerror(buffer, print);
+#endif
 }
 
 char* __loader_dlerror() {

--- a/hybris/common/q/linker_globals.h
+++ b/hybris/common/q/linker_globals.h
@@ -40,12 +40,19 @@
 
 #define DL_ERR(fmt, x...) \
     do { \
-      fprintf(stderr, fmt, ##x); \
-      fprintf(stderr, "\n"); \
+      snprintf( \
+        linker_get_error_buffer(), \
+        linker_get_error_buffer_size(), \
+        fmt, ##x); \
     } while (false)
 
+/* Hybris: '#' tells __bionic_format_dlerror() to skip printing this error. */
 #define DL_ERR_NO_PRINT(fmt, x...) \
     do { \
+      snprintf( \
+        linker_get_error_buffer(), \
+        linker_get_error_buffer_size(), \
+        "#" fmt, ##x); \
     } while (false)
 
 #define DL_WARN(fmt, x...) \


### PR DESCRIPTION
A call to `DL_ERR()` does not guarantee that the operation will end up with this error. For example, it's called when a library is not found in a namespace, even though subsequent search(es) in linked namespace(s) will eventually succeed. Thus, it's not productive to print every single time `DL_ERR()` is called.

Thus, move error printing to `__bionic_set_dlerror()`, where it will be called only if the operation ends up in failure. As a side effect, `android_dlerror()` will now work for whatever program that actually calls it.

Some additional logic is added to support `DL_ERR_NO_PRINT()` so that we don't spam `stderr` every time an undefined symbol is searched.