### PR TITLE
fix: define TEMP_FAILURE_RETRY for non-glibc systems

### DIFF
--- a/hybris/common/hooks.c
+++ b/hybris/common/hooks.c
@@ -80,6 +80,10 @@ extern int my_property_list(void (*propfn)(const char *key, const char *value, v
 
 #include <hybris/common/hooks.h>
 
+#ifndef __GLIBC__
+#include <hybris/common/musl_compat.h>
+#endif
+
 #include <android-config.h>
 
 // this is also used in bionic:

--- a/hybris/common/hooks_shm.c
+++ b/hybris/common/hooks_shm.c
@@ -33,6 +33,10 @@
 #include <sys/shm.h>
 #include <sys/mman.h>
 
+#ifndef __GLIBC__
+#include <hybris/common/musl_compat.h>
+#endif
+
 /* Debug */
 #include "logging.h"
 #define LOGD(message, ...) HYBRIS_DEBUG_LOG(HOOKS, message, ##__VA_ARGS__)

--- a/hybris/common/legacy_properties/properties.c
+++ b/hybris/common/legacy_properties/properties.c
@@ -36,6 +36,10 @@
 #include <poll.h>
 
 #include <hybris/properties/properties.h>
+#ifndef __GLIBC__
+#include <hybris/common/musl_compat.h>
+#endif
+
 #include "properties_p.h"
 
 static const char property_service_socket[] = "/dev/socket/" PROP_SERVICE_NAME;

--- a/hybris/common/mm/hybris_compat.h
+++ b/hybris/common/mm/hybris_compat.h
@@ -32,6 +32,9 @@
 
 #include <string.h>
 #include <memory.h>
+#ifndef __GLIBC__
+#include <hybris/common/musl_compat.h>
+#endif
 
 extern "C" size_t strlcpy(char *dest, const char *src, size_t size);
 extern "C" size_t strlcat(char *dst, const char *src, size_t size);

--- a/hybris/include/hybris/common/musl_compat.h
+++ b/hybris/include/hybris/common/musl_compat.h
@@ -1,0 +1,11 @@
++#include <unistd.h>
++/* taken from glibc unistd.h and fixes musl */
++#ifndef TEMP_FAILURE_RETRY
++#define TEMP_FAILURE_RETRY(expression) \
++  (__extension__                                                              \
++    ({ long int __result;                                                     \
++       do __result = (long int) (expression);                                 \
++       while (__result == -1L && errno == EINTR);                             \
++       __result; }))
++#endif
+

--- a/hybris/tests/test_camera.cpp
+++ b/hybris/tests/test_camera.cpp
@@ -45,6 +45,10 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#ifndef __GLIBC__
+#include <hybris/common/musl_compat.h>
+#endif
+
 #include "test_common.h"
 
 int shot_counter = 1;


### PR DESCRIPTION
Musl libc doesn't have a definition for TEMP_FAILURE_RETRY