### PR TITLE
hybris/common/q: don't set default LD_LIBRARY_PATH when using vendor ns

### DIFF
--- a/hybris/common/q/linker_main.cpp
+++ b/hybris/common/q/linker_main.cpp
@@ -802,10 +802,15 @@ extern "C" void android_linker_init(int sdk_version, void* (*get_hooked_symbol)(
     ldpreload_env = getenv("HYBRIS_LD_PRELOAD");
   }
 
+  bool wants_linkerconfig =
+    getenv("HYBRIS_USE_VENDOR_NAMESPACE") != NULL &&
+    access("/linkerconfig/ld.config.txt", R_OK) == 0;
+
   if (ldpath_env)
     parse_LD_LIBRARY_PATH(ldpath_env);
-  else
+  else if (!wants_linkerconfig)
     parse_LD_LIBRARY_PATH(DEFAULT_HYBRIS_LD_LIBRARY_PATH);
+
   parse_LD_PRELOAD(ldpreload_env);
 
   DEBUG("sdk_version %d\n", sdk_version);


### PR DESCRIPTION
In order for vendor binaries (or in this case, programs with `HYBRIS_USE _VENDOR_NAMESPACE` set) to load libraries from `/system`, it must load it from the linked `system` namespace, not from the vendor's `default` namespace. This let linker search this library's dependencies from either `system` namespace or its linked namespaces (such as `i18n` APEX).

However, if `LD_LIBARY_PATH` is "set", then such path will be added to vendor's default namespace. Because namespace linking is not transitive [^1], this means the lib will not have access to `system`'s linked namespaces.

For example, `/system/lib64/libxml2.so` is supposed to be loaded in `system` namespace in order to have access to `libandroidicu.so` in `com_android_i18n` APEX namespace. But because it's loaded in `default` namespace, it no longer have access to that.

[^1]: https://source.android.com/docs/core/architecture/partitions/linker-namespace#relation-properties