### PR TITLE
egl: rebind the display mapping when the native display changes

### DIFF
--- a/hybris/egl/egl.c
+++ b/hybris/egl/egl.c
@@ -260,12 +260,22 @@ EGLDisplay __eglHybrisGetPlatformDisplayCommon(EGLenum platform,
 	}
 
 	struct _EGLDisplay *dpy = hybris_egl_display_get_mapping(real_display);
+	if (dpy && dpy->native_display != (EGLNativeDisplayType)display_id) {
+		// The mapping belongs to a previous native display. Drop it so
+		// the new one gets fresh ws state, unless it is still in use.
+		if (!ws_releaseUnusedDisplays()) {
+			HYBRIS_WARN("eglGetDisplay: another native display is still initialized");
+			return EGL_NO_DISPLAY;
+		}
+		dpy = NULL;
+	}
 	if (!dpy) {
 		dpy = ws_GetDisplay(display_id);
 		if (!dpy) {
 			return EGL_NO_DISPLAY;
 		}
 		dpy->dpy = real_display;
+		dpy->native_display = (EGLNativeDisplayType)display_id;
 		_addMapping(dpy);
 	}
 

--- a/hybris/egl/ws.c
+++ b/hybris/egl/ws.c
@@ -138,6 +138,18 @@ void ws_releaseDisplay(struct _EGLDisplay *dpy)
 	}
 }
 
+EGLBoolean ws_releaseUnusedDisplays(void)
+{
+	EGLBoolean released = EGL_FALSE;
+	pthread_mutex_lock(&mutex);
+	if (ws_init_count == 0) {
+		hybris_egl_display_release_mappings();
+		released = EGL_TRUE;
+	}
+	pthread_mutex_unlock(&mutex);
+	return released;
+}
+
 EGLNativeWindowType ws_CreateWindow(EGLNativeWindowType win, struct _EGLDisplay *display)
 {
 	assert(ws != NULL);

--- a/hybris/egl/ws.h
+++ b/hybris/egl/ws.h
@@ -32,6 +32,7 @@ extern struct ws_egl_interface hybris_egl_interface;
 
 struct _EGLDisplay {
 	EGLDisplay dpy;
+	EGLNativeDisplayType native_display;
 };
 
 struct egl_image
@@ -73,5 +74,6 @@ void ws_prepareSwap(EGLDisplay dpy, EGLNativeWindowType win, EGLint *damage_rect
 void ws_finishSwap(EGLDisplay dpy, EGLNativeWindowType win);
 void ws_setSwapInterval(EGLDisplay dpy, EGLNativeWindowType win, EGLint interval);
 void ws_releaseDisplay(struct _EGLDisplay *dpy);
+EGLBoolean ws_releaseUnusedDisplays(void);
 
 #endif


### PR DESCRIPTION
eglGetDisplay keys its mapping by the single Android display, so a second native display in the same process (a second wayland connection, e.g. a Qt UI plus an SDL streaming window) gets the first connection's ws state: buffers go through the old connection's android_wlegl and die with a wl_surface.attach "unknown object" protocol error, and once the old connection is closed the stale mapping crashes marshalling on dead wayland proxies.

Store the native display in the mapping; when eglGetDisplay is called with a different one, drop the stale mappings through the existing hybris_egl_display_release_mappings() so the new display gets fresh ws state. If the previous display is still initialized the new one cannot work, so return EGL_NO_DISPLAY with a warning instead of state that breaks later.

Hit porting moonlight-qt to Ubuntu Touch on gts9 (samsung tab s9): SDL reopens its wayland connection between codec probing and streaming. Verified on device: probe connection terminates, stream connection gets fresh state, hw-decoded streaming stable. Ownership checked across all four ws platforms (wayland/null/hwcomposer/fbdev): each display is freed exactly once.
