### PR TITLE
configure.ac: fix --disable-wayland incorrectly requiring wayland dev packages

### DIFF
--- a/hybris/configure.ac
+++ b/hybris/configure.ac
@@ -81,16 +81,20 @@ AM_CONDITIONAL( [WANT_UBUNTU_CAMERA_HEADERS], [test x"$ubuntu_camera_headers" = 
 
 AC_ARG_ENABLE(wayland,
   [  --enable-wayland            Enable wayland support (default=disabled)],
-  [wayland=$enableval
-	PKG_CHECK_MODULES(WAYLAND_CLIENT, wayland-client,, exit)
-	PKG_CHECK_MODULES(WAYLAND_SERVER, wayland-server,, exit)
-	PKG_CHECK_MODULES(WAYLAND_EGL, [wayland-egl >= 1.15],, exit)
+  [wayland=$enableval],
+  [wayland="no"])
+AS_IF([test "x$wayland" = "xyes"], [
+	PKG_CHECK_MODULES(WAYLAND_CLIENT, wayland-client,,
+		[AC_MSG_ERROR([wayland-client development files not found (required by --enable-wayland)])])
+	PKG_CHECK_MODULES(WAYLAND_SERVER, wayland-server,,
+		[AC_MSG_ERROR([wayland-server development files not found (required by --enable-wayland)])])
+	PKG_CHECK_MODULES(WAYLAND_EGL, [wayland-egl >= 1.15],,
+		[AC_MSG_ERROR([wayland-egl >= 1.15 development files not found (required by --enable-wayland)])])
 	WAYLAND_PREFIX=`$PKG_CONFIG --variable=prefix wayland-client`
 
 	AC_PATH_PROG([WAYLAND_SCANNER], [wayland-scanner],, [${WAYLAND_PREFIX}/bin$PATH_SEPARATOR$PATH])
 	AC_DEFINE(WANT_WAYLAND, [], [We want Wayland support])
-],
-  [wayland="no"])
+])
 AM_CONDITIONAL( [WANT_WAYLAND], [test x"$wayland" = x"yes"])
 
 AC_ARG_ENABLE(glvnd,


### PR DESCRIPTION
AC_ARG_ENABLE(wayland, ..., ACTION-IF-GIVEN, ACTION-IF-NOT-GIVEN)'s third argument runs whenever the flag is passed at all `--enable-wayland` and `--disable-wayland` both count as "given" and take that branch. Only omitting the flag entirely falls through to the fourth argument. The three PKG_CHECK_MODULES(..., exit) calls for wayland-client/-server/-egl live inside that third argument, so explicitly passing `--disable-wayland` on a system without the Wayland dev packages installed hits those checks anyway, and hard-exits configure immediately, via a bare exit, with no message at all.

## Reproduction
```
./autogen.sh --disable-wayland
...
checking for wayland-client... no
$
```

No error, no explanation, configure just silently returns to the shell prompt. Confusing to diagnose blind, since the natural read of a checking for wayland-client... no line followed by nothing is a hung or killed process, not a script that exited on purpose.

## The fix

Two changes:

Move the dependency checks out of AC_ARG_ENABLE's branch and into a separate AS_IF([test "x$wayland" = "xyes"], ...) gated on the resolved value so they only run when Wayland support is actually being enabled, not merely mentioned.
Replace the bare exit with AC_MSG_ERROR(...) in each check, so someone who does want --enable-wayland without the dev packages installed gets an actual explanation instead of the same silent exit.

## Testing

Verified `--disable-wayland` now configures cleanly without wayland-client/-server/-egl installed, and that `--enable-wayland` still correctly requires and picks them up when present.